### PR TITLE
Discovery API postman collection init

### DIFF
--- a/apps/discovery_api/Discovery API.postman_collection.json
+++ b/apps/discovery_api/Discovery API.postman_collection.json
@@ -1,0 +1,58 @@
+{
+	"info": {
+		"_postman_id": "e5b6644c-acc9-4bce-9a1e-c191380b5d73",
+		"name": "Discovery API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Healthcheck",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:4000/healthcheck",
+					"host": [
+						"localhost"
+					],
+					"port": "4000",
+					"path": [
+						"healthcheck"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Freeform Query",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "api_key",
+						"value": "key_from_auth0",
+						"description": "optional if accessing a private dataset",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "select * from Azzurro_Max__Damson_Green_MSTZE limit 10"
+				},
+				"url": {
+					"raw": "localhost:4000/api/v1/query",
+					"host": [
+						"localhost"
+					],
+					"port": "4000",
+					"path": [
+						"api",
+						"v1",
+						"query"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
Adds postman collection for 2 discovery api routes.

## Reminders:

- [x] ~if changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?~ N/A
