### PR TITLE
SSL Redis - Reaper / Forklift / Disc_Streams

### DIFF
--- a/apps/discovery_streams/mix.exs
+++ b/apps/discovery_streams/mix.exs
@@ -4,7 +4,7 @@ defmodule DiscoveryStreams.Mixfile do
   def project do
     [
       app: :discovery_streams,
-      version: "3.0.2",
+      version: "3.0.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_streams/runtime.exs
+++ b/apps/discovery_streams/runtime.exs
@@ -2,9 +2,8 @@ use Mix.Config
 
 kafka_brokers = System.get_env("KAFKA_BROKERS")
 
-get_redix_args = fn host, password, port, ssl ->
-  port = if (port in [nil, ""]), do: port, else: String.to_integer(port)
-  [host: host, password: password, port: port, ssl: ssl]
+get_redix_args = fn (host, port, password, ssl) ->
+  [host: host, port: port, password: password, ssl: ssl]
   |> Enum.filter(fn
     {_, nil} -> false
     {_, ""} -> false
@@ -12,7 +11,10 @@ get_redix_args = fn host, password, port, ssl ->
   end)
 end
 
-redix_args = get_redix_args.(System.get_env("REDIS_HOST"), System.get_env("REDIS_PASSWORD"), System.get_env("REDIS_PORT"), System.get_env("REDIS_SSL"))
+ssl_enabled = Regex.match?(~r/^true$/i, System.get_env("REDIS_SSL"))
+{redis_port, ""} = Integer.parse(System.get_env("REDIS_PORT"))
+
+redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.get_env("REDIS_PASSWORD"), ssl_enabled)
 
 if kafka_brokers do
   endpoints =

--- a/apps/discovery_streams/runtime.exs
+++ b/apps/discovery_streams/runtime.exs
@@ -2,9 +2,9 @@ use Mix.Config
 
 kafka_brokers = System.get_env("KAFKA_BROKERS")
 
-get_redix_args = fn host, password, port ->
+get_redix_args = fn host, password, port, ssl ->
   port = if (port in [nil, ""]), do: port, else: String.to_integer(port)
-  [host: host, password: password, port: port]
+  [host: host, password: password, port: port, ssl: ssl]
   |> Enum.filter(fn
     {_, nil} -> false
     {_, ""} -> false
@@ -12,7 +12,7 @@ get_redix_args = fn host, password, port ->
   end)
 end
 
-redix_args = get_redix_args.(System.get_env("REDIS_HOST"), System.get_env("REDIS_PASSWORD"), System.get_env("REDIS_PORT"))
+redix_args = get_redix_args.(System.get_env("REDIS_HOST"), System.get_env("REDIS_PASSWORD"), System.get_env("REDIS_PORT"), System.get_env("REDIS_SSL"))
 
 if kafka_brokers do
   endpoints =

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.17.13",
+      version: "0.17.14",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/runtime.exs
+++ b/apps/forklift/runtime.exs
@@ -16,15 +16,20 @@ Enum.each(required_envars, fn var ->
 end)
 
 kafka_brokers = System.get_env("KAFKA_BROKERS")
-get_redix_args = fn (host, password) ->
-  [host: host, password: password]
+
+get_redix_args = fn (host, port, password, ssl) ->
+  [host: host, port: port, password: password, ssl: ssl]
   |> Enum.filter(fn
     {_, nil} -> false
     {_, ""} -> false
     _ -> true
   end)
 end
-redix_args = get_redix_args.(System.get_env("REDIS_HOST"), System.get_env("REDIS_PASSWORD"))
+
+ssl_enabled = Regex.match?(~r/^true$/i, System.get_env("REDIS_SSL"))
+{redis_port, ""} = Integer.parse(System.get_env("REDIS_PORT"))
+
+redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.get_env("REDIS_PASSWORD"), ssl_enabled)
 
 topic = System.get_env("DATA_TOPIC_PREFIX")
 output_topic = System.get_env("OUTPUT_TOPIC")

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.1.0",
+      version: "1.1.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/raptor/runtime.exs
+++ b/apps/raptor/runtime.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-get_redix_args = fn host, password ->
-  [host: host, password: password]
+get_redix_args = fn (host, port, password, ssl) ->
+  [host: host, port: port, password: password, ssl: ssl]
   |> Enum.filter(fn
     {_, nil} -> false
     {_, ""} -> false
@@ -9,7 +9,11 @@ get_redix_args = fn host, password ->
   end)
 end
 
-redix_args = get_redix_args.(System.get_env("REDIS_HOST"), System.get_env("REDIS_PASSWORD"))
+ssl_enabled = Regex.match?(~r/^true$/i, System.get_env("REDIS_SSL"))
+{redis_port, ""} = Integer.parse(System.get_env("REDIS_PORT"))
+
+redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.get_env("REDIS_PASSWORD"), ssl_enabled)
+
 
 config :redix,
   args: redix_args

--- a/apps/raptor/runtime.exs
+++ b/apps/raptor/runtime.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-get_redix_args = fn (host, port, password, ssl) ->
+get_redix_args = fn host, port, password, ssl ->
   [host: host, port: port, password: password, ssl: ssl]
   |> Enum.filter(fn
     {_, nil} -> false
@@ -12,8 +12,13 @@ end
 ssl_enabled = Regex.match?(~r/^true$/i, System.get_env("REDIS_SSL"))
 {redis_port, ""} = Integer.parse(System.get_env("REDIS_PORT"))
 
-redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.get_env("REDIS_PASSWORD"), ssl_enabled)
-
+redix_args =
+  get_redix_args.(
+    System.get_env("REDIS_HOST"),
+    redis_port,
+    System.get_env("REDIS_PASSWORD"),
+    ssl_enabled
+  )
 
 config :redix,
   args: redix_args

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/runtime.exs
+++ b/apps/reaper/runtime.exs
@@ -15,15 +15,20 @@ Enum.each(required_envars, fn var ->
 end)
 
 kafka_brokers = System.get_env("KAFKA_BROKERS")
-get_redix_args = fn (host, password) ->
-  [host: host, password: password]
+
+get_redix_args = fn (host, port, password, ssl) ->
+  [host: host, port: port, password: password, ssl: ssl]
   |> Enum.filter(fn
     {_, nil} -> false
     {_, ""} -> false
     _ -> true
   end)
 end
-redix_args = get_redix_args.(System.get_env("REDIS_HOST"), System.get_env("REDIS_PASSWORD"))
+
+ssl_enabled = Regex.match?(~r/^true$/i, System.get_env("REDIS_SSL"))
+{redis_port, ""} = Integer.parse(System.get_env("REDIS_PORT"))
+
+redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.get_env("REDIS_PASSWORD"), ssl_enabled)
 
 endpoints =
   kafka_brokers

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
+cd "$(dirname ${BASH_SOURCE[0]})"
+cd ".."
+
+nl=$'\n'
+
+if [[ $1 == "" || $1 == "help" || $2 == "" ]]; then
+  echo "build {app_name} {image_tag} {rebuild_build_image} {repository}${nl}"
+  echo "  Defaults:"
+  echo "  - rebuild_build_image: true"
+  echo "  - repository: smartcitiesdata/{app_name}${nl}"
+  echo "  Note: build_image is *all* of the elixir apps compiled."
+  echo "        Only needs to be rebuilt once for changes across multiple apps.${nl}"
+  exit 1
+fi
 
 set -e
 
 app="${1}"
-version="${2}"
+tag="${2}"
 rebuild_build_image="${3:-true}"
+repository="${4:-smartcitiesdata/$app}"
 
 if [[ ! -d apps/$app ]]; then
   echo "Directory apps/$app does not exist. Please check the app name you provided."
@@ -12,8 +27,12 @@ if [[ ! -d apps/$app ]]; then
 fi
 
 if ([[ "$(docker images -q smartcitiesdata:build 2> /dev/null)" == "" ]] || $rebuild_build_image ); then
-  docker rmi -f smartcitiesdata:build
+  echo "Rebuilding elixir build image..."
+  docker rmi -f smartcitiesdata:build 2> /dev/null
   docker build -t smartcitiesdata:build .
 fi
 
-docker build -t smartcitiesdata/$app:$version apps/$app
+echo "Building $repository:$tag"
+docker build -t $repository:$tag apps/$app
+
+echo "${nl}Built ${repository}:${tag}${nl}"


### PR DESCRIPTION
## Changes 

- Adds support for Redis over SSL to reaper, forklift, and discovery streams
- Updates build script to allow for repository customization
  - All existing parameters, even if renamed internally, are unchanged. Previous default values / script usage is unchanged.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
