### PR TITLE
WIP: configuration idea

### DIFF
--- a/apps/discovery_streams/config/prod.exs
+++ b/apps/discovery_streams/config/prod.exs
@@ -10,7 +10,7 @@ config :discovery_streams, DiscoveryStreamsWeb.Endpoint,
 config :discovery_streams, DiscoveryStreamsWeb.Endpoint, check_origin: false
 
 config :raptor_service,
-  raptor_url: "http://raptor.admin/api/authorize"
+  raptor_url: if System.get_env("RAPTOR_URL") != "", do: System.get_env("RAPTOR_URL"), else: "http://raptor.admin/api/authorize"
 
 config :logger,
   level: :info


### PR DESCRIPTION
Won't merge, just to illustrate a question

Been thinking about which config live in mix env config files, and what lives in chart values

1) Any cluster that's running an elixir app is running the "prod" configuration from a mix standpoint right? Something like the staging cluster is actually running "prod" config?

2) Is it worth removing this attribute from the env config files, and redefining it centrally in the chart?

3) I'd like to instead make this one line conditional in the prod config file, thoughts on that / will it work? Instead of altering the chart values for all other clusters.
