### PR TITLE
Raptor url config

### DIFF
--- a/apps/discovery_api/config/integration.exs
+++ b/apps/discovery_api/config/integration.exs
@@ -18,9 +18,6 @@ config :discovery_api,
   hosted_region: aws_region,
   hsts_enabled: false
 
-config :raptor_service,
-  raptor_url: "http://localhost:4002/api/authorize"
-
 config :redix,
   args: redix_args
 

--- a/apps/discovery_api/config/integration.exs
+++ b/apps/discovery_api/config/integration.exs
@@ -18,6 +18,9 @@ config :discovery_api,
   hosted_region: aws_region,
   hsts_enabled: false
 
+config :discovery_api,
+  raptor_url: "http://localhost:4002/api/authorize"
+
 config :redix,
   args: redix_args
 

--- a/apps/discovery_api/config/prod.exs
+++ b/apps/discovery_api/config/prod.exs
@@ -10,9 +10,6 @@ config :discovery_api, DiscoveryApiWeb.Endpoint,
   version: Application.spec(:discovery_api, :vsn),
   check_origin: false
 
-config :raptor_service,
-  raptor_url: "http://raptor.admin/api/authorize"
-
 # Do not print debug messages in production
 config :logger, level: :info
 

--- a/apps/discovery_api/config/test.exs
+++ b/apps/discovery_api/config/test.exs
@@ -17,9 +17,6 @@ config :discovery_api,
   test_mode: true,
   hsts_enabled: false
 
-config :raptor_service,
-  raptor_url: "raptor/test/"
-
 config :logger, level: :warn
 
 config :ex_json_schema,

--- a/apps/discovery_api/config/test.exs
+++ b/apps/discovery_api/config/test.exs
@@ -19,6 +19,9 @@ config :discovery_api,
 
 config :logger, level: :warn
 
+config :discovery_api,
+  raptor_url: "raptor.url"
+
 config :ex_json_schema,
        :remote_schema_resolver,
        fn url -> URLResolver.resolve_url(url) end

--- a/apps/discovery_api/lib/discovery_api_web/utilities/model_access_utils.ex
+++ b/apps/discovery_api/lib/discovery_api_web/utilities/model_access_utils.ex
@@ -5,6 +5,9 @@ defmodule DiscoveryApiWeb.Utilities.ModelAccessUtils do
   @behaviour DiscoveryApiWeb.Utilities.AccessUtils
   alias RaptorService
   alias DiscoveryApi.Data.Model
+  use Properties, otp_app: :discovery_api
+
+  getter(:raptor_url, generic: true)
 
   def has_access?(%Model{private: false} = _dataset, _username), do: true
   def has_access?(%Model{private: true} = _dataset, nil), do: false
@@ -14,7 +17,7 @@ defmodule DiscoveryApiWeb.Utilities.ModelAccessUtils do
   end
 
   def has_access?(%Model{private: true, systemName: systemName} = _dataset, [apiKey]) do
-    RaptorService.is_authorized(apiKey, systemName)
+    RaptorService.is_authorized(raptor_url(), apiKey, systemName)
   end
 
   def has_access?(_base, _case), do: false

--- a/apps/discovery_api/lib/discovery_api_web/utilities/query_access_utils.ex
+++ b/apps/discovery_api/lib/discovery_api_web/utilities/query_access_utils.ex
@@ -6,6 +6,9 @@ defmodule DiscoveryApiWeb.Utilities.QueryAccessUtils do
   alias DiscoveryApi.Services.PrestoService
   alias DiscoveryApi.Data.Model
   alias DiscoveryApiWeb.Utilities.ModelAccessUtils
+  use Properties, otp_app: :discovery_api
+
+  getter(:raptor_url, generic: true)
 
   def authorized_session(conn, affected_models) do
     current_user = conn.assigns.current_user
@@ -47,7 +50,7 @@ defmodule DiscoveryApiWeb.Utilities.QueryAccessUtils do
   end
 
   def api_key_can_access_models?(affected_models, [api_key]) do
-    Enum.all?(affected_models, &RaptorService.is_authorized(api_key, &1[:systemName]))
+    Enum.all?(affected_models, &RaptorService.is_authorized(raptor_url(), api_key, &1[:systemName]))
   end
 
   defp map_affected_tables_to_models(affected_tables) do

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.2.3",
+      version: "1.2.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/runtime.exs
+++ b/apps/discovery_api/runtime.exs
@@ -212,3 +212,8 @@ config :telemetry_event,
       metric_type: :counter
     ]
   ]
+
+
+if System.get_env("RAPTOR_URL") do
+  config :discovery_api, raptor_url: System.get_env("RAPTOR_URL")
+end

--- a/apps/discovery_api/test/unit/discovery_api_web/utilities/query_access_utils_test.exs
+++ b/apps/discovery_api/test/unit/discovery_api_web/utilities/query_access_utils_test.exs
@@ -84,7 +84,7 @@ defmodule DiscoveryApiWeb.Utilities.QueryAccessUtilsTest do
       [expected_api_key] = Plug.Conn.get_req_header(conn, "api_key")
 
       allow ModelAccessUtils.has_access?(model, conn.assigns.current_user), return: false
-      allow RaptorService.is_authorized(expected_api_key, model[:systemName]), return: false
+      allow RaptorService.is_authorized("raptor.url", expected_api_key, model[:systemName]), return: false
 
       assert {:error, "Session not authorized"} = QueryAccessUtils.authorized_session(conn, [model])
     end
@@ -112,7 +112,7 @@ defmodule DiscoveryApiWeb.Utilities.QueryAccessUtilsTest do
       [expected_api_key] = Plug.Conn.get_req_header(conn, "api_key")
 
       allow ModelAccessUtils.has_access?(model, conn.assigns.current_user), return: false
-      allow RaptorService.is_authorized(expected_api_key, model[:systemName]), return: true
+      allow RaptorService.is_authorized("raptor.url", expected_api_key, model[:systemName]), return: true
 
       assert {:ok, authorized_session} = QueryAccessUtils.authorized_session(conn, [model])
     end

--- a/apps/discovery_streams/config/integration.exs
+++ b/apps/discovery_streams/config/integration.exs
@@ -4,6 +4,9 @@ host = "127.0.0.1"
 endpoints = [{String.to_atom(host), 9092}]
 
 config :discovery_streams,
+  raptor_url: "http://localhost:4002/api/authorize"
+
+config :discovery_streams,
   divo: [
     {DivoKafka, [create_topics: "event-stream:1:1", outside_host: host, kafka_image_version: "2.12-2.1.1"]},
     {DivoRedis, []}

--- a/apps/discovery_streams/config/integration.exs
+++ b/apps/discovery_streams/config/integration.exs
@@ -14,9 +14,6 @@ config :discovery_streams, endpoints: endpoints
 
 config :discovery_streams, topic_subscriber_interval: 1_000
 
-config :raptor_service,
-  raptor_url: "http://localhost:4002/api/authorize"
-
 config :discovery_streams, :brook,
   instance: :discovery_streams,
   driver: [

--- a/apps/discovery_streams/config/prod.exs
+++ b/apps/discovery_streams/config/prod.exs
@@ -9,9 +9,6 @@ config :discovery_streams, DiscoveryStreamsWeb.Endpoint,
 
 config :discovery_streams, DiscoveryStreamsWeb.Endpoint, check_origin: false
 
-config :raptor_service,
-  raptor_url: "http://raptor.admin/api/authorize"
-
 config :logger,
   level: :info
 

--- a/apps/discovery_streams/config/test.exs
+++ b/apps/discovery_streams/config/test.exs
@@ -7,9 +7,6 @@ config :discovery_streams, DiscoveryStreamsWeb.Endpoint,
   http: [port: 4001],
   server: false
 
-config :raptor_service,
-  raptor_url: "raptor/test/"
-
 config :discovery_streams, endpoints: [localhost: 9092]
 
 config :discovery_streams, :brook,

--- a/apps/discovery_streams/config/test.exs
+++ b/apps/discovery_streams/config/test.exs
@@ -7,6 +7,9 @@ config :discovery_streams, DiscoveryStreamsWeb.Endpoint,
   http: [port: 4001],
   server: false
 
+config :discovery_streams,
+  raptor_url: "raptor.url"
+
 config :discovery_streams, endpoints: [localhost: 9092]
 
 config :discovery_streams, :brook,

--- a/apps/discovery_streams/lib/discovery_streams_web/channels/streaming_channel.ex
+++ b/apps/discovery_streams/lib/discovery_streams_web/channels/streaming_channel.ex
@@ -7,6 +7,9 @@ defmodule DiscoveryStreamsWeb.StreamingChannel do
   alias RaptorService
 
   use DiscoveryStreamsWeb, :channel
+  use Properties, otp_app: :discovery_streams
+
+  getter(:raptor_url, generic: true)
 
   @instance_name DiscoveryStreams.instance_name()
 
@@ -25,7 +28,7 @@ defmodule DiscoveryStreamsWeb.StreamingChannel do
       {:ok, _dataset_id} ->
         api_key = params["api_key"]
 
-        if RaptorService.is_authorized(api_key, system_name) do
+        if RaptorService.is_authorized(raptor_url(), api_key, system_name) do
           filter = Map.delete(params, "api_key")
           {:ok, assign(socket, :filter, create_filter_rules(filter))}
         else

--- a/apps/discovery_streams/mix.exs
+++ b/apps/discovery_streams/mix.exs
@@ -4,7 +4,7 @@ defmodule DiscoveryStreams.Mixfile do
   def project do
     [
       app: :discovery_streams,
-      version: "3.0.3",
+      version: "3.0.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_streams/runtime.exs
+++ b/apps/discovery_streams/runtime.exs
@@ -80,3 +80,7 @@ config :telemetry_event,
       metric_type: :sum
     ]
   ]
+
+if System.get_env("RAPTOR_URL") do
+  config :discovery_streams, raptor_url: System.get_env("RAPTOR_URL")
+end

--- a/apps/discovery_streams/test/integration/discovery_streams_test.exs
+++ b/apps/discovery_streams/test/integration/discovery_streams_test.exs
@@ -30,7 +30,7 @@ defmodule DiscoveryStreams.DiscoveryStreamsTest do
       end
     end)
 
-    System.put_env("RAPTOR_URL", "http://localhost:#{bypass.port}/api/authorize")
+    Application.put_env(:discovery_streams, :raptor_url, "http://localhost:#{bypass.port}/api/authorize")
     :ok
   end
 

--- a/apps/discovery_streams/test/integration/discovery_streams_test.exs
+++ b/apps/discovery_streams/test/integration/discovery_streams_test.exs
@@ -30,8 +30,7 @@ defmodule DiscoveryStreams.DiscoveryStreamsTest do
       end
     end)
 
-    Application.put_env(:raptor_service, :raptor_url, "http://localhost:#{bypass.port}/api/authorize")
-
+    System.put_env("RAPTOR_URL", "http://localhost:#{bypass.port}/api/authorize")
     :ok
   end
 

--- a/apps/discovery_streams/test/unit/message_handler_test.exs
+++ b/apps/discovery_streams/test/unit/message_handler_test.exs
@@ -23,7 +23,7 @@ defmodule DiscoveryStreams.SourceHandlerTest do
       return: {:ok, @dataset_2_id}
     )
 
-    allow(RaptorService.is_authorized(any(), any()),
+    allow(RaptorService.is_authorized(any(), any(), any()),
       return: true
     )
 

--- a/apps/discovery_streams/test/unit/streaming_channel_test.exs
+++ b/apps/discovery_streams/test/unit/streaming_channel_test.exs
@@ -14,7 +14,7 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
       return: {:ok, @dataset_1_id}
     )
 
-    allow(RaptorService.is_authorized(any(), any()),
+    allow(RaptorService.is_authorized(any(), any(), any()),
       return: true
     )
 
@@ -115,7 +115,7 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
   end
 
   test "joining unauthorized topic returns error tuple" do
-    allow(RaptorService.is_authorized(any(), any()),
+    allow(RaptorService.is_authorized(any(), any(), any()),
       return: false
     )
 
@@ -136,6 +136,6 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
       socket(DiscoveryStreamsWeb.UserSocket)
     )
 
-    assert_called(RaptorService.is_authorized(api_key, "shuttle-position"))
+    assert_called(RaptorService.is_authorized("raptor.url", api_key, "shuttle-position"))
   end
 end

--- a/apps/raptor_service/config/integration.exs
+++ b/apps/raptor_service/config/integration.exs
@@ -1,4 +1,0 @@
-use Mix.Config
-
-config :raptor_service,
-  raptor_url: "http://localhost:4002/api/authorize"

--- a/apps/raptor_service/config/prod.exs
+++ b/apps/raptor_service/config/prod.exs
@@ -1,4 +1,0 @@
-use Mix.Config
-
-config :raptor_service,
-  raptor_url: "http://raptor.admin/api/authorize"

--- a/apps/raptor_service/lib/raptor_service.ex
+++ b/apps/raptor_service/lib/raptor_service.ex
@@ -2,8 +2,7 @@ defmodule RaptorService do
   use Properties, otp_app: :raptor_service
   require Logger
 
-  def is_authorized(api_key, system_name) do
-    raptor_url = System.get_env("RAPTOR_URL")
+  def is_authorized(raptor_url, api_key, system_name) do
     case HTTPoison.get(raptor_url_with_params(raptor_url, api_key, system_name)) do
       {:ok, %{body: body}} ->
         {:ok, is_authorized} = Jason.decode(body)

--- a/apps/raptor_service/lib/raptor_service.ex
+++ b/apps/raptor_service/lib/raptor_service.ex
@@ -2,10 +2,9 @@ defmodule RaptorService do
   use Properties, otp_app: :raptor_service
   require Logger
 
-  getter(:raptor_url, generic: true)
-
   def is_authorized(api_key, system_name) do
-    case HTTPoison.get(raptor_url_with_params(raptor_url(), api_key, system_name)) do
+    raptor_url = System.get_env("RAPTOR_URL")
+    case HTTPoison.get(raptor_url_with_params(raptor_url, api_key, system_name)) do
       {:ok, %{body: body}} ->
         {:ok, is_authorized} = Jason.decode(body)
         is_authorized["is_authorized"]

--- a/apps/raptor_service/mix.exs
+++ b/apps/raptor_service/mix.exs
@@ -4,7 +4,7 @@ defmodule RaptorService.MixProject do
   def project do
     [
       app: :raptor_service,
-      version: "0.1.0",
+      version: "0.1.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/raptor_service/readme.md
+++ b/apps/raptor_service/readme.md
@@ -1,3 +1,7 @@
 ## Raptor Service
 
 An elixir library for making requests to Raptor
+
+## Requirements
+
+The RAPTOR_URL environment variable should point to a raptor instance

--- a/apps/raptor_service/test/unit/raptor_service_test.exs
+++ b/apps/raptor_service/test/unit/raptor_service_test.exs
@@ -8,7 +8,7 @@ defmodule RaptorServiceTest do
         return: {:ok, %{body: "{\"is_authorized\":true}"}}
       )
 
-      assert RaptorService.is_authorized("ap1K3y", "system__name")
+      assert RaptorService.is_authorized("raptor_url", "ap1K3y", "system__name")
     end
 
     test "returns false if unauthorized in Raptor" do
@@ -16,7 +16,7 @@ defmodule RaptorServiceTest do
         return: {:ok, %{body: "{\"is_authorized\":false}"}}
       )
 
-      assert not RaptorService.is_authorized("ap1K3y", "system__name")
+      assert not RaptorService.is_authorized("raptor_url", "ap1K3y", "system__name")
     end
   end
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,8 @@ if [[ $1 == "" || $1 == "help" || $2 == "" ]]; then
   echo "  Defaults:"
   echo "  - rebuild_build_image: true"
   echo "  - repository: smartcitiesdata/{app_name}${nl}"
+  echo "  Flags:"
+  echo "   --push: Runs docker push on the built image"
   echo "  Note: build_image is *all* of the elixir apps compiled."
   echo "        Only needs to be rebuilt once for changes across multiple apps.${nl}"
   exit 1
@@ -35,4 +37,11 @@ fi
 echo "Building $repository:$tag"
 docker build -t $repository:$tag apps/$app
 
-echo "${nl}Built ${repository}:${tag}${nl}"
+echo "${nl}Built ${repository}:${tag}$"
+
+if [[ $* == *--push* ]]; then
+  echo "Pushing ${repository}:${tag}"
+  docker push "${repository}:${tag}"
+fi
+
+echo "Done ${nl}"


### PR DESCRIPTION
## Description

A while ago we moved raptor logic to a shared library. Old config values were not removed when this happened.
The raptor URL was hardcoded, this change allows it to be configured with an environment variable.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
