### PR TITLE
Same access group with custom name

### DIFF
--- a/apps/andi/assets/css/access-groups.scss
+++ b/apps/andi/assets/css/access-groups.scss
@@ -6,6 +6,14 @@
   margin: 1em;
 }
 
+.access-groups-title {
+  display: inline-flex;
+  height: 3.5rem;
+  border-bottom: 1px solid $color-form-border;
+  margin-left: 1rem;
+  margin-right: 2rem;
+}
+
 .access-groups-index {
   padding: 1rem 3rem;
 }

--- a/apps/andi/lib/andi/input_schemas/access_group.ex
+++ b/apps/andi/lib/andi/input_schemas/access_group.ex
@@ -10,7 +10,6 @@ defmodule Andi.InputSchemas.AccessGroup do
   alias Andi.InputSchemas.StructTools
   alias Andi.InputSchemas.Datasets.Dataset
   alias Andi.Schemas.User
-  alias AndiWeb.Views.Options
 
   @primary_key {:id, Ecto.UUID, autogenerate: true}
   schema "access_groups" do
@@ -18,6 +17,8 @@ defmodule Andi.InputSchemas.AccessGroup do
     field(:description, :string)
     many_to_many(:users, User, join_through: Andi.Schemas.UserAccessGroup)
     many_to_many(:datasets, Dataset, join_through: Andi.Schemas.DatasetAccessGroup)
+
+    timestamps()
   end
 
   use Accessible

--- a/apps/andi/lib/andi_web/controllers/edit_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/edit_controller.ex
@@ -156,7 +156,7 @@ defmodule AndiWeb.EditController do
 
       access_group ->
         live_render(conn, AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView,
-          session: %{"access-group" => access_group, "is_curator" => is_curator}
+          session: %{"access_group" => access_group, "is_curator" => is_curator}
         )
     end
   end

--- a/apps/andi/lib/andi_web/live/access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.AccessGroupLiveView do
         <p>Access Groups determine who is allowed to see datasets. If a dataset is restricted to one or more Access Groups, only the users in
         those groups may view the dataset.</p>
 
-        <%= live_component(@socket, Table, id: :access_groups_table, access_groups: [], is_curator: @is_curator) %>
+        <%= live_component(@socket, Table, id: :access_groups_table, access_groups: @view_models, is_curator: @is_curator) %>
       </div>
     </div>
     """
@@ -27,8 +27,32 @@ defmodule AndiWeb.AccessGroupLiveView do
   def mount(_params, %{"is_curator" => is_curator} = _session, socket) do
     {:ok,
      assign(socket,
-       is_curator: is_curator
+       is_curator: is_curator,
+       access_groups: nil
      )}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    access_groups = Andi.InputSchemas.AccessGroups.get_all()
+    view_models = access_groups |> convert_to_view_models()
+
+    {:noreply,
+     assign(socket,
+       access_groups: access_groups,
+       view_models: view_models
+     )}
+  end
+
+  defp convert_to_view_models(access_groups) do
+    Enum.map(access_groups, &to_view_model/1)
+  end
+
+  defp to_view_model(access_group) do
+    %{
+      "id" => access_group.id,
+      "name" => access_group.name,
+      "modified_date" => access_group.updated_at
+    }
   end
 
   def handle_event("add-access-group", _, socket) do

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -5,30 +5,69 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
   import Phoenix.HTML.Form
 
+  alias Andi.InputSchemas.AccessGroup
+  alias Andi.InputSchemas.AccessGroups
+
   access_levels(render: [:private])
 
   def render(assigns) do
     ~L"""
     <%= header_render(@socket, @is_curator) %>
-    <div class="edit-page" id="access-groups-edit-page">
-    <div class="edit-page__btn-group">
-        <div class="btn-group__standard">
-          <button type="button" class="btn btn--large btn--cancel" phx-click="cancel-edit">Cancel</button>
-        </div>
+    <div class="edit-page" id="access-groups-edit-page edit-page">
+      <div class="edit-access-group-title">
+        <h2 class="component-title-text">Edit Access Group </h2>
+      </div>
 
+      <%= form = form_for @changeset, "#", [as: :form_data, phx_change: :form_change] %>
+      <%= hidden_input(form, :id) %>
+      <%= hidden_input(form, :description) %>
+
+        <div class="access-group-form__name">
+          <%= label(form, :name, class: "label label--required") do "Access Group Name" end %>
+          <%= text_input(form, :name, class: "input") %>
+        </div>
+      </form>
+
+      <div class="edit-button-group">
+        <div class="edit-button-group__cancel-btn">
+          <button type="button" class="btn btn--large" phx-click="cancel-edit">Cancel</button>
+        </div>
+        <div class="edit-button-group__save-btn">
+          <button type="submit" id="save-button" name="save-button" phx-click="form_save" class="btn btn--action btn--large">Save</button>
+        </div>
       </div>
     </div>
     """
   end
 
-  def mount(_params, %{"is_curator" => is_curator} = _session, socket) do
+  def mount(_params, %{"is_curator" => is_curator, "access_group" => access_group} = _session, socket) do
+    default_changeset = AccessGroup.changeset(access_group, %{}) |> Map.put(:errors, [])
+
     {:ok,
      assign(socket,
-       is_curator: is_curator
+       is_curator: is_curator,
+       access_group: access_group,
+       changeset: default_changeset
      )}
   end
 
   def handle_event("cancel-edit", _, socket) do
     {:noreply, redirect(socket, to: header_access_groups_path())}
+  end
+
+  def handle_event("form_save", _, socket) do
+    case socket.assigns.changeset |> Ecto.Changeset.apply_changes() |> AccessGroups.update() do
+      {:ok, _} ->
+        {:noreply, redirect(socket, to: header_access_groups_path())}
+
+      error ->
+        Logger.warn("Unable to save Access Groups changes: #{inspect(error)}")
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("form_change", %{"form_data" => form_data}, socket) do
+    new_changeset = form_data |> AccessGroup.changeset()
+    {:noreply, assign(socket, changeset: new_changeset)}
   end
 end

--- a/apps/andi/lib/andi_web/live/access_group_live_view/table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/table.ex
@@ -4,6 +4,7 @@ defmodule AndiWeb.AccessGroupLiveView.Table do
   """
 
   use Phoenix.LiveComponent
+  alias Phoenix.HTML.Link
 
   def render(assigns) do
     ~L"""
@@ -15,9 +16,24 @@ defmodule AndiWeb.AccessGroupLiveView.Table do
           <th class="access-groups-table__th access-groups-table__cell">Action</th>
         </thead>
 
-        <tr><td class="access-groups-table__cell" colspan="100%">No Access Groups</td></tr>
+        <%= if @access_groups == [] do %>
+          <tr><td class="access-groups-table__cell" colspan="100%">No Access Groups</td></tr>
+        <% else %>
+          <%= for access_group <- @access_groups do %>
+          <tr class="access-groups-table__tr">
+              <td class="access-groups-table__cell access-groups-table__cell--break access-groups-table__data-title-cell"><%= access_group["name"] %></td>
+              <td class="access-groups-table__cell access-groups-table__cell--break"><%= format_modified_date(access_group["modified_date"]) %></td>
+              <td class="access-groups-table__cell access-groups-table__cell--break" style="width: 10%;"><%= Link.link("Edit", to: "/access-groups/#{access_group["id"]}", class: "btn") %></td>
+            </tr>
+          <% end %>
+        <% end %>
       </table>
     </div>
     """
+  end
+
+  defp format_modified_date(datetime) do
+    format = "{M}-{D}-{YYYY}"
+    Timex.format!(datetime, format)
   end
 end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.6",
+      version: "2.1.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/priv/repo/migrations/20220317172817_add_timestamps_to_access_groups.exs
+++ b/apps/andi/priv/repo/migrations/20220317172817_add_timestamps_to_access_groups.exs
@@ -1,0 +1,9 @@
+defmodule Andi.Repo.Migrations.AddTimestampsToAccessGroups do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_groups) do
+      timestamps()
+    end
+  end
+end

--- a/apps/andi/test/integration/andi_web/live/access_group_live_view/edit_access_group_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/access_group_live_view/edit_access_group_live_view_test.exs
@@ -7,12 +7,13 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
 
   import Placebo
   import Phoenix.LiveViewTest
-  import SmartCity.TestHelper, only: [eventually: 1]
+  import SmartCity.TestHelper, only: [eventually: 1, eventually: 3]
 
   import FlokiHelpers,
     only: [
       find_elements: 2,
-      get_texts: 2
+      get_texts: 2,
+      get_attributes: 3
     ]
 
   alias SmartCity.TestDataGenerator, as: TDG
@@ -25,9 +26,41 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
   @url_path "/access-groups"
 
   describe "curator users access" do
+    test "the access group name field is alterable", %{curator_conn: conn} do
+      uuid = UUID.uuid4()
+      access_group = TDG.create_access_group(%{name: "old-group-name", id: uuid})
+      AccessGroups.update(access_group)
+      assert {:ok, view, _html} = live(conn, "#{@url_path}/#{uuid}")
+
+      new_access_group_name = "new-group-name"
+      form_data = %{"name" => new_access_group_name, "id" => uuid}
+
+      render_change(view, "form_change", %{"form_data" => form_data, "_target" => ["form_data", "name"]})
+
+      save_btn = element(view, ".btn", "Save")
+      render_click(save_btn)
+
+      eventually(fn ->
+        group = AccessGroups.get(uuid)
+        assert group != nil
+        assert group.name == new_access_group_name
+      end)
+    end
+
+    test "the access group name is loaded into the name field upon load", %{curator_conn: conn} do
+      access_group_name = "cool-group-name"
+      uuid = UUID.uuid4()
+      access_group = TDG.create_access_group(%{name: access_group_name, id: uuid})
+      AccessGroups.update(access_group)
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{uuid}")
+
+      assert [access_group_name] = get_attributes(html, "#form_data_name", "value")
+    end
+
     test "the cancel button redirects users back to the main access groups page", %{curator_conn: conn} do
       uuid = UUID.uuid4()
-      {:ok, access_group} = SmartCity.AccessGroup.new(%{name: "Smrt Access Group", id: uuid})
+      access_group = TDG.create_access_group(%{name: "Smrt Access Group", id: uuid})
       AccessGroups.update(access_group)
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{uuid}")
 

--- a/apps/andi/test/integration/andi_web/live/access_group_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/access_group_live_view_test.exs
@@ -40,5 +40,27 @@ defmodule AndiWeb.AccessGroupLiveViewTest do
     test "curators can view all the access groups", %{curator_conn: conn} do
       assert {:ok, view, html} = live(conn, @url_path)
     end
+
+    test "all access groups are shown", %{curator_conn: conn} do
+      {:ok, access_group_a} = TDG.create_access_group(%{}) |> AccessGroups.update()
+      {:ok, access_group_b} = TDG.create_access_group(%{}) |> AccessGroups.update()
+
+      {:ok, _view, html} = live(conn, @url_path)
+
+      dataset_rows = find_elements(html, ".access-groups-table__tr")
+
+      assert Enum.count(dataset_rows) >= 2
+    end
+
+    test "edit button links to the access group edit page", %{curator_conn: conn} do
+      access_group = AccessGroups.create()
+
+      {:ok, view, _html} = live(conn, @url_path)
+
+      edit_access_group_button = element(view, ".btn", "Edit")
+
+      render_click(edit_access_group_button)
+      assert_redirected(view, "/access-groups/#{access_group.id}")
+    end
   end
 end

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/table_test.exs
@@ -28,9 +28,48 @@ defmodule AndiWeb.AccessGroupLiveView.TableTest do
 
   describe "Basic access groups page load" do
     test "shows \"No Access Groups\" when there are no rows to show", %{conn: conn} do
+      allow(Andi.InputSchemas.AccessGroups.get_all(), return: [])
       assert {:ok, view, html} = live(conn, @url_path)
 
       assert get_text(html, ".access-groups-table__cell") =~ "No Access Groups"
+    end
+
+    test "represents an Access Group when one exists", %{conn: conn} do
+      group_name = "group-one"
+      group_id = UUID.uuid4()
+      updated_at = DateTime.utc_now()
+      allow(Andi.InputSchemas.AccessGroups.get_all(), return: [%{name: group_name, id: group_id, updated_at: updated_at}])
+
+      assert {:ok, view, html} = live(conn, @url_path)
+
+      assert get_text(html, ".access-groups-table__cell") =~ group_name
+    end
+
+    test "displays 'Modified Date' attribute correctly", %{conn: conn} do
+      group_name = "group-one"
+      group_id = UUID.uuid4()
+      updated_at = DateTime.utc_now()
+      allow(Andi.InputSchemas.AccessGroups.get_all(), return: [%{name: group_name, id: group_id, updated_at: updated_at}])
+
+      assert {:ok, view, html} = live(conn, @url_path)
+
+      expected_time_string = Timex.format!(updated_at, "{M}-{D}-{YYYY}")
+      assert get_text(html, ".access-groups-table__cell") =~ expected_time_string
+    end
+
+    test "represents Access Groups when multiple exist", %{conn: conn} do
+      group_name = "group-one"
+      group_id = UUID.uuid4()
+      updated_at = DateTime.utc_now()
+
+      allow(Andi.InputSchemas.AccessGroups.get_all(),
+        return: [%{name: group_name, id: group_id, updated_at: updated_at}, %{name: "group2", id: UUID.uuid4(), updated_at: updated_at}]
+      )
+
+      assert {:ok, view, html} = live(conn, @url_path)
+
+      assert get_text(html, ".access-groups-table__cell") =~ group_name
+      assert get_text(html, ".access-groups-table__cell") =~ "group2"
     end
   end
 end


### PR DESCRIPTION
## Changes
- Adds ModifedBy to access groups index page
- Adds Name field to access groups edit page

## [Ticket](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/580)

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- NA ~~If altering an API endpoint, was the relevant postman collection updated?~~
