### PR TITLE
De-bolding orgs to match the other navbar items

### DIFF
--- a/apps/andi/assets/css/app.scss
+++ b/apps/andi/assets/css/app.scss
@@ -284,10 +284,6 @@ body {
     align-items: center;
     font-size: 1.1rem;
 
-    .organization-link__text {
-        font-weight: bold;
-    }
-
     &:hover {
         cursor: pointer;
     }


### PR DESCRIPTION
## Reminders:

- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`? No, because this isn't critical enough to warrant its own release. It can go in the next batch of changes.
- [ ] If altering an API endpoint, was the relevant postman collection updated?
