### PR TITLE
Save Access Groups with Associated Datasets

### DIFF
--- a/apps/andi/assets/css/access-groups.scss
+++ b/apps/andi/assets/css/access-groups.scss
@@ -1,3 +1,8 @@
+#access-groups-edit-page {
+  grid-row-gap: 0;
+  padding-top: 0.5rem;
+}
+
 .access-groups-view {
   flex: 1;
   background: $color-content-background;
@@ -12,6 +17,10 @@
   border-bottom: 1px solid $color-form-border;
   margin-left: 1rem;
   margin-right: 2rem;
+}
+
+.access-groups-component-title-text {
+  margin-bottom: 0;
 }
 
 .access-groups-index {
@@ -55,6 +64,11 @@
   width: 10%;
 }
 
+#access-groups-edit-button-group {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .btn--add-dataset-search {
     min-width: 100px;
     height: 2.3rem;
@@ -73,4 +87,42 @@
 
 .add-dataset-modal--hidden {
     display: none;
+}
+
+.access-groups-dataset-table-container {
+  max-height: 250px;
+  overflow-y: auto;
+  margin: 0.5rem 0rem;
+}
+
+.access-groups-dataset-table {
+  width: 100%;
+  border: $table-border;
+  border-top: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  max-height: 200px;
+}
+
+.access-groups-dataset-table__tr:nth-child(odd) {
+  background-color: $color-table-stripe;
+}
+
+.access-groups-dataset-table__th {
+  padding: $table-padding;
+  border-top: $table-border;
+  text-align: left;
+  background: $color-table-header;
+  position: sticky;
+  top: 0;
+}
+
+.access-groups-dataset-table__cell {
+  padding: $table-padding;
+  height: $table-height;
+  max-width: 30rem;
+}
+
+.access-groups-dataset-table__status-cell {
+  width: 10%;
 }

--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -23,6 +23,7 @@ defmodule Andi.Event.EventHandler do
   alias SmartCity.{Dataset, Organization, Ingestion}
   alias SmartCity.UserOrganizationAssociate
   alias SmartCity.UserOrganizationDisassociate
+  alias SmartCity.DatasetAccessGroupRelation
 
   alias Andi.Services.DatasetStore
   alias Andi.Services.OrgStore
@@ -122,13 +123,11 @@ defmodule Andi.Event.EventHandler do
 
   def handle_event(%Brook.Event{
         type: dataset_access_group_associate(),
-        data: %SmartCity.DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id},
+        data: %DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id},
         author: author
       }) do
     dataset_access_group_associate()
     |> add_event_count(author, nil)
-
-    IO.inspect(dataset_id, label: "REACHED EVENT HANDLER")
 
     case Andi.InputSchemas.Datasets.Dataset.associate_with_access_group(access_group_id, dataset_id) do
       {:error, error} ->
@@ -143,7 +142,7 @@ defmodule Andi.Event.EventHandler do
 
   def handle_event(%Brook.Event{
         type: dataset_access_group_disassociate(),
-        data: %SmartCity.DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id},
+        data: %DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id},
         author: author
       }) do
     dataset_access_group_disassociate()

--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -15,7 +15,9 @@ defmodule Andi.Event.EventHandler do
       dataset_harvest_end: 0,
       user_login: 0,
       ingestion_update: 0,
-      ingestion_delete: 0
+      ingestion_delete: 0,
+      dataset_access_group_associate: 0,
+      dataset_access_group_disassociate: 0
     ]
 
   alias SmartCity.{Dataset, Organization, Ingestion}
@@ -109,6 +111,48 @@ defmodule Andi.Event.EventHandler do
       {:error, error} ->
         Logger.error(
           "Unable to disassociate user with organization #{disassociation.org_id}: #{inspect(error)}. This event has been discarded."
+        )
+
+      _ ->
+        :ok
+    end
+
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: dataset_access_group_associate(),
+        data: %SmartCity.DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id},
+        author: author
+      }) do
+    dataset_access_group_associate()
+    |> add_event_count(author, nil)
+
+    IO.inspect(dataset_id, label: "REACHED EVENT HANDLER")
+
+    case Andi.InputSchemas.Datasets.Dataset.associate_with_access_group(access_group_id, dataset_id) do
+      {:error, error} ->
+        Logger.error("Unable to associate dataset with access group #{access_group_id}: #{inspect(error)}. This event has been discarded.")
+
+      _ ->
+        :ok
+    end
+
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: dataset_access_group_disassociate(),
+        data: %SmartCity.DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id},
+        author: author
+      }) do
+    dataset_access_group_disassociate()
+    |> add_event_count(author, nil)
+
+    case Andi.InputSchemas.Datasets.Dataset.disassociate_with_access_group(access_group_id, dataset_id) do
+      {:error, error} ->
+        Logger.error(
+          "Unable to disassociate dataset from access group #{access_group_id}: #{inspect(error)}. This event has been discarded."
         )
 
       _ ->

--- a/apps/andi/lib/andi/schemas/dataset_access_group.ex
+++ b/apps/andi/lib/andi/schemas/dataset_access_group.ex
@@ -9,9 +9,9 @@ defmodule Andi.Schemas.DatasetAccessGroup do
 
   @primary_key false
 
-  schema "user_access_groups" do
+  schema "dataset_access_groups" do
     belongs_to(:access_group, AccessGroup, type: Ecto.UUID, primary_key: true)
-    belongs_to(:dataset, Dataset, type: Ecto.UUID, primary_key: true)
+    belongs_to(:dataset, Dataset, type: :string, primary_key: true)
 
     timestamps()
   end

--- a/apps/andi/lib/andi_web/controllers/edit_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/edit_controller.ex
@@ -149,7 +149,7 @@ defmodule AndiWeb.EditController do
   end
 
   def edit_access_group(conn, %{"id" => id}) do
-    %{"is_curator" => is_curator} = AndiWeb.Auth.TokenHandler.Plug.current_resource(conn)
+    %{"is_curator" => is_curator, "user_id" => user_id} = AndiWeb.Auth.TokenHandler.Plug.current_resource(conn)
 
     case AccessGroups.get(id) do
       nil ->
@@ -160,7 +160,7 @@ defmodule AndiWeb.EditController do
 
       access_group ->
         live_render(conn, AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView,
-          session: %{"access_group" => access_group, "is_curator" => is_curator}
+          session: %{"access_group" => access_group, "is_curator" => is_curator, "user_id" => user_id}
         )
     end
   end

--- a/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
@@ -1,0 +1,43 @@
+defmodule AndiWeb.AccessGroupLiveView.DatasetTable do
+  @moduledoc """
+  LiveComponent for access group datasets table
+  """
+
+  use Phoenix.LiveComponent
+  alias Phoenix.HTML.Link
+
+  def render(assigns) do
+    ~L"""
+    <div class="access-group-datasets-results">
+      <h2 class="component-title-text">Datasets Assigned to This Access Group</h2>
+      <div class="access-groups-dataset-table-container">
+        <table class="access-groups-dataset-table">
+          <thead>
+            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Dataset</th>
+            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Organization</th>
+            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Keywords</th>
+          </thead>
+
+          <%= if @selected_datasets == [] and @associated_datasets == [] do %>
+            <tr><td class="access-groups-dataset-table__cell" colspan="100%">No Associated Datasets</td></tr>
+          <% else %>
+            <%= for dataset <- datasets_to_display(@associated_datasets, @selected_datasets) do %>
+            <tr class="access-groups-dataset-table__tr">
+                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break access-groups-dataset-table__data-title-cell wide-column"><%= dataset.business.dataTitle %></td>
+                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break wide-column"><%= dataset.business.orgTitle %></td>
+                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break wide-column"><%= Enum.join(dataset.business.keywords, ", ") %></td>
+              </tr>
+            <% end %>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    """
+  end
+
+  defp datasets_to_display(associated_datasets, selected_dataset_ids) do
+    associated_dataset_ids = Enum.map(associated_datasets, fn associated_dataset -> associated_dataset.id end)
+    datasets_to_display = Enum.uniq(associated_dataset_ids ++ selected_dataset_ids)
+    Enum.map(datasets_to_display, fn dataset_id -> Andi.InputSchemas.Datasets.get(dataset_id) end)
+  end
+end

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -5,6 +5,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
   import Phoenix.HTML.Form
   import Ecto.Query, only: [from: 2]
+  import SmartCity.Event
 
   alias Andi.InputSchemas.AccessGroup
   alias Andi.InputSchemas.AccessGroups
@@ -15,10 +16,12 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@socket, @is_curator) %>
-    <div class="edit-page" id="access-groups-edit-page edit-page">
+    <div class="edit-page" id="access-groups-edit-page">
       <div class="edit-access-group-title">
-        <h2 class="component-title-text">Edit Access Group </h2>
+        <h2 class="component-title-text access-groups-component-title-text">Edit Access Group </h2>
       </div>
+
+      <hr class="datasets-modal-divider">
 
       <%= form = form_for @changeset, "#", [as: :form_data, phx_change: :form_change] %>
       <%= hidden_input(form, :id) %>
@@ -29,6 +32,31 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
           <%= text_input(form, :name, class: "input") %>
         </div>
 
+        <div class="dataset-modal-search-results">
+          <h2 class="component-title-text">Datasets Assigned to This Access Group</h2>
+          <div class="access-groups-dataset-table-container">
+            <table class="access-groups-dataset-table">
+              <thead>
+                <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Dataset</th>
+                <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Organization</th>
+                <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Keywords</th>
+              </thead>
+
+              <%= if @selected_datasets == [] and @associated_datasets == [] do %>
+                <tr><td class="access-groups-dataset-table__cell" colspan="100%">No Associated Datasets</td></tr>
+              <% else %>
+                <%= for dataset <- datasets_to_display(@associated_datasets, @selected_datasets) do %>
+                <tr class="access-groups-dataset-table__tr">
+                    <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break access-groups-dataset-table__data-title-cell wide-column"><%= dataset.business.dataTitle %></td>
+                    <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break wide-column"><%= dataset.business.orgTitle %></td>
+                    <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break wide-column"><%= Enum.join(dataset.business.keywords, ", ") %></td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </table>
+          </div>
+        </div>
+
         <div class="access-group-form__datasets">
           <button class="btn btn--add-dataset-search" phx-click="add-dataset" type="button">+ Add Dataset</button>
         </div>
@@ -36,12 +64,12 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
       <%= live_component(@socket, AndiWeb.Search.AddDatasetModal, visibility: @add_dataset_modal_visibility, datasets: @datasets, search_text: @search_text, selected_datasets: @selected_datasets) %>
 
-      <div class="edit-button-group">
+      <div class="edit-button-group" id="access-groups-edit-button-group">
         <div class="edit-button-group__cancel-btn">
           <button type="button" class="btn btn--large cancel-edit" phx-click="cancel-edit">Cancel</button>
         </div>
         <div class="edit-button-group__save-btn">
-          <button type="submit" id="save-button" name="save-button" phx-click="form_save" class="btn btn--action btn--large save-edit">Save</button>
+          <button type="submit" id="save-button" name="save-button" phx-click="access-group-form_save" class="btn btn--action btn--large save-edit">Save</button>
         </div>
       </div>
     </div>
@@ -50,6 +78,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
   def mount(_params, %{"is_curator" => is_curator, "access_group" => access_group} = _session, socket) do
     default_changeset = AccessGroup.changeset(access_group, %{}) |> Map.put(:errors, [])
+    access_group_with_datasets = Andi.Repo.get(Andi.InputSchemas.AccessGroup, access_group.id) |> Andi.Repo.preload(:datasets)
 
     {:ok,
      assign(socket,
@@ -59,7 +88,8 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
        add_dataset_modal_visibility: "hidden",
        datasets: [],
        search_text: "",
-       selected_datasets: []
+       selected_datasets: [],
+       associated_datasets: access_group_with_datasets.datasets
      )}
   end
 
@@ -71,7 +101,18 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
     {:noreply, assign(socket, add_dataset_modal_visibility: "hidden")}
   end
 
-  def handle_event("form_save", _, socket) do
+  def handle_event("save-search", _, socket) do
+    {:noreply,
+     assign(socket,
+       add_dataset_modal_visibility: "hidden",
+       datasets: socket.assigns.datasets,
+       selected_datasets: socket.assigns.selected_datasets
+     )}
+  end
+
+  def handle_event("access-group-form_save", _, socket) do
+    associate_datasets_with_access_group(socket.assigns.selected_datasets, socket.assigns.access_group.id)
+
     case socket.assigns.changeset |> Ecto.Changeset.apply_changes() |> AccessGroups.update() do
       {:ok, _} ->
         {:noreply, redirect(socket, to: header_access_groups_path())}
@@ -144,5 +185,21 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
     query
     |> Andi.Repo.all()
+  end
+
+  def datasets_to_display(associated_datasets, selected_dataset_ids) do
+    associated_dataset_ids = Enum.map(associated_datasets, fn associated_dataset -> associated_dataset.id end)
+    datasets_to_display = Enum.uniq(associated_dataset_ids ++ selected_dataset_ids)
+    Enum.map(datasets_to_display, fn dataset_id -> Andi.InputSchemas.Datasets.get(dataset_id) end)
+  end
+
+  def associate_datasets_with_access_group(selected_datasets, access_group_id) do
+    Enum.map(selected_datasets, fn selected_dataset ->
+      {:ok, dataset_access_group_association} =
+        SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: selected_dataset, access_group_id: access_group_id})
+
+      # Andi.Schemas.AuditEvents.log_audit_event(socket.assigns.signed_in_user_id, dataset_access_group_associate(), dataset_access_group_association)
+      Brook.Event.send(:andi, dataset_access_group_associate(), :andi, dataset_access_group_association)
+    end)
   end
 end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.10",
+      version: "2.1.11",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
+++ b/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
@@ -1,0 +1,70 @@
+defmodule Andi.Schemas.UserTest do
+  use ExUnit.Case
+  use Andi.DataCase
+
+  alias SmartCity.TestDataGenerator, as: TDG
+  alias Andi.InputSchemas.Datasets
+  alias Andi.InputSchemas.Datasets.Dataset
+  alias Andi.InputSchemas.AccessGroups
+  import SmartCity.TestHelper, only: [eventually: 1]
+
+  @moduletag shared_data_connection: true
+
+  describe "associate_with_access_group/2" do
+    setup do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _andi_dataset} = Datasets.update(dataset)
+
+      access_group = TDG.create_access_group(%{})
+      {:ok, _andi_access_group} = AccessGroups.update(access_group)
+
+      %{dataset_id: dataset.id, access_group_id: access_group.id}
+    end
+
+    test "associates a dataset with an access group", %{dataset_id: dataset_id, access_group_id: access_group_id} do
+      {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
+
+      eventually(fn ->
+        assert [%{id: access_group_id}] = Map.get(dataset, :access_groups)
+      end)
+    end
+
+    test "a dataset can be associated with multiple access groups", %{dataset_id: dataset_id, access_group_id: access_group_id} do
+      access_group_2 = TDG.create_access_group(%{})
+      {:ok, _andi_access_group} = AccessGroups.update(access_group_2)
+
+      {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
+      {:ok, dataset} = Dataset.associate_with_access_group(access_group_2.id, dataset_id)
+
+      eventually(fn ->
+        assert [%{id: access_group_id}, %{id: access_group_2.id}] = Map.get(dataset, :access_groups)
+      end)
+    end
+  end
+
+  describe "disassociate_with_access_group/2" do
+    setup do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _andi_dataset} = Datasets.update(dataset)
+
+      access_group = TDG.create_access_group(%{})
+      {:ok, _andi_access_group} = AccessGroups.update(access_group)
+
+      %{dataset_id: dataset.id, access_group_id: access_group.id}
+
+      {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
+
+      eventually(fn ->
+        assert [%{id: access_group_id}] = Map.get(dataset, :access_groups)
+      end)
+    end
+
+    test "disassociates a dataset from an access group", %{dataset_id: dataset_id, access_group_id: access_group_id} do
+      {:ok, dataset} = Dataset.disassociate_with_access_group(access_group_id, dataset_id)
+
+      eventually(fn ->
+        assert [] = Map.get(dataset, :access_groups)
+      end)
+    end
+  end
+end

--- a/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
+++ b/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
@@ -28,19 +28,6 @@ defmodule Andi.InputSchemas.Datasets.DatasetTest do
         assert [%{id: ^access_group_id}] = Map.get(dataset, :access_groups)
       end)
     end
-
-    test "a dataset can be associated with multiple access groups", %{dataset_id: dataset_id, access_group_id: access_group_id} do
-      access_group_2 = TDG.create_access_group(%{})
-      access_group_2_id = access_group_2.id
-      {:ok, _andi_access_group} = AccessGroups.update(access_group_2)
-
-      {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
-      {:ok, dataset} = Dataset.associate_with_access_group(access_group_2.id, dataset_id)
-
-      eventually(fn ->
-        assert [%{id: ^access_group_id}, %{id: ^access_group_2_id}] = Map.get(dataset, :access_groups)
-      end)
-    end
   end
 
   describe "disassociate_with_access_group/2" do

--- a/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
+++ b/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
@@ -1,4 +1,4 @@
-defmodule Andi.Schemas.UserTest do
+defmodule Andi.InputSchemas.Datasets.DatasetTest do
   use ExUnit.Case
   use Andi.DataCase
 

--- a/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
+++ b/apps/andi/test/integration/andi/input_schemas/datasets/dataset_test.exs
@@ -25,19 +25,20 @@ defmodule Andi.InputSchemas.Datasets.DatasetTest do
       {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
 
       eventually(fn ->
-        assert [%{id: access_group_id}] = Map.get(dataset, :access_groups)
+        assert [%{id: ^access_group_id}] = Map.get(dataset, :access_groups)
       end)
     end
 
     test "a dataset can be associated with multiple access groups", %{dataset_id: dataset_id, access_group_id: access_group_id} do
       access_group_2 = TDG.create_access_group(%{})
+      access_group_2_id = access_group_2.id
       {:ok, _andi_access_group} = AccessGroups.update(access_group_2)
 
       {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
       {:ok, dataset} = Dataset.associate_with_access_group(access_group_2.id, dataset_id)
 
       eventually(fn ->
-        assert [%{id: access_group_id}, %{id: access_group_2.id}] = Map.get(dataset, :access_groups)
+        assert [%{id: ^access_group_id}, %{id: ^access_group_2_id}] = Map.get(dataset, :access_groups)
       end)
     end
   end
@@ -48,22 +49,25 @@ defmodule Andi.InputSchemas.Datasets.DatasetTest do
       {:ok, _andi_dataset} = Datasets.update(dataset)
 
       access_group = TDG.create_access_group(%{})
+      access_group_id = access_group.id
       {:ok, _andi_access_group} = AccessGroups.update(access_group)
 
       %{dataset_id: dataset.id, access_group_id: access_group.id}
 
-      {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset_id)
+      {:ok, dataset} = Dataset.associate_with_access_group(access_group_id, dataset.id)
 
       eventually(fn ->
-        assert [%{id: access_group_id}] = Map.get(dataset, :access_groups)
+        assert [%{id: ^access_group_id}] = Map.get(dataset, :access_groups)
       end)
+
+      %{dataset_id: dataset.id, access_group_id: access_group.id}
     end
 
     test "disassociates a dataset from an access group", %{dataset_id: dataset_id, access_group_id: access_group_id} do
       {:ok, dataset} = Dataset.disassociate_with_access_group(access_group_id, dataset_id)
 
       eventually(fn ->
-        assert [] = Map.get(dataset, :access_groups)
+        assert [] == Map.get(dataset, :access_groups)
       end)
     end
   end

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
@@ -10,7 +10,6 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
   alias Andi.InputSchemas.AccessGroups
   alias Andi.InputSchemas.AccessGroup
 
-
   @endpoint AndiWeb.Endpoint
   @url_path "/access-groups"
   @user UserHelpers.create_user()
@@ -77,8 +76,5 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
       assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset_1.business.dataTitle
       assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset_2.business.dataTitle
     end
-
-
-
   end
 end

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
@@ -1,0 +1,84 @@
+defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
+  use AndiWeb.Test.AuthConnCase.UnitCase
+  use Placebo
+  alias Andi.Schemas.User
+
+  import Phoenix.LiveViewTest
+  import FlokiHelpers, only: [get_text: 2]
+
+  alias SmartCity.TestDataGenerator, as: TDG
+  alias Andi.InputSchemas.AccessGroups
+  alias Andi.InputSchemas.AccessGroup
+
+
+  @endpoint AndiWeb.Endpoint
+  @url_path "/access-groups"
+  @user UserHelpers.create_user()
+
+  defp allowAuthUser do
+    allow(Andi.Repo.get_by(Andi.Schemas.User, any()), return: @user)
+    allow(User.get_all(), return: [@user])
+    allow(User.get_by_subject_id(any()), return: @user)
+  end
+
+  setup do
+    allowAuthUser()
+    []
+  end
+
+  setup %{auth_conn_case: auth_conn_case} do
+    auth_conn_case.disable_revocation_list.()
+    :ok
+  end
+
+  describe "Basic associated datasets table load" do
+    test "shows \"No Associated Datasets\" when there are no rows to show", %{conn: conn} do
+      access_group = TDG.create_access_group(%{})
+      allow(AccessGroups.update(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(AccessGroups.get(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(Andi.InputSchemas.AccessGroup.changeset(any(), any()), return: AccessGroup.changeset(access_group))
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+      assert get_text(html, ".access-groups-dataset-table__cell") =~ "No Associated Datasets"
+    end
+
+    test "shows an associated dataset", %{conn: conn} do
+      access_group = TDG.create_access_group(%{})
+      allow(AccessGroups.update(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(AccessGroups.get(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(Andi.InputSchemas.AccessGroup.changeset(any(), any()), return: AccessGroup.changeset(access_group))
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      dataset = TDG.create_dataset(%{})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset.id}]})
+      allow(Andi.InputSchemas.Datasets.get(dataset.id), return: dataset)
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+      assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset.business.dataTitle
+    end
+
+    test "shows multiple associated datasets", %{conn: conn} do
+      access_group = TDG.create_access_group(%{})
+      allow(AccessGroups.update(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(AccessGroups.get(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(Andi.InputSchemas.AccessGroup.changeset(any(), any()), return: AccessGroup.changeset(access_group))
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      dataset_1 = TDG.create_dataset(%{})
+      dataset_2 = TDG.create_dataset(%{})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset_1.id}, %{id: dataset_2.id}]})
+      allow(Andi.InputSchemas.Datasets.get(dataset_1.id), return: dataset_1)
+      allow(Andi.InputSchemas.Datasets.get(dataset_2.id), return: dataset_2)
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+      assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset_1.business.dataTitle
+      assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset_2.business.dataTitle
+    end
+
+
+
+  end
+end

--- a/apps/andi/test/unit/andi_web/live/search/add_dataset_modal_test.exs
+++ b/apps/andi/test/unit/andi_web/live/search/add_dataset_modal_test.exs
@@ -36,6 +36,9 @@ defmodule AndiWeb.Search.AddDatasetModalTest do
       allow(Andi.InputSchemas.Datasets.get_all(), return: [])
       allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
+
       access_group = create_access_group()
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
@@ -50,6 +53,8 @@ defmodule AndiWeb.Search.AddDatasetModalTest do
       allow(Andi.Repo.all(any()), return: [%Dataset{business: %{dataTitle: "Noodles", orgTitle: "Happy", keywords: ["Soup"]}}])
       allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
       access_group = create_access_group()
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
@@ -74,6 +79,8 @@ defmodule AndiWeb.Search.AddDatasetModalTest do
 
       allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
       access_group = create_access_group()
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 


### PR DESCRIPTION
## [Ticket Link #570](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/570)

## Description

 - There is a save button on the dataset search page.
 - Clicking the save button navigates back to the edit access group page.
 - If datasets were selected when save was clicked, those datasets are listed under "Datasets assigned to this access group" with their name, organization, and keywords.
 - When the access group is saved from the edit page, a dataset_access_group_associate event is sent.

  
![image](https://user-images.githubusercontent.com/73911735/160169384-0b1e7bd0-6bc2-40f7-a680-3978f006f632.png)
 
 
## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
NA If altering an API endpoint, was the relevant postman collection updated?
NAIf a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
