### PR TITLE
587 access groups users

### DIFF
--- a/apps/andi/assets/css/access-groups.scss
+++ b/apps/andi/assets/css/access-groups.scss
@@ -70,15 +70,15 @@
 }
 
 .btn--manage-datasets-search {
-    min-width: 100px;
-    height: 2.3rem;
-    background-color: #27cb00;
-    margin: 20px 0px;
-    padding: 0 50px;
+  min-width: 100px;
+  height: 2.3rem;
+  background-color: #27cb00;
+  margin: 20px 0px;
+  padding: 0 50px;
 
-    &:hover {
-        background-color: #2de000;
-    }
+  &:hover {
+    background-color: #2de000;
+  }
 }
 
 .btn--manage-users-search {
@@ -86,11 +86,11 @@
 }
 
 .manage-datasets-modal--visible {
-    @include modal-wrapper();
+  @include modal-wrapper();
 }
 
 .manage-datasets-modal--hidden {
-    display: none;
+  display: none;
 }
 
 .manage-users-modal--visible {
@@ -98,16 +98,16 @@
 }
 
 .manage-users-modal--hidden {
-    display: none;
+  display: none;
 }
 
-.access-groups-dataset-table-container {
+.access-groups-sub-table-container {
   max-height: 250px;
   overflow-y: auto;
   margin: 0.5rem 0rem;
 }
 
-.access-groups-dataset-table {
+.access-groups-sub-table {
   width: 100%;
   border: $table-border;
   border-top: 0;
@@ -116,11 +116,11 @@
   max-height: 200px;
 }
 
-.access-groups-dataset-table__tr:nth-child(odd) {
+.access-groups-sub-table__tr:nth-child(odd) {
   background-color: $color-table-stripe;
 }
 
-.access-groups-dataset-table__th {
+.access-groups-sub-table__th {
   padding: $table-padding;
   border-top: $table-border;
   text-align: left;
@@ -129,12 +129,12 @@
   top: 0;
 }
 
-.access-groups-dataset-table__cell {
+.access-groups-sub-table__cell {
   padding: $table-padding;
   height: $table-height;
   max-width: 30rem;
 }
 
-.access-groups-dataset-table__status-cell {
+.access-groups-sub-table__status-cell {
   width: 10%;
 }

--- a/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
@@ -9,24 +9,24 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTable do
     ~L"""
     <div class="access-group-datasets-results">
       <h2 class="component-title-text">Datasets Assigned to This Access Group</h2>
-      <div class="access-groups-dataset-table-container">
-        <table class="access-groups-dataset-table">
+      <div class="access-groups-sub-table-container">
+        <table class="access-groups-sub-table">
           <thead>
-            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Dataset</th>
-            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Organization</th>
-            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Keywords</th>
-            <th class="access-groups-dataset-table__th access-groups-dataset-table__cell wide-column">Action</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Dataset</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Organization</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Keywords</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Action</th>
           </thead>
 
           <%= if @selected_datasets == [] do %>
-            <tr><td class="access-groups-dataset-table__cell" colspan="100%">No Associated Datasets</td></tr>
+            <tr><td class="access-groups-sub-table__cell" colspan="100%">No Associated Datasets</td></tr>
           <% else %>
             <%= for dataset <- datasets_to_display(@selected_datasets) do %>
-            <tr class="access-groups-dataset-table__tr">
-                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break access-groups-dataset-table__data-title-cell wide-column"><%= dataset.business.dataTitle %></td>
-                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break wide-column"><%= dataset.business.orgTitle %></td>
-                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break wide-column"><%= Enum.join(dataset.business.keywords, ", ") %></td>
-                <td class="access-groups-dataset-table__cell access-groups-dataset-table__cell--break modal-action-text thin-column" phx-click="remove-selected-dataset" phx-value-id=<%= dataset.id %>>Remove</td>
+            <tr class="access-groups-sub-table__tr">
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break access-groups-sub-table__data-title-cell wide-column"><%= dataset.business.dataTitle %></td>
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= dataset.business.orgTitle %></td>
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= Enum.join(dataset.business.keywords, ", ") %></td>
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break modal-action-text thin-column" phx-click="remove-selected-dataset" phx-value-id=<%= dataset.id %>>Remove</td>
               </tr>
             <% end %>
           <% end %>

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -38,6 +38,9 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
         <div>
           <button class="btn btn--manage-datasets-search" phx-click="manage-datasets" type="button">Manage Datasets</button>
         </div>
+
+        <%= live_component(@socket, AndiWeb.AccessGroupLiveView.UserTable, selected_users: @selected_users) %>
+
         <div>
           <button class="btn btn--manage-users-search" phx-click="manage-users" type="button">Manage Users</button>
         </div>

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -45,7 +45,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
       <%= live_component(@socket, AndiWeb.Search.ManageDatasetsModal, visibility: @manage_datasets_modal_visibility, search_results: @dataset_search_results, search_text: @dataset_search_text, selected_datasets: @selected_datasets) %>
 
-      <%= live_component(@socket, AndiWeb.Search.ManageUsersModal, visibility: @manage_users_modal_visibility, search_results: @user_search_results, search_text: @user_search_text) %>
+      <%= live_component(@socket, AndiWeb.Search.ManageUsersModal, visibility: @manage_users_modal_visibility, search_results: @user_search_results, search_text: @user_search_text, selected_users: @selected_users) %>
 
       <div class="edit-button-group" id="access-groups-edit-button-group">
         <div class="edit-button-group__cancel-btn">
@@ -62,17 +62,18 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
   def mount(_params, %{"is_curator" => is_curator, "access_group" => access_group, "user_id" => user_id} = _session, socket) do
     default_changeset = AccessGroup.changeset(access_group, %{}) |> Map.put(:errors, [])
 
-    access_group_with_datasets =
+    access_group_with_datasets_and_users =
       Andi.Repo.get(Andi.InputSchemas.AccessGroup, access_group.id)
-      |> Andi.Repo.preload(:datasets)
+      |> Andi.Repo.preload([:datasets, :users])
 
-    starting_dataset_ids = Enum.map(access_group_with_datasets.datasets, fn dataset -> dataset.id end)
+    starting_dataset_ids = Enum.map(access_group_with_datasets_and_users.datasets, fn dataset -> dataset.id end)
+    starting_user_ids = Enum.map(access_group_with_datasets_and_users.users, fn user -> user.id end)
 
     {:ok,
      assign(socket,
        is_curator: is_curator,
        user_id: user_id,
-       access_group: access_group_with_datasets,
+       access_group: access_group_with_datasets_and_users,
        changeset: default_changeset,
        manage_datasets_modal_visibility: "hidden",
        manage_users_modal_visibility: "hidden",
@@ -81,7 +82,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
        dataset_search_text: "",
        user_search_text: "",
        selected_datasets: starting_dataset_ids,
-       selected_users: []
+       selected_users: starting_user_ids
      )}
   end
 
@@ -167,6 +168,26 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
   def handle_event("remove-selected-dataset", %{"id" => id}, socket) do
     update_dataset_selection(id, socket)
+  end
+
+  def handle_event("select-user-search", %{"id" => id}, socket) do
+    update_user_selection(id, socket)
+  end
+
+  def handle_event("remove-user", %{"id" => id}, socket) do
+    update_user_selection(id, socket)
+  end
+
+  defp update_user_selection(id, socket) do
+    case id in socket.assigns.selected_users do
+      true ->
+        selected_users = List.delete(socket.assigns.selected_users, id)
+        {:noreply, assign(socket, add_user_modal_visibility: "visible", selected_users: selected_users)}
+
+      _ ->
+        selected_users = [id | socket.assigns.selected_users]
+        {:noreply, assign(socket, add_user_modal_visibility: "visible", selected_users: selected_users)}
+    end
   end
 
   defp update_dataset_selection(id, socket) do

--- a/apps/andi/lib/andi_web/live/access_group_live_view/user_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/user_table.ex
@@ -1,0 +1,42 @@
+defmodule AndiWeb.AccessGroupLiveView.UserTable do
+  @moduledoc """
+  LiveComponent for access group users table
+  """
+
+  use Phoenix.LiveComponent
+
+  def render(assigns) do
+    ~L"""
+    <div class="access-group-users-results">
+      <h2 class="component-title-text">Users Assigned to This Access Group</h2>
+      <div class="access-groups-sub-table-container">
+        <table class="access-groups-sub-table">
+          <thead>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Name</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Email</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Organizations</th>
+          </thead>
+
+          <%= if @selected_users == [] do %>
+            <tr><td class="access-groups-sub-table__cell" colspan="100%">No Associated Users</td></tr>
+          <% else %>
+            <%= for user <- users_to_display(@selected_users) do %>
+            <tr class="access-groups-sub-table__tr">
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break access-groups-sub-table__data-title-cell wide-column"><%= user.name %></td>
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= user.email %></td>
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= Enum.join(Enum.map(user.organizations, fn org -> org.orgTitle end), ", ") %></td>
+
+
+              </tr>
+            <% end %>
+          <% end %>
+        </table>
+      </div>
+    </div>
+    """
+  end
+
+  defp users_to_display(selected_users) do
+    Enum.map(selected_users, fn user_id -> Andi.Schemas.User.get_by_id(user_id) end)
+  end
+end

--- a/apps/andi/lib/andi_web/live/search/manage_users_modal.ex
+++ b/apps/andi/lib/andi_web/live/search/manage_users_modal.ex
@@ -52,11 +52,21 @@ defmodule AndiWeb.Search.ManageUsersModal do
                     <td class="search-table__cell search-table__cell--break search-table__user-name-cell wide-column"><%= user.name %></td>
                     <td class="search-table__cell search-table__cell--break search-table__user-email-cell wide-column"><%= user.email %></td>
                     <td class="search-table__cell search-table__cell--break wide-column"><%= pretty_print_orgs(user.organizations) %></td>
+                    <td class="search-table__cell search-table__cell--break modal-action-text thin-column" phx-click="select-user-search" phx-value-id=<%= user.id %>><%=selected_value(user.id, @selected_users)%></td>
                     <td></td>
                   </tr>
                 <% end %>
               <% end %>
             </table>
+          </div>
+        </div>
+
+        <div class="user-search-selected-users">
+          <p class="search-modal-section-header-text">Selected Users</p>
+          <div class="selected-results-from-search">
+            <%= for user <- selected_users(@search_results, @selected_users) do %>
+              <div class="selected-result-from-search"><span class="selected-result-text"><%= user.name %></span><i class="material-icons remove-selected-result" phx-click="remove-user" phx-value-id=<%= user.id %>>close</i></div>
+            <% end %>
           </div>
         </div>
 
@@ -74,5 +84,21 @@ defmodule AndiWeb.Search.ManageUsersModal do
     organizations
     |> Enum.map(fn org -> org.orgTitle end)
     |> Enum.join(", ")
+  end
+
+  def selected_users(users, selected_users) do
+    Enum.map(selected_users, fn selected_user ->
+      case Enum.find(users, fn user -> user.id == selected_user end) do
+        nil -> Andi.Schemas.User.get_by_id(selected_user)
+        result -> result
+      end
+    end)
+  end
+
+  def selected_value(user_id, selected_users) do
+    case user_id in selected_users do
+      true -> "Remove"
+      false -> "Select"
+    end
   end
 end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.14",
+      version: "2.1.15",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/search/manage_users_modal_test.exs
+++ b/apps/andi/test/integration/andi_web/live/search/manage_users_modal_test.exs
@@ -91,6 +91,57 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
     assert get_text(html, ".search-table") =~ org.orgTitle
   end
 
+  test "successfully can add a user to the list of selected users", %{curator_conn: conn} do
+
+    {:ok, user} = User.create_or_update("auth0|123458", %{email: "test@example.com", name: "TestingTurtle"})
+    access_group = create_access_group()
+    assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+    find_manage_users_button(view) |> render_click
+    html = render_submit(view, "user-search", %{"search-value" => user.name})
+
+    html = find_add_user_button(view) |> render_click
+
+    assert get_text(html, ".selected-results-from-search") =~ user.name
+  end
+
+  test "sucessfully can remove a user from the list of selected users", %{curator_conn: conn} do
+    {:ok, user} = User.create_or_update("auth0|123458", %{email: "test@example.com", name: "TestingLadybug"})
+    access_group = create_access_group()
+    assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+    find_manage_users_button(view) |> render_click
+    html = render_submit(view, "user-search", %{"search-value" => user.name})
+
+    html = find_add_user_button(view) |> render_click
+
+    assert get_text(html, ".selected-results-from-search") =~ user.name
+
+    remove_action = element(view, ".modal-action-text", "Remove")
+    html = render_click(remove_action)
+
+    refute get_text(html, ".selected-results-from-search") =~ user.name
+  end
+
+  test "selected users are persisted when a new search is made", %{curator_conn: conn} do
+
+    {:ok, user} = User.create_or_update("auth0|123458", %{email: "test@example.com", name: "TestingLeopard"})
+    access_group = create_access_group()
+    assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+    find_manage_users_button(view) |> render_click
+    html = render_submit(view, "user-search", %{"search-value" => user.name})
+
+    html = find_add_user_button(view) |> render_click
+
+    assert get_text(html, ".selected-results-from-search") =~ user.name
+
+    html = render_submit(view, "user-search", %{"search-value" => "second search value"})
+
+    assert get_text(html, ".selected-results-from-search") =~ user.name
+
+  end
+
   test "shows all of a user's organizations", %{curator_conn: conn} do
     {:ok, org1} = TDG.create_organization(%{}) |> Organizations.update()
     {:ok, org2} = TDG.create_organization(%{}) |> Organizations.update()
@@ -137,5 +188,9 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
 
   defp find_manage_users_button(view) do
     element(view, ".btn", "Manage Users")
+  end
+
+  defp find_add_user_button(view) do
+    element(view, ".modal-action-text", "Select")
   end
 end

--- a/apps/andi/test/integration/andi_web/live/search/manage_users_modal_test.exs
+++ b/apps/andi/test/integration/andi_web/live/search/manage_users_modal_test.exs
@@ -92,7 +92,6 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
   end
 
   test "successfully can add a user to the list of selected users", %{curator_conn: conn} do
-
     {:ok, user} = User.create_or_update("auth0|123458", %{email: "test@example.com", name: "TestingTurtle"})
     access_group = create_access_group()
     assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
@@ -124,7 +123,6 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
   end
 
   test "selected users are persisted when a new search is made", %{curator_conn: conn} do
-
     {:ok, user} = User.create_or_update("auth0|123458", %{email: "test@example.com", name: "TestingLeopard"})
     access_group = create_access_group()
     assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
@@ -139,7 +137,6 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveViewTest do
     html = render_submit(view, "user-search", %{"search-value" => "second search value"})
 
     assert get_text(html, ".selected-results-from-search") =~ user.name
-
   end
 
   test "shows all of a user's organizations", %{curator_conn: conn} do

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
@@ -37,7 +37,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
-      assert get_text(html, ".access-groups-dataset-table__cell") =~ "No Associated Datasets"
+      assert get_text(html, ".access-groups-sub-table__cell") =~ "No Associated Datasets"
     end
 
     test "shows an associated dataset", %{conn: conn} do
@@ -48,7 +48,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
-      assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset.business.dataTitle
+      assert get_text(html, ".access-groups-sub-table__cell") =~ dataset.business.dataTitle
     end
 
     test "shows multiple associated datasets", %{conn: conn} do
@@ -61,8 +61,8 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
-      assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset_1.business.dataTitle
-      assert get_text(html, ".access-groups-dataset-table__cell") =~ dataset_2.business.dataTitle
+      assert get_text(html, ".access-groups-sub-table__cell") =~ dataset_1.business.dataTitle
+      assert get_text(html, ".access-groups-sub-table__cell") =~ dataset_2.business.dataTitle
     end
 
     test "shows a remove button for each dataset", %{conn: conn} do
@@ -74,7 +74,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
       allow(Andi.InputSchemas.Datasets.get(dataset_2.id), return: dataset_2)
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
-      text = get_text(html, ".access-groups-dataset-table__cell")
+      text = get_text(html, ".access-groups-sub-table__cell")
       results = Regex.scan(~r/Remove/, text)
 
       assert length(results) == 2

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/dataset_table_test.exs
@@ -33,7 +33,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
   describe "Basic associated datasets table load" do
     test "shows \"No Associated Datasets\" when there are no rows to show", %{conn: conn} do
       access_group = setup_access_group()
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: []})
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
@@ -43,7 +43,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
     test "shows an associated dataset", %{conn: conn} do
       access_group = setup_access_group()
       dataset = TDG.create_dataset(%{})
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset.id}]})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset.id}], users: []})
       allow(Andi.InputSchemas.Datasets.get(dataset.id), return: dataset)
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
@@ -55,7 +55,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
       access_group = setup_access_group()
       dataset_1 = TDG.create_dataset(%{})
       dataset_2 = TDG.create_dataset(%{})
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset_1.id}, %{id: dataset_2.id}]})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset_1.id}, %{id: dataset_2.id}], users: []})
       allow(Andi.InputSchemas.Datasets.get(dataset_1.id), return: dataset_1)
       allow(Andi.InputSchemas.Datasets.get(dataset_2.id), return: dataset_2)
 
@@ -69,7 +69,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTableTest do
       access_group = setup_access_group()
       dataset_1 = TDG.create_dataset(%{})
       dataset_2 = TDG.create_dataset(%{})
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset_1.id}, %{id: dataset_2.id}]})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [%{id: dataset_1.id}, %{id: dataset_2.id}], users: []})
       allow(Andi.InputSchemas.Datasets.get(dataset_1.id), return: dataset_1)
       allow(Andi.InputSchemas.Datasets.get(dataset_2.id), return: dataset_2)
 

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/user_table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/user_table_test.exs
@@ -1,0 +1,102 @@
+defmodule AndiWeb.AccessGroupLiveView.UserTableTest do
+  use AndiWeb.Test.AuthConnCase.UnitCase
+  use Placebo
+  alias Andi.Schemas.User
+
+  import Phoenix.LiveViewTest
+  import FlokiHelpers, only: [get_text: 2]
+
+  alias SmartCity.TestDataGenerator, as: TDG
+  alias Andi.InputSchemas.AccessGroups
+  alias Andi.InputSchemas.AccessGroup
+
+  @endpoint AndiWeb.Endpoint
+  @url_path "/access-groups"
+  @user UserHelpers.create_user()
+
+  defp allowAuthUser do
+    allow(Andi.Repo.get_by(Andi.Schemas.User, any()), return: @user)
+    allow(User.get_all(), return: [@user])
+    allow(User.get_by_subject_id(any()), return: @user)
+  end
+
+  setup do
+    allowAuthUser()
+    []
+  end
+
+  setup %{auth_conn_case: auth_conn_case} do
+    auth_conn_case.disable_revocation_list.()
+    :ok
+  end
+
+  describe "Basic associated users table load" do
+    test "shows \"No Associated Users\" when there are no rows to show", %{conn: conn} do
+      access_group = setup_access_group()
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: []})
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+      assert get_text(html, ".access-groups-sub-table__cell") =~ "No Associated Users"
+    end
+
+    test "shows an associated user", %{conn: conn} do
+      access_group = setup_access_group()
+      org_title = "Constellations R Us"
+
+      user = %Andi.Schemas.User{
+        id: UUID.uuid4(),
+        subject_id: "auth0|someStringOfNumbers",
+        name: "Ophiuchus",
+        email: "ophiuchus@constellations.net",
+        organizations: [%Andi.InputSchemas.Organization{orgTitle: "Constellations R Us"}]
+      }
+
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: [user]})
+      allow(Andi.Schemas.User.get_by_id(user.id), return: user)
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+      assert get_text(html, ".access-groups-sub-table__cell") =~ user.name
+      assert get_text(html, ".access-groups-sub-table__cell") =~ org_title
+    end
+
+    test "shows multiple associated users", %{conn: conn} do
+      access_group = setup_access_group()
+
+      user_1 = %Andi.Schemas.User{
+        id: UUID.uuid4(),
+        subject_id: "auth0|someStringOfNumbers",
+        name: "Penny",
+        email: "penny@dogs.com",
+        organizations: []
+      }
+
+      user_2 = %Andi.Schemas.User{
+        id: UUID.uuid4(),
+        subject_id: "auth0|someStringOfNumbersAlso",
+        name: "Hazel",
+        email: "hazel@dogs.com",
+        organizations: []
+      }
+
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: [user_1, user_2]})
+      allow(Andi.Schemas.User.get_by_id(user_1.id), return: user_1)
+      allow(Andi.Schemas.User.get_by_id(user_2.id), return: user_2)
+
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
+
+      assert get_text(html, ".access-groups-sub-table__cell") =~ user_1.name
+      assert get_text(html, ".access-groups-sub-table__cell") =~ user_2.name
+    end
+
+    defp setup_access_group() do
+      access_group = TDG.create_access_group(%{})
+      allow(AccessGroups.update(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(AccessGroups.get(any()), return: %AccessGroup{id: access_group.id, name: access_group.name})
+      allow(Andi.InputSchemas.AccessGroup.changeset(any(), any()), return: AccessGroup.changeset(access_group))
+      allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
+      access_group
+    end
+  end
+end

--- a/apps/andi/test/unit/andi_web/live/search/manage_datasets_modal_test.exs
+++ b/apps/andi/test/unit/andi_web/live/search/manage_datasets_modal_test.exs
@@ -39,7 +39,7 @@ defmodule AndiWeb.Search.ManageDatasetsModalTest do
       allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: []})
 
       access_group = create_access_group()
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
@@ -55,7 +55,7 @@ defmodule AndiWeb.Search.ManageDatasetsModalTest do
       allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: []})
       access_group = create_access_group()
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
@@ -80,7 +80,7 @@ defmodule AndiWeb.Search.ManageDatasetsModalTest do
       allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
       allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
-      allow(Andi.Repo.preload(any(), any()), return: %{datasets: []})
+      allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: []})
       access_group = create_access_group()
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 

--- a/apps/andi/test/unit/andi_web/live/search/manage_users_modal_test.exs
+++ b/apps/andi/test/unit/andi_web/live/search/manage_users_modal_test.exs
@@ -125,7 +125,7 @@ defmodule AndiWeb.Search.ManageUsersModalTest do
     allow(AccessGroups.update(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
     allow(AccessGroups.get(any()), return: %AccessGroup{id: UUID.uuid4(), name: "group"})
     allow(Andi.Repo.get(Andi.InputSchemas.AccessGroup, any()), return: [])
-    allow(Andi.Repo.preload(any(), :datasets), return: %{datasets: []})
+    allow(Andi.Repo.preload(any(), [:datasets, :users]), return: %{datasets: [], users: []})
   end
 
   defp create_access_group() do


### PR DESCRIPTION
## [Ticket Link #587](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/587)

## Description

Ability to add users to an access group.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
