### PR TITLE
check_origin fixes

### DIFF
--- a/apps/andi/Dockerfile
+++ b/apps/andi/Dockerfile
@@ -7,7 +7,8 @@ RUN cd apps/andi/assets/ && \
     mix cmd --app andi mix do compile, phx.digest
 RUN MIX_ENV=prod mix distillery.release --name andi
 
-FROM alpine:3.9
+FROM bitwalker/alpine-elixir:1.13.3
+WORKDIR ${HOME}
 ENV REPLACE_OS_VARS=true
 ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt
 RUN apk update && \
@@ -18,7 +19,7 @@ COPY --from=builder /app/_build/prod/rel/andi/ .
 RUN chgrp -R 0 ${HOME} && \
     chmod -R g+rwX ${HOME}
 USER default
-ENV PORT 80
+ENV PORT 4000
 EXPOSE ${PORT}
-COPY start.sh /
-CMD ["/start.sh"]
+COPY start.sh ${HOME}
+CMD ["./start.sh"]

--- a/apps/andi/config/config.exs
+++ b/apps/andi/config/config.exs
@@ -14,7 +14,7 @@ config :andi, AndiWeb.Endpoint,
   secret_key_base: "z7Iv1RcFiPow+/j3QKYyezhVCleXMuNBmrDO130ddUzysadB1stTt+q0JfIrm/q7",
   render_errors: [view: AndiWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: Andi.PubSub,
-  check_origin: ["http://localhost:4000", "https://*.smartcolumbusos.com"],
+  check_origin: ["http://localhost:4000", "https://*.urbanos-demo.com"],
   http: [stream_handlers: [Web.StreamHandlers.StripServerHeader, :cowboy_stream_h]]
 
 # Configures Elixir's Logger

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.15",
+      version: "2.1.16",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.14",
+      version: "2.1.15",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/runtime.exs
+++ b/apps/andi/runtime.exs
@@ -59,7 +59,8 @@ config :andi, :brook,
 config :andi, AndiWeb.Endpoint,
   live_view: [
     signing_salt: live_view_salt
-  ]
+  ],
+  check_origin: [System.get_env("ALLOWED_ORIGIN")]
 
 config :andi,
   secrets_endpoint: System.get_env("SECRETS_ENDPOINT"),


### PR DESCRIPTION
## Description

- Changed dockerfile to handle openshift runtime requirements
- Added a configurable origin property to support multiple deployment environments

## Reminders:

- [X] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
