### PR TITLE
588 save users to access groups

### DIFF
--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -17,13 +17,15 @@ defmodule Andi.Event.EventHandler do
       ingestion_update: 0,
       ingestion_delete: 0,
       dataset_access_group_associate: 0,
-      dataset_access_group_disassociate: 0
+      dataset_access_group_disassociate: 0,
+      user_access_group_associate: 0
     ]
 
   alias SmartCity.{Dataset, Organization, Ingestion}
   alias SmartCity.UserOrganizationAssociate
   alias SmartCity.UserOrganizationDisassociate
   alias SmartCity.DatasetAccessGroupRelation
+  alias SmartCity.UserAccessGroupRelation
 
   alias Andi.Services.DatasetStore
   alias Andi.Services.OrgStore
@@ -128,6 +130,25 @@ defmodule Andi.Event.EventHandler do
     |> add_event_count(author, nil)
 
     case Andi.InputSchemas.Datasets.Dataset.associate_with_access_group(access_group_id, dataset_id) do
+      {:error, error} ->
+        Logger.error("Unable to associate dataset with access group #{access_group_id}: #{inspect(error)}. This event has been discarded.")
+
+      _ ->
+        :ok
+    end
+
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: user_access_group_associate(),
+        data: %UserAccessGroupRelation{subject_id: subject_id, access_group_id: access_group_id},
+        author: author
+      }) do
+    user_access_group_associate()
+    |> add_event_count(author, nil)
+
+    case Andi.Schemas.User.associate_with_access_group(subject_id, access_group_id) do
       {:error, error} ->
         Logger.error("Unable to associate dataset with access group #{access_group_id}: #{inspect(error)}. This event has been discarded.")
 

--- a/apps/andi/lib/andi/schemas/user.ex
+++ b/apps/andi/lib/andi/schemas/user.ex
@@ -43,14 +43,12 @@ defmodule Andi.Schemas.User do
   end
 
   def associate_with_access_group(subject_id, access_group_id) do
-    with user <- Repo.get_by(__MODULE__, subject_id: subject_id) |> Repo.preload(:access_groups) |> IO.inspect(label: "user associate"),
+    with user <- Repo.get_by(__MODULE__, subject_id: subject_id) |> Repo.preload(:access_groups),
          access_group <- AccessGroups.get(access_group_id) do
       user
       |> Repo.preload(:access_groups)
-      |> IO.inspect(label: "before change")
       |> change()
       |> put_assoc(:access_groups, [access_group | user.access_groups])
-      |> IO.inspect(label: "after change")
       |> Repo.update()
     else
       error -> error

--- a/apps/andi/lib/andi/schemas/user.ex
+++ b/apps/andi/lib/andi/schemas/user.ex
@@ -9,6 +9,7 @@ defmodule Andi.Schemas.User do
   alias Andi.InputSchemas.Organization
   alias Andi.InputSchemas.Organizations
   alias Andi.InputSchemas.AccessGroup
+  alias Andi.InputSchemas.AccessGroups
   import Ecto.Query, only: [from: 1]
 
   @primary_key {:id, Ecto.UUID, autogenerate: true}
@@ -31,6 +32,7 @@ defmodule Andi.Schemas.User do
     |> unique_constraint(:subject_id)
   end
 
+  @spec create_or_update(any, :invalid | %{optional(:__struct__) => none, optional(atom | binary) => any}) :: any
   def create_or_update(subject_id, changes \\ %{}) do
     case get_by_subject_id(subject_id) do
       nil -> %__MODULE__{subject_id: subject_id}
@@ -38,6 +40,21 @@ defmodule Andi.Schemas.User do
     end
     |> changeset(changes)
     |> Repo.insert_or_update()
+  end
+
+  def associate_with_access_group(subject_id, access_group_id) do
+    with user <- Repo.get_by(__MODULE__, subject_id: subject_id) |> Repo.preload(:access_groups) |> IO.inspect(label: "user associate"),
+         access_group <- AccessGroups.get(access_group_id) do
+      user
+      |> Repo.preload(:access_groups)
+      |> IO.inspect(label: "before change")
+      |> change()
+      |> put_assoc(:access_groups, [access_group | user.access_groups])
+      |> IO.inspect(label: "after change")
+      |> Repo.update()
+    else
+      error -> error
+    end
   end
 
   def associate_with_organization(subject_id, organization_id) do

--- a/apps/andi/lib/andi_web/live/access_group_live_view/user_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/user_table.ex
@@ -37,6 +37,6 @@ defmodule AndiWeb.AccessGroupLiveView.UserTable do
   end
 
   defp users_to_display(selected_users) do
-    Enum.map(selected_users, fn user_id -> Andi.Schemas.User.get_by_id(user_id) end)
+    Enum.map(selected_users, fn user_id -> Andi.Schemas.User.get_by_subject_id(user_id) end)
   end
 end

--- a/apps/andi/lib/andi_web/live/search/manage_users_modal.ex
+++ b/apps/andi/lib/andi_web/live/search/manage_users_modal.ex
@@ -52,7 +52,7 @@ defmodule AndiWeb.Search.ManageUsersModal do
                     <td class="search-table__cell search-table__cell--break search-table__user-name-cell wide-column"><%= user.name %></td>
                     <td class="search-table__cell search-table__cell--break search-table__user-email-cell wide-column"><%= user.email %></td>
                     <td class="search-table__cell search-table__cell--break wide-column"><%= pretty_print_orgs(user.organizations) %></td>
-                    <td class="search-table__cell search-table__cell--break modal-action-text thin-column" phx-click="select-user-search" phx-value-id=<%= user.id %>><%=selected_value(user.id, @selected_users)%></td>
+                    <td class="search-table__cell search-table__cell--break modal-action-text thin-column" phx-click="select-user-search" phx-value-id=<%= user.subject_id %>><%=selected_value(user.subject_id, @selected_users)%></td>
                     <td></td>
                   </tr>
                 <% end %>
@@ -65,7 +65,7 @@ defmodule AndiWeb.Search.ManageUsersModal do
           <p class="search-modal-section-header-text">Selected Users</p>
           <div class="selected-results-from-search">
             <%= for user <- selected_users(@search_results, @selected_users) do %>
-              <div class="selected-result-from-search"><span class="selected-result-text"><%= user.name %></span><i class="material-icons remove-selected-result" phx-click="remove-user" phx-value-id=<%= user.id %>>close</i></div>
+              <div class="selected-result-from-search"><span class="selected-result-text"><%= user.name %></span><i class="material-icons remove-selected-result" phx-click="remove-user" phx-value-id=<%= user.subject_id %>>close</i></div>
             <% end %>
           </div>
         </div>
@@ -88,8 +88,8 @@ defmodule AndiWeb.Search.ManageUsersModal do
 
   def selected_users(users, selected_users) do
     Enum.map(selected_users, fn selected_user ->
-      case Enum.find(users, fn user -> user.id == selected_user end) do
-        nil -> Andi.Schemas.User.get_by_id(selected_user)
+      case Enum.find(users, fn user -> user.subject_id == selected_user end) do
+        nil -> Andi.Schemas.User.get_by_subject_id(selected_user)
         result -> result
       end
     end)

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.15",
+      version: "2.1.16",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi_web/live/access_group_live_view/user_table_test.exs
+++ b/apps/andi/test/unit/andi_web/live/access_group_live_view/user_table_test.exs
@@ -53,7 +53,7 @@ defmodule AndiWeb.AccessGroupLiveView.UserTableTest do
       }
 
       allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: [user]})
-      allow(Andi.Schemas.User.get_by_id(user.id), return: user)
+      allow(Andi.Schemas.User.get_by_subject_id(user.subject_id), return: user)
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 
@@ -81,8 +81,8 @@ defmodule AndiWeb.AccessGroupLiveView.UserTableTest do
       }
 
       allow(Andi.Repo.preload(any(), any()), return: %{datasets: [], users: [user_1, user_2]})
-      allow(Andi.Schemas.User.get_by_id(user_1.id), return: user_1)
-      allow(Andi.Schemas.User.get_by_id(user_2.id), return: user_2)
+      allow(Andi.Schemas.User.get_by_subject_id(user_1.subject_id), return: user_1)
+      allow(Andi.Schemas.User.get_by_subject_id(user_2.subject_id), return: user_2)
 
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{access_group.id}")
 


### PR DESCRIPTION
## [Ticket Link #588](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/588)

## Description

- Clicking the save button adds all users in the selected user list to the access group
- Clicking the save button returns the user to the edit access group page
- The edit access group page shows a list of all users that are added to the access group
- When navigating back to the search modal, the selected users are shown in the selected box on the bottom

![image](https://user-images.githubusercontent.com/73911735/162282303-d7212201-6c4f-4817-b4c0-4073dc4340ed.png)


## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
