### PR TITLE
Add cadence form step to ingestions edit

### DIFF
--- a/apps/andi/assets/css/ingestions.scss
+++ b/apps/andi/assets/css/ingestions.scss
@@ -23,6 +23,7 @@
   width: 100%;
   border: $table-border;
   border-collapse: collapse;
+  margin-top: 2em;
 }
 
 .ingestions-table__tr:nth-child(odd) {

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_add_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_add_field_editor.ex
@@ -131,7 +131,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
     DataDictionary.changeset_for_new_field(%DataDictionary{}, %{})
   end
 
-  defp blank_changeset(%{view: AndiWeb.EditIngestionLiveView.DataDictionaryForm} = _socket) do
+  defp blank_changeset(%{view: AndiWeb.IngestionLiveView.DataDictionaryForm} = _socket) do
     DataDictionary.ingestion_changeset_for_new_field(%DataDictionary{}, %{})
   end
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
@@ -1,4 +1,4 @@
-defmodule AndiWeb.EditIngestionLiveView.DataDictionaryForm do
+defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
   @moduledoc """
   LiveComponent for editing ingestion schema
   """

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -14,6 +14,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
 
   access_levels(render: [:private])
 
+  # refactor: EditIngestionLiveView.DataDictionaryForm to IngestionLiveView.DataDictionaryForm
   def render(assigns) do
     ~L"""
     <%= header_render(@socket, @is_curator) %>
@@ -29,6 +30,10 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
 
         <div class="data-dictionary-form-component">
           <%= live_render(@socket, AndiWeb.EditIngestionLiveView.DataDictionaryForm, id: :data_dictionary_form_editor, session: %{"ingestion" => @ingestion, "is_curator" => @is_curator, "order" => "2"}) %>
+        </div>
+
+        <div class="finalize-form-component ">
+          <%= live_render(@socket, AndiWeb.IngestionLiveView.FinalizeForm, id: :finalize_form_editor, session: %{"ingestion" => @ingestion, "order" => "4"}) %>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -3,10 +3,6 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
   use AndiWeb.HeaderLiveView
   require Logger
 
-  @instance_name Andi.instance_name()
-
-  import SmartCity.Event, only: [ingestion_delete: 0]
-
   alias Andi.InputSchemas.Ingestions
   alias Andi.Services.IngestionStore
   alias Andi.Services.IngestionDelete

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -10,7 +10,6 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
 
   access_levels(render: [:private])
 
-  # refactor: EditIngestionLiveView.DataDictionaryForm to IngestionLiveView.DataDictionaryForm
   def render(assigns) do
     ~L"""
     <%= header_render(@socket, @is_curator) %>
@@ -25,7 +24,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
         </div>
 
         <div class="data-dictionary-form-component">
-          <%= live_render(@socket, AndiWeb.EditIngestionLiveView.DataDictionaryForm, id: :data_dictionary_form_editor, session: %{"ingestion" => @ingestion, "is_curator" => @is_curator, "order" => "2"}) %>
+          <%= live_render(@socket, AndiWeb.IngestionLiveView.DataDictionaryForm, id: :data_dictionary_form_editor, session: %{"ingestion" => @ingestion, "is_curator" => @is_curator, "order" => "2"}) %>
         </div>
 
         <div class="finalize-form-component ">

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
@@ -1,0 +1,255 @@
+defmodule AndiWeb.IngestionLiveView.FinalizeForm do
+  @moduledoc """
+  LiveComponent for scheduling dataset ingestion
+  """
+  use Phoenix.LiveView
+  use AndiWeb.FormSection, schema_module: AndiWeb.InputSchemas.FinalizeFormSchema
+  import Phoenix.HTML.Form
+  require Logger
+
+  alias Andi.InputSchemas.Ingestions
+  alias AndiWeb.InputSchemas.FinalizeFormSchema
+  alias AndiWeb.ErrorHelpers
+
+  @quick_schedules %{
+    "hourly" => "0 0 * * * *",
+    "daily" => "0 0 0 * * *",
+    "weekly" => "0 0 0 * * 0",
+    "monthly" => "0 0 0 1 * *",
+    "yearly" => "0 0 0 1 1 *"
+  }
+
+  def mount(_, %{"ingestion" => ingestion}, socket) do
+    new_changeset = FinalizeFormSchema.changeset_from_andi_ingestion(ingestion)
+
+    AndiWeb.Endpoint.subscribe("toggle-visibility")
+    AndiWeb.Endpoint.subscribe("form-save")
+
+    default_cron =
+      case ingestion.cadence do
+        cadence when cadence in ["once", "never", "", nil] -> "0 * * * * *"
+        cron -> cron
+      end
+
+    repeat_ingestion? = ingestion.cadence not in ["once", "never", "", nil]
+
+    {:ok,
+     assign(socket,
+       visibility: "collapsed",
+       changeset: new_changeset,
+       repeat_ingestion?: repeat_ingestion?,
+       crontab: default_cron,
+       validation_status: "collapsed",
+       crontab_list: parse_crontab(default_cron),
+       ingestion_id: ingestion.id
+     )}
+  end
+
+  def render(assigns) do
+    modifier =
+      if assigns.repeat_ingestion? do
+        "visible"
+      else
+        "hidden"
+      end
+
+    action =
+      case assigns.visibility do
+        "collapsed" -> "EDIT"
+        "expanded" -> "MINIMIZE"
+      end
+
+    ~L"""
+    <div id="finalize_form" class="finalize-form finalize-form--<%= @visibility %>">
+      <div class="component-header" phx-click="toggle-component-visibility" phx-value-component="finalize_form">
+        <div class="section-number">
+          <h3 class="component-number component-number--<%= @validation_status %>">4</h3>
+          <div class="component-number-status--<%= @validation_status %>"></div>
+        </div>
+        <div class="component-title full-width">
+          <h2 class="component-title-text component-title-text--<%= @visibility %> ">Finalize</h2>
+          <div class="component-title-action">
+            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+            <div class="component-title-icon--<%= @visibility %>"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <%= f = form_for @changeset, "#", [phx_change: :validate, as: :form_data] %>
+          <div class="component-edit-section--<%= @visibility %>">
+            <div class="finalize-form-edit-section form-grid">
+              <div "finalize-form__schedule">
+                <h3>Schedule Job</h3>
+
+                <div class="finalize-form__schedule-options">
+                  <div class="finalize-form__schedule-option">
+                    <%= label(f, :cadence, "Immediately", class: "finalize-form__schedule-option-label") %>
+                    <%= radio_button(f, :cadence, "once")%>
+                  </div>
+                  <div class="finalize-form__schedule-option">
+                  <%= label(f, :cadence, "Never", class: "finalize-form__schedule-option-label") %>
+                  <%= radio_button(f, :cadence, "never") %>
+                  </div>
+                  <div class="finalize-form__schedule-option">
+                    <%= label(f, :cadence, "Repeat", class: "finalize-form__schedule-option-label") %>
+                    <%= radio_button(f, :cadence, @crontab) %>
+                  </div>
+                </div>
+
+                <div class="finalize-form__scheduler--<%= modifier %>">
+                  <h4>Quick Schedule</h4>
+
+                  <div class="finalize-form__quick-schedule">
+                    <button type="button" class="finalize-form-cron-button" phx-click="quick_schedule" phx-value-schedule="hourly" >Hourly</button>
+                    <button type="button" class="finalize-form-cron-button" phx-click="quick_schedule" phx-value-schedule="daily">Daily</button>
+                    <button type="button" class="finalize-form-cron-button" phx-click="quick_schedule" phx-value-schedule="weekly">Weekly</button>
+                    <button type="button" class="finalize-form-cron-button" phx-click="quick_schedule" phx-value-schedule="monthly">Monthly</button>
+                    <button type="button" class="finalize-form-cron-button" phx-click="quick_schedule" phx-value-schedule="yearly">Yearly</button>
+                  </div>
+
+                  <div class="finalize-form__help-link">
+                    <a href="https://en.wikipedia.org/wiki/Cron" target="_blank">Cron Schedule Help</a>
+                  </div>
+
+                  <div class="finalize-form__schedule-input">
+                    <div class="finalize-form__schedule-input-field">
+                      <label>Second</label>
+                      <input class="finalize-form-schedule-input__field" phx-keyup="set_schedule" phx-value-input-field="second" value="<%= @crontab_list[:second] %>" />
+
+                    </div>
+                    <div class="finalize-form__schedule-input-field">
+                      <label>Minute</label>
+                      <input class="finalize-form-schedule-input__field" phx-keyup="set_schedule" phx-value-input-field="minute" value="<%= @crontab_list[:minute] %>" />
+                    </div>
+                    <div class="finalize-form__schedule-input-field">
+                      <label>Hour</label>
+                      <input class="finalize-form-schedule-input__field" phx-keyup="set_schedule" phx-value-input-field="hour" value="<%= @crontab_list[:hour] %>" />
+                    </div>
+                    <div class="finalize-form__schedule-input-field">
+                      <label>Day</label>
+                      <input class="finalize-form-schedule-input__field" phx-keyup="set_schedule" phx-value-input-field="day" value="<%= @crontab_list[:day] %>" />
+                    </div>
+                    <div class="finalize-form__schedule-input-field">
+                      <label>Month</label>
+                      <input class="finalize-form-schedule-input__field" phx-keyup="set_schedule" phx-value-input-field="month" value="<%= @crontab_list[:month] %>" />
+                    </div>
+                    <div class="finalize-form__schedule-input-field">
+                      <label>Week</label>
+                      <input class="finalize-form-schedule-input__field" phx-keyup="set_schedule" phx-value-input-field="week" value="<%= @crontab_list[:week] %>" />
+                    </div>
+                  </div>
+                </div>
+                <%= ErrorHelpers.error_tag(f, :cadence) %>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+    """
+  end
+
+  def handle_event("validate", %{"form_data" => form_data}, socket) do
+    form_data
+    |> FinalizeFormSchema.changeset_from_form_data()
+    |> complete_validation(socket)
+  end
+
+  def handle_event("publish", _, socket) do
+    send(socket.parent_pid, :publish)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("set_schedule", %{"input-field" => input_field, "value" => value}, socket) do
+    new_crontab_list = Map.put(socket.assigns.crontab_list, String.to_existing_atom(input_field), value)
+
+    new_cron = cronlist_to_cronstring(new_crontab_list)
+
+    {:ok, andi_ingestion} = Ingestions.update_cadence(socket.assigns.ingestion_id, new_cron)
+
+    {_, updated_socket} =
+      andi_ingestion
+      |> FinalizeFormSchema.changeset_from_andi_ingestion()
+      |> complete_validation(socket)
+
+    {:noreply, assign(updated_socket, crontab: new_cron, crontab_list: new_crontab_list)}
+  end
+
+  def handle_event("quick_schedule", %{"schedule" => schedule}, socket) do
+    cronstring = @quick_schedules[schedule]
+
+    {:ok, andi_ingestion} = Ingestions.update_cadence(socket.assigns.ingestion_id, cronstring)
+
+    {_, updated_socket} =
+      andi_ingestion
+      |> FinalizeFormSchema.changeset_from_andi_ingestion()
+      |> complete_validation(socket)
+
+    {:noreply, assign(updated_socket, crontab: cronstring, crontab_list: parse_crontab(cronstring))}
+  end
+
+  def handle_info(
+        %{
+          topic: "toggle-visibility",
+          payload: %{expand: "finalize_form", ingestion_id: ingestion_id}
+        },
+        %{assigns: %{ingestion_id: ingestion_id}} = socket
+      ) do
+    {:noreply, assign(socket, visibility: "expanded") |> update_validation_status()}
+  end
+
+  def handle_info(%{topic: "toggle-visibility"}, socket) do
+    {:noreply, socket}
+  end
+
+  defp parse_crontab(nil), do: %{}
+  defp parse_crontab("never"), do: %{}
+
+  defp parse_crontab(cronstring) do
+    cronlist = String.split(cronstring, " ")
+    default_keys = [:minute, :hour, :day, :month, :week]
+
+    keys =
+      case crontab_length(cronstring) do
+        6 -> [:second | default_keys]
+        _ -> default_keys
+      end
+
+    keys
+    |> Enum.zip(cronlist)
+    |> Map.new()
+  end
+
+  defp cronlist_to_cronstring(%{second: second} = cronlist) when second != "" do
+    [:second, :minute, :hour, :day, :month, :week]
+    |> Enum.reduce("", fn field, acc ->
+      acc <> " " <> Map.get(cronlist, field, "nil")
+    end)
+    |> String.trim_leading()
+  end
+
+  defp cronlist_to_cronstring(cronlist) do
+    cronlist
+    |> Map.put(:second, "0")
+    |> cronlist_to_cronstring()
+  end
+
+  defp crontab_length(cronstring) do
+    cronstring
+    |> String.split(" ")
+    |> Enum.count()
+  end
+
+  defp complete_validation(changeset, socket) do
+    new_changeset = Map.put(changeset, :action, :update)
+    cadence = Ecto.Changeset.get_field(changeset, :cadence)
+    repeat_ingestion? = cadence not in ["once", "never", nil]
+    send(socket.parent_pid, :form_update)
+
+    {:noreply,
+     assign(socket, changeset: new_changeset, repeat_ingestion?: repeat_ingestion?)
+     |> update_validation_status()}
+  end
+end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.20",
+      version: "2.1.21",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
@@ -1,4 +1,4 @@
-defmodule AndiWeb.EditIngestionLiveView.DataDictionaryFormTest do
+defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
   use ExUnit.Case
   use Andi.DataCase
   use AndiWeb.Test.AuthConnCase.IntegrationCase

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/finalize_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/finalize_form_test.exs
@@ -1,4 +1,4 @@
-defmodule AndiWeb.EditIngestionLiveView.FinalizeFormTest do
+defmodule AndiWeb.IngestionLiveView.FinalizeFormTest do
   use ExUnit.Case
   use Andi.DataCase
   use AndiWeb.Test.AuthConnCase.IntegrationCase
@@ -18,7 +18,6 @@ defmodule AndiWeb.EditIngestionLiveView.FinalizeFormTest do
     ]
 
   alias SmartCity.TestDataGenerator, as: TDG
-  # alias Andi.InputSchemas.Datasets
   alias Andi.InputSchemas.Ingestions
   alias AndiWeb.Helpers.FormTools
   alias Andi.InputSchemas.InputConverter
@@ -51,6 +50,155 @@ defmodule AndiWeb.EditIngestionLiveView.FinalizeFormTest do
     end
   end
 
+  describe "never ingestion" do
+    setup %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("never")
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+
+      [
+        view: view,
+        html: html
+      ]
+    end
+
+    test "shows the Never ingestion button selected", %{html: html} do
+      refute Enum.empty?(get_attributes(html, "#form_data_cadence_never", "checked"))
+    end
+
+    test "does not show cron scheduler", %{html: html} do
+      assert Enum.empty?(find_elements(html, ".finalize-form__scheduler--visible"))
+      refute Enum.empty?(find_elements(html, ".finalize-form__scheduler--hidden"))
+    end
+  end
+
+  describe "repeat ingestion" do
+    setup %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("0 * * * * *")
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+
+      [
+        view: view,
+        html: html
+      ]
+    end
+
+    test "shows the repeat ingestion button selected", %{html: html} do
+      refute Enum.empty?(get_attributes(html, "#form_data_cadence_0__________", "checked"))
+    end
+
+    test "shows cron scheduler", %{html: html} do
+      refute Enum.empty?(find_elements(html, ".finalize-form__scheduler--visible"))
+      assert Enum.empty?(find_elements(html, ".finalize-form__scheduler--hidden"))
+
+      assert "0 * * * * *" == get_crontab_from_html(html)
+    end
+
+    data_test "does not allow schedules more frequent than every 2 seconds", %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("#{second_value} * * * * *")
+
+      assert {:ok, view, _} = live(conn, @url_path <> ingestion.id)
+      finalize_view = find_live_child(view, "finalize_form_editor")
+
+      form_data = FormTools.form_data_from_andi_ingestion(ingestion)
+      form_data |> IO.inspect(label: "form_data")
+      html = render_change(finalize_view, :validate, %{"form_data" => form_data})
+
+      refute Enum.empty?(find_elements(html, "#cadence-error-msg"))
+
+      where(second_value: ["*", "*/1"])
+    end
+
+    data_test "marks #{cronstring} as invalid", %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("0 0 * * *")
+
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      finalize_view = find_live_child(view, "finalize_form_editor")
+
+      form_data = %{"cadence" => cronstring}
+      html = render_change(finalize_view, :validate, %{"form_data" => form_data})
+
+      refute Enum.empty?(find_elements(html, "#cadence-error-msg"))
+
+      where([
+        [:cronstring],
+        [""],
+        ["1 2 3 4"],
+        ["1 nil 2 3 4 5"]
+      ])
+    end
+  end
+
+  describe "finalize form" do
+    setup do
+      ingestion = create_ingestion_with_cadence("1 1 1 * * *")
+      [ingestion: ingestion]
+    end
+
+    data_test "quick schedule #{schedule}", %{conn: conn, ingestion: ingestion} do
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      finalize_view = find_live_child(view, "finalize_form_editor")
+
+      render_click(finalize_view, "quick_schedule", %{"schedule" => schedule})
+      html = render(finalize_view)
+
+      assert expected_crontab == get_crontab_from_html(html)
+      assert Enum.empty?(find_elements(html, "#cadence-error-msg"))
+
+      where([
+        [:schedule, :expected_crontab],
+        ["hourly", "0 0 * * * *"],
+        ["daily", "0 0 0 * * *"],
+        ["weekly", "0 0 0 * * 0"],
+        ["monthly", "0 0 0 1 * *"],
+        ["yearly", "0 0 0 1 1 *"]
+      ])
+    end
+
+    test "set schedule manually", %{conn: conn, ingestion: ingestion} do
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      finalize_view = find_live_child(view, "finalize_form_editor")
+
+      form_data = %{"cadence" => ingestion.cadence}
+      html = render_change(finalize_view, :validate, %{"form_data" => form_data})
+
+      assert ingestion.cadence == get_crontab_from_html(html)
+      assert Enum.empty?(find_elements(html, "#cadence-error-msg"))
+    end
+
+    test "handles five-character cronstrings", %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("4 2 7 * *")
+
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      finalize_view = find_live_child(view, "finalize_form_editor")
+
+      form_data = %{"cadence" => ingestion.cadence}
+      render_change(finalize_view, :validate, %{"form_data" => form_data})
+      html = render(view)
+
+      assert ingestion.cadence == get_crontab_from_html(html) |> String.trim_leading()
+      assert Enum.empty?(find_elements(html, "#cadence-error-msg"))
+    end
+
+    test "handles cadence of never", %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("never")
+
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      assert Enum.empty?(find_elements(html, "#cadence-error-msg"))
+    end
+  end
+
+  test "required cadence field displays proper error message", %{conn: conn} do
+    ingestion = create_ingestion_with_cadence("0 0 * * *")
+
+    assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+    finalize_view = find_live_child(view, "finalize_form_editor")
+
+    form_data = %{"cadence" => ""}
+    html = render_change(finalize_view, :validate, %{"form_data" => form_data})
+
+    assert get_text(html, "#cadence-error-msg") == "Please enter a valid cadence."
+  end
+
   defp create_ingestion_with_cadence(cadence) do
     dataset = TDG.create_dataset(%{})
     ingestion = TDG.create_ingestion(%{targetDataset: dataset.id, cadence: cadence})
@@ -63,5 +211,11 @@ defmodule AndiWeb.EditIngestionLiveView.FinalizeFormTest do
     end)
 
     Ingestions.get(ingestion.id)
+  end
+
+  defp get_crontab_from_html(html) do
+    html
+    |> get_values(".finalize-form-schedule-input__field")
+    |> Enum.join(" ")
   end
 end

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/finalize_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/finalize_form_test.exs
@@ -1,0 +1,67 @@
+defmodule AndiWeb.EditIngestionLiveView.FinalizeFormTest do
+  use ExUnit.Case
+  use Andi.DataCase
+  use AndiWeb.Test.AuthConnCase.IntegrationCase
+  use Placebo
+  import Checkov
+
+  import Phoenix.LiveViewTest
+  import SmartCity.Event, only: [ingestion_update: 0, dataset_update: 0]
+  import SmartCity.TestHelper, only: [eventually: 1]
+
+  import FlokiHelpers,
+    only: [
+      get_text: 2,
+      get_attributes: 3,
+      get_values: 2,
+      find_elements: 2
+    ]
+
+  alias SmartCity.TestDataGenerator, as: TDG
+  # alias Andi.InputSchemas.Datasets
+  alias Andi.InputSchemas.Ingestions
+  alias AndiWeb.Helpers.FormTools
+  alias Andi.InputSchemas.InputConverter
+  alias AndiWeb.InputSchemas.FinalizeFormSchema
+
+  @endpoint AndiWeb.Endpoint
+  @url_path "/ingestions/"
+
+  @moduletag shared_data_connection: true
+  @instance_name Andi.instance_name()
+
+  describe "one-time ingestion" do
+    setup %{conn: conn} do
+      ingestion = create_ingestion_with_cadence("once")
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+
+      [
+        view: view,
+        html: html
+      ]
+    end
+
+    test "shows the Immediate ingestion button selected", %{html: html} do
+      refute Enum.empty?(get_attributes(html, "#form_data_cadence_once", "checked"))
+    end
+
+    test "does not show cron scheduler", %{html: html} do
+      assert Enum.empty?(find_elements(html, ".finalize-form__scheduler--visible"))
+      refute Enum.empty?(find_elements(html, ".finalize-form__scheduler--hidden"))
+    end
+  end
+
+  defp create_ingestion_with_cadence(cadence) do
+    dataset = TDG.create_dataset(%{})
+    ingestion = TDG.create_ingestion(%{targetDataset: dataset.id, cadence: cadence})
+
+    Brook.Event.send(@instance_name, dataset_update(), :andi, dataset)
+    Brook.Event.send(@instance_name, ingestion_update(), :andi, ingestion)
+
+    eventually(fn ->
+      assert Ingestions.get(ingestion.id) != nil
+    end)
+
+    Ingestions.get(ingestion.id)
+  end
+end


### PR DESCRIPTION
## [Ticket Link #607](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/607)

## Description

- Adds cadence form to ingestions edit page
- Includes all test cases from when it was on dataset edit page

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
