### PR TITLE
574 Stream Private Datasets by Access Groups

### DIFF
--- a/apps/raptor/README.md
+++ b/apps/raptor/README.md
@@ -52,6 +52,41 @@ To send a user_organization_disassociate event:
   disassociation = %SmartCity.UserOrganizationDisassociate{org_id: "org1", subject_id: "user1"}
   Brook.Event.send(Raptor.instance_name(), user_organization_disassociate(), :testing, disassociation)
 ```
+To send a user_access_group_associate event:
+
+```
+  alias SmartCity.UserAccessGroupRelation
+  import SmartCity.Event
+  association = %SmartCity.UserAccessGroupRelation{access_group_id: "group1", subject_id: "user1"}
+  Brook.Event.send(Raptor.instance_name(), user_access_group_associate(), :testing, association)
+```
+
+To send a user_access_group_disassociate event:
+
+```
+  alias SmartCity.UserAccessGroupRelation
+  import SmartCity.Event
+  disassociation = %SmartCity.UserAccessGroupRelation{access_group_id: "group1", subject_id: "user1"}
+  Brook.Event.send(Raptor.instance_name(), user_access_group_disassociate(), :testing, disassociation)
+```
+
+To send a dataset_access_group_associate event:
+
+```
+  alias SmartCity.DatasetAccessGroupRelation
+  import SmartCity.Event
+  association = %SmartCity.DatasetAccessGroupRelation{access_group_id: "group1", dataset_id: "dataset1"}
+  Brook.Event.send(Raptor.instance_name(), dataset_access_group_associate(), :testing, association)
+```
+
+To send a dataset_access_group_disassociate event:
+
+```
+  alias SmartCity.DatasetAccessGroupRelation
+  import SmartCity.Event
+  disassociation = %SmartCity.DatasetAccessGroupRelation{access_group_id: "group1", dataset_id: "dataset1"}
+  Brook.Event.send(Raptor.instance_name(), dataset_access_group_disassociate(), :testing, disassociation)
+```
 
 Note: You should not send a disassociate event before sending an associate event.
 

--- a/apps/raptor/lib/raptor/event/event_handler.ex
+++ b/apps/raptor/lib/raptor/event/event_handler.ex
@@ -7,15 +7,29 @@ defmodule Raptor.Event.EventHandler do
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Schemas.UserOrgAssoc
   alias Raptor.Schemas.Dataset
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Schemas.UserAccessGroupRelation
+  alias Raptor.Services.DatasetAccessGroupRelationStore
+  alias Raptor.Schemas.DatasetAccessGroupRelation
 
   import SmartCity.Event,
     only: [
       dataset_update: 0,
       user_organization_associate: 0,
-      user_organization_disassociate: 0
+      user_organization_disassociate: 0,
+      user_access_group_associate: 0,
+      user_access_group_disassociate: 0,
+      dataset_access_group_associate: 0,
+      dataset_access_group_disassociate: 0
     ]
 
-  alias SmartCity.{UserOrganizationAssociate, UserOrganizationDisassociate, Dataset}
+  alias SmartCity.{
+    UserOrganizationAssociate,
+    UserOrganizationDisassociate,
+    Dataset,
+    UserAccessGroupRelation,
+    DatasetAccessGroupRelation
+  }
 
   def handle_event(%Brook.Event{
         type: dataset_update(),
@@ -44,6 +58,54 @@ defmodule Raptor.Event.EventHandler do
       }) do
     {:ok, user_org_assoc} = UserOrgAssoc.from_disassociate_event(disassociation)
     UserOrgAssocStore.delete(user_org_assoc)
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: user_access_group_associate(),
+        data: %UserAccessGroupRelation{} = association,
+        author: _author
+      }) do
+    {:ok, user_access_group_assoc} =
+      Raptor.Schemas.UserAccessGroupRelation.from_smrt_relation(association)
+
+    UserAccessGroupRelationStore.persist(user_access_group_assoc)
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: user_access_group_disassociate(),
+        data: %UserAccessGroupRelation{} = disassociation,
+        author: _author
+      }) do
+    {:ok, user_access_group_disassoc} =
+      Raptor.Schemas.UserAccessGroupRelation.from_smrt_relation(disassociation)
+
+    UserAccessGroupRelationStore.delete(user_access_group_disassoc)
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: dataset_access_group_associate(),
+        data: %DatasetAccessGroupRelation{} = association,
+        author: _author
+      }) do
+    {:ok, dataset_access_group_assoc} =
+      Raptor.Schemas.DatasetAccessGroupRelation.from_smrt_relation(association)
+
+    DatasetAccessGroupRelationStore.persist(dataset_access_group_assoc)
+    :discard
+  end
+
+  def handle_event(%Brook.Event{
+        type: dataset_access_group_disassociate(),
+        data: %DatasetAccessGroupRelation{} = disassociation,
+        author: _author
+      }) do
+    {:ok, dataset_access_group_disassoc} =
+      Raptor.Schemas.DatasetAccessGroupRelation.from_smrt_relation(disassociation)
+
+    DatasetAccessGroupRelationStore.delete(dataset_access_group_disassoc)
     :discard
   end
 end

--- a/apps/raptor/lib/raptor/schemas/dataset_access_group_relation.ex
+++ b/apps/raptor/lib/raptor/schemas/dataset_access_group_relation.ex
@@ -1,0 +1,41 @@
+defmodule Raptor.Schemas.DatasetAccessGroupRelation do
+  @moduledoc """
+  This module defines the structure for a dataset access group relation
+  """
+
+  @derive Jason.Encoder
+
+  @type t :: %__MODULE__{
+          dataset_id: String.t(),
+          access_group_id: String.t()
+        }
+
+  defstruct [
+    :dataset_id,
+    :access_group_id
+  ]
+
+  @doc """
+  Converts a `SmartCity.DatasetAccessGroupRelation` to a `Raptor.Schemas.DatasetAccessGroupRelation`
+  """
+  @spec from_smrt_relation(SmartCity.DatasetAccessGroupRelation.t()) ::
+          {:ok, Raptor.Schemas.DatasetAccessGroupRelation.t()}
+  def from_smrt_relation(%SmartCity.DatasetAccessGroupRelation{} = assoc) do
+    struct = %__MODULE__{
+      dataset_id: assoc.dataset_id,
+      access_group_id: assoc.access_group_id
+    }
+
+    {:ok, struct}
+  end
+
+  @spec encode(Raptor.Schemas.DatasetAccessGroupRelation.t()) ::
+          {:ok, String.t()} | {:error, Jason.EncodeError.t() | Exception.t()}
+  def encode(%__MODULE__{} = dataset_access_group_relation) do
+    Jason.encode(dataset_access_group_relation)
+  end
+
+  def encode!(%__MODULE__{} = dataset_access_group_relation) do
+    Jason.encode!(dataset_access_group_relation)
+  end
+end

--- a/apps/raptor/lib/raptor/schemas/user_access_group_relation.ex
+++ b/apps/raptor/lib/raptor/schemas/user_access_group_relation.ex
@@ -1,0 +1,41 @@
+defmodule Raptor.Schemas.UserAccessGroupRelation do
+  @moduledoc """
+  This module defines the structure for a user access group relation
+  """
+
+  @derive Jason.Encoder
+
+  @type t :: %__MODULE__{
+          user_id: String.t(),
+          access_group_id: String.t()
+        }
+
+  defstruct [
+    :user_id,
+    :access_group_id
+  ]
+
+  @doc """
+  Converts a `SmartCity.UserAccessGroupRelation` to a `Raptor.Schemas.UserAccessGroupRelation`
+  """
+  @spec from_smrt_relation(SmartCity.UserAccessGroupRelation.t()) ::
+          {:ok, Raptor.Schemas.UserAccessGroupRelation.t()}
+  def from_smrt_relation(%SmartCity.UserAccessGroupRelation{} = assoc) do
+    struct = %__MODULE__{
+      user_id: assoc.subject_id,
+      access_group_id: assoc.access_group_id
+    }
+
+    {:ok, struct}
+  end
+
+  @spec encode(Raptor.Schemas.UserAccessGroupRelation.t()) ::
+          {:ok, String.t()} | {:error, Jason.EncodeError.t() | Exception.t()}
+  def encode(%__MODULE__{} = user_access_group_relation) do
+    Jason.encode(user_access_group_relation)
+  end
+
+  def encode!(%__MODULE__{} = user_access_group_relation) do
+    Jason.encode!(user_access_group_relation)
+  end
+end

--- a/apps/raptor/lib/raptor/services/dataset_access_group_relation_store.ex
+++ b/apps/raptor/lib/raptor/services/dataset_access_group_relation_store.ex
@@ -1,0 +1,113 @@
+defmodule Raptor.Services.DatasetAccessGroupRelationStore do
+  @moduledoc """
+  This module provides functionality for interacting with Redis
+  """
+  require Logger
+  alias Raptor.Schemas.DatasetAccessGroupRelation
+
+  @namespace "raptor:dataset_access_group_relation:"
+  @redix Raptor.Application.redis_client()
+
+  @doc """
+  Get all dataset access group relations from Redis
+  """
+  @spec get_all() :: list(map())
+  def get_all() do
+    case Redix.command!(@redix, ["KEYS", @namespace <> "*"]) do
+      [] ->
+        []
+
+      keys ->
+        keys
+        |> (fn keys -> Redix.command!(@redix, ["MGET" | keys]) end).()
+        |> Enum.map(&from_json/1)
+    end
+  end
+
+  @doc """
+  Get all access groups from Redis for a specific dataset
+  """
+  @spec get_all_by_dataset(String.t()) :: list(map())
+  def get_all_by_dataset(dataset_id) do
+    case Redix.command!(@redix, ["KEYS", @namespace <> dataset_id <> ":*"]) do
+      [] ->
+        []
+
+      keys ->
+        keys
+        |> (fn keys -> Redix.command!(@redix, ["MGET" | keys]) end).()
+        |> Enum.map(&from_json/1)
+        |> Enum.map(fn relation -> relation.access_group_id end)
+    end
+  end
+
+  @doc """
+  Get a given dataset-access_group relation
+  """
+  @spec get(String.t(), String.t()) :: map()
+  def get(dataset_id, access_group_id) do
+    key = "#{dataset_id}:#{access_group_id}"
+    matching_entries = Redix.command!(@redix, ["KEYS", @namespace <> key])
+
+    case length(matching_entries) do
+      0 ->
+        Logger.warn(
+          "No dataset access group relations exist with dataset_id #{dataset_id} and access_group_id #{
+            access_group_id
+          }"
+        )
+
+        %{}
+
+      1 ->
+        assoc_key = matching_entries |> List.first()
+        Redix.command!(@redix, ["MGET", assoc_key]) |> Enum.map(&from_json/1) |> List.first()
+
+      _ ->
+        Logger.warn(
+          "Multiple dataset-access_group relations match #{dataset_id}:#{access_group_id}. Cannot continue."
+        )
+
+        %{}
+    end
+  end
+
+  @doc """
+  Save a `Raptor.Schemas.DatasetAccessGroupRelation` to Redis
+  """
+  @spec persist(Raptor.Schemas.DatasetAccessGroupRelation.t()) ::
+          Redix.Protocol.redis_value() | no_return()
+  def persist(%DatasetAccessGroupRelation{} = dataset_access_group_relation) do
+    key =
+      "#{dataset_access_group_relation.dataset_id}:#{
+        dataset_access_group_relation.access_group_id
+      }"
+
+    dataset_access_group_relation
+    |> Map.from_struct()
+    |> Jason.encode!()
+    |> (fn assoc_json ->
+          Redix.command!(@redix, ["SET", @namespace <> key, assoc_json])
+        end).()
+  end
+
+  @doc """
+  Remove a `Raptor.Schemas.DatasetAccessGroupRelation` from Redis
+  """
+  @spec delete(Raptor.Schemas.DatasetAccessGroupRelation.t()) ::
+          Redix.Protocol.redis_value() | no_return()
+  def delete(%DatasetAccessGroupRelation{} = dataset_access_group_relation) do
+    key =
+      "#{dataset_access_group_relation.dataset_id}:#{
+        dataset_access_group_relation.access_group_id
+      }"
+
+    Redix.command!(@redix, ["DEL", @namespace <> key])
+  end
+
+  defp from_json(json_string) do
+    json_string
+    |> Jason.decode!(keys: :atoms)
+    |> (fn map -> struct(%DatasetAccessGroupRelation{}, map) end).()
+  end
+end

--- a/apps/raptor/lib/raptor/services/user_access_group_relation_store.ex
+++ b/apps/raptor/lib/raptor/services/user_access_group_relation_store.ex
@@ -1,0 +1,106 @@
+defmodule Raptor.Services.UserAccessGroupRelationStore do
+  @moduledoc """
+  This module provides functionality for interacting with Redis
+  """
+  require Logger
+  alias Raptor.Schemas.UserAccessGroupRelation
+
+  @namespace "raptor:user_access_group_relation:"
+  @redix Raptor.Application.redis_client()
+
+  @doc """
+  Get all user access group relations from Redis
+  """
+  @spec get_all() :: list(map())
+  def get_all() do
+    case Redix.command!(@redix, ["KEYS", @namespace <> "*"]) do
+      [] ->
+        []
+
+      keys ->
+        keys
+        |> (fn keys -> Redix.command!(@redix, ["MGET" | keys]) end).()
+        |> Enum.map(&from_json/1)
+    end
+  end
+
+  @doc """
+  Get all access groups from Redis for a specific user
+  """
+  @spec get_all_by_user(String.t()) :: list(map())
+  def get_all_by_user(user_id) do
+    case Redix.command!(@redix, ["KEYS", @namespace <> user_id <> ":*"]) do
+      [] ->
+        []
+
+      keys ->
+        keys
+        |> (fn keys -> Redix.command!(@redix, ["MGET" | keys]) end).()
+        |> Enum.map(&from_json/1)
+        |> Enum.map(fn relation -> relation.access_group_id end)
+    end
+  end
+
+  @doc """
+  Get a given user-access_group relation
+  """
+  @spec get(String.t(), String.t()) :: map()
+  def get(user_id, access_group_id) do
+    key = "#{user_id}:#{access_group_id}"
+    matching_entries = Redix.command!(@redix, ["KEYS", @namespace <> key])
+
+    case length(matching_entries) do
+      0 ->
+        Logger.warn(
+          "No user access group relations exist with user_id #{user_id} and access_group_id #{
+            access_group_id
+          }"
+        )
+
+        %{}
+
+      1 ->
+        assoc_key = matching_entries |> List.first()
+        Redix.command!(@redix, ["MGET", assoc_key]) |> Enum.map(&from_json/1) |> List.first()
+
+      _ ->
+        Logger.warn(
+          "Multiple user-access_group relations match #{user_id}:#{access_group_id}. Cannot continue."
+        )
+
+        %{}
+    end
+  end
+
+  @doc """
+  Save a `Raptor.Schemas.UserAccessGroupRelation` to Redis
+  """
+  @spec persist(Raptor.Schemas.UserAccessGroupRelation.t()) ::
+          Redix.Protocol.redis_value() | no_return()
+  def persist(%UserAccessGroupRelation{} = user_access_group_relation) do
+    key = "#{user_access_group_relation.user_id}:#{user_access_group_relation.access_group_id}"
+
+    user_access_group_relation
+    |> Map.from_struct()
+    |> Jason.encode!()
+    |> (fn assoc_json ->
+          Redix.command!(@redix, ["SET", @namespace <> key, assoc_json])
+        end).()
+  end
+
+  @doc """
+  Remove a `Raptor.Schemas.UserAccessGroupRelation` from Redis
+  """
+  @spec delete(Raptor.Schemas.UserAccessGroupRelation.t()) ::
+          Redix.Protocol.redis_value() | no_return()
+  def delete(%UserAccessGroupRelation{} = user_access_group_relation) do
+    key = "#{user_access_group_relation.user_id}:#{user_access_group_relation.access_group_id}"
+    Redix.command!(@redix, ["DEL", @namespace <> key])
+  end
+
+  defp from_json(json_string) do
+    json_string
+    |> Jason.decode!(keys: :atoms)
+    |> (fn map -> struct(%UserAccessGroupRelation{}, map) end).()
+  end
+end

--- a/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
@@ -4,6 +4,8 @@ defmodule RaptorWeb.AuthorizeController do
   alias Raptor.Services.Auth0Management
   alias Raptor.Services.DatasetStore
   alias Raptor.Services.UserOrgAssocStore
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Services.DatasetAccessGroupRelationStore
   require Logger
 
   plug(:accepts, ["json"])
@@ -12,13 +14,20 @@ defmodule RaptorWeb.AuthorizeController do
     UserOrgAssocStore.get(user_id, org_id) != %{}
   end
 
+  @spec is_user_in_access_group?(binary, any) :: any
+  def is_user_in_access_group?(user_id, dataset_id) do
+    user_access_groups = UserAccessGroupRelationStore.get_all_by_user(user_id)
+    dataset_access_groups = DatasetAccessGroupRelationStore.get_all_by_dataset(dataset_id)
+    Enum.any?(user_access_groups, fn user_access_group -> Enum.member?(dataset_access_groups, user_access_group) end)
+  end
+
   def is_valid_dataset?(dataset) do
     dataset != %{}
   end
 
   def check_user_association(user, dataset) do
     org_id_of_dataset = dataset.org_id
-    is_user_in_org?(user["user_id"], org_id_of_dataset)
+    is_user_in_org?(user["user_id"], org_id_of_dataset) or is_user_in_access_group?(user["user_id"], dataset.dataset_id)
   end
 
   def validate_user_list(user_list, dataset) do

--- a/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
@@ -18,7 +18,10 @@ defmodule RaptorWeb.AuthorizeController do
   def is_user_in_access_group?(user_id, dataset_id) do
     user_access_groups = UserAccessGroupRelationStore.get_all_by_user(user_id)
     dataset_access_groups = DatasetAccessGroupRelationStore.get_all_by_dataset(dataset_id)
-    Enum.any?(user_access_groups, fn user_access_group -> Enum.member?(dataset_access_groups, user_access_group) end)
+
+    Enum.any?(user_access_groups, fn user_access_group ->
+      Enum.member?(dataset_access_groups, user_access_group)
+    end)
   end
 
   def is_valid_dataset?(dataset) do
@@ -27,7 +30,9 @@ defmodule RaptorWeb.AuthorizeController do
 
   def check_user_association(user, dataset) do
     org_id_of_dataset = dataset.org_id
-    is_user_in_org?(user["user_id"], org_id_of_dataset) or is_user_in_access_group?(user["user_id"], dataset.dataset_id)
+
+    is_user_in_org?(user["user_id"], org_id_of_dataset) or
+      is_user_in_access_group?(user["user_id"], dataset.dataset_id)
   end
 
   def validate_user_list(user_list, dataset) do

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.1.5",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/raptor/test/integration/raptor/event/event_handler_test.exs
+++ b/apps/raptor/test/integration/raptor/event/event_handler_test.exs
@@ -157,7 +157,9 @@ defmodule Raptor.Event.EventHandlerTest do
       }
 
       eventually(fn ->
-        raptor_dataset_access_group_relation = DatasetAccessGroupRelationStore.get("captains log", "ds9")
+        raptor_dataset_access_group_relation =
+          DatasetAccessGroupRelationStore.get("captains log", "ds9")
+
         assert expected_raptor_assoc == raptor_dataset_access_group_relation
       end)
     end
@@ -183,7 +185,9 @@ defmodule Raptor.Event.EventHandlerTest do
       }
 
       eventually(fn ->
-        raptor_dataset_access_group_relation = DatasetAccessGroupRelationStore.get("captains log", "ds9")
+        raptor_dataset_access_group_relation =
+          DatasetAccessGroupRelationStore.get("captains log", "ds9")
+
         assert expected_raptor_assoc == raptor_dataset_access_group_relation
       end)
 
@@ -195,12 +199,13 @@ defmodule Raptor.Event.EventHandlerTest do
       )
 
       eventually(fn ->
-        raptor_dataset_access_group_relation = DatasetAccessGroupRelationStore.get("captains log", "ds9")
-        assert %{}== raptor_dataset_access_group_relation
+        raptor_dataset_access_group_relation =
+          DatasetAccessGroupRelationStore.get("captains log", "ds9")
+
+        assert %{} == raptor_dataset_access_group_relation
       end)
     end
   end
-
 
   describe "user_organization:disassociate" do
     setup do

--- a/apps/raptor/test/integration/raptor/event/event_handler_test.exs
+++ b/apps/raptor/test/integration/raptor/event/event_handler_test.exs
@@ -7,12 +7,20 @@ defmodule Raptor.Event.EventHandlerTest do
   alias Raptor.Schemas.Dataset
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Schemas.UserOrgAssoc
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Schemas.UserAccessGroupRelation
+  alias Raptor.Services.DatasetAccessGroupRelationStore
+  alias Raptor.Schemas.DatasetAccessGroupRelation
 
   import SmartCity.Event,
     only: [
       dataset_update: 0,
       user_organization_associate: 0,
-      user_organization_disassociate: 0
+      user_organization_disassociate: 0,
+      user_access_group_associate: 0,
+      user_access_group_disassociate: 0,
+      dataset_access_group_associate: 0,
+      dataset_access_group_disassociate: 0
     ]
 
   @instance_name Raptor.instance_name()
@@ -64,6 +72,135 @@ defmodule Raptor.Event.EventHandlerTest do
       end)
     end
   end
+
+  describe "user_access_group:associate" do
+    test "when a user_access_group_associate event is received, a user_organization_associate event is stored in Redis" do
+      association = %SmartCity.UserAccessGroupRelation{
+        access_group_id: "ds9",
+        subject_id: "sisko"
+      }
+
+      Brook.Event.send(
+        Raptor.instance_name(),
+        user_access_group_associate(),
+        :testing,
+        association
+      )
+
+      expected_raptor_assoc = %Raptor.Schemas.UserAccessGroupRelation{
+        user_id: "sisko",
+        access_group_id: "ds9"
+      }
+
+      eventually(fn ->
+        raptor_user_access_group_relation = UserAccessGroupRelationStore.get("sisko", "ds9")
+        assert expected_raptor_assoc == raptor_user_access_group_relation
+      end)
+    end
+  end
+
+  describe "user_access_group:disassociate" do
+    test "when a user_access_group_disassociate event is received, a user_organization_disassociate event is removed from Redis" do
+      association = %SmartCity.UserAccessGroupRelation{
+        access_group_id: "ds9",
+        subject_id: "sisko"
+      }
+
+      Brook.Event.send(
+        Raptor.instance_name(),
+        user_access_group_associate(),
+        :testing,
+        association
+      )
+
+      expected_raptor_assoc = %Raptor.Schemas.UserAccessGroupRelation{
+        user_id: "sisko",
+        access_group_id: "ds9"
+      }
+
+      eventually(fn ->
+        raptor_user_access_group_relation = UserAccessGroupRelationStore.get("sisko", "ds9")
+        assert expected_raptor_assoc == raptor_user_access_group_relation
+      end)
+
+      Brook.Event.send(
+        Raptor.instance_name(),
+        user_access_group_disassociate(),
+        :testing,
+        association
+      )
+
+      eventually(fn ->
+        raptor_user_access_group_relation = UserAccessGroupRelationStore.get("sisko", "ds9")
+        assert %{} == raptor_user_access_group_relation
+      end)
+    end
+  end
+
+  describe "dataset_access_group:associate" do
+    test "when a dataset_access_group_associate event is received, a dataset_organization_associate event is stored in Redis" do
+      association = %SmartCity.DatasetAccessGroupRelation{
+        access_group_id: "ds9",
+        dataset_id: "captains log"
+      }
+
+      Brook.Event.send(
+        Raptor.instance_name(),
+        dataset_access_group_associate(),
+        :testing,
+        association
+      )
+
+      expected_raptor_assoc = %Raptor.Schemas.DatasetAccessGroupRelation{
+        dataset_id: "captains log",
+        access_group_id: "ds9"
+      }
+
+      eventually(fn ->
+        raptor_dataset_access_group_relation = DatasetAccessGroupRelationStore.get("captains log", "ds9")
+        assert expected_raptor_assoc == raptor_dataset_access_group_relation
+      end)
+    end
+  end
+
+  describe "dataset_access_group:disassociate" do
+    test "when a dataset_access_group_disassociate event is received, a dataset_access_group_disassociate event is remved from Redis" do
+      association = %SmartCity.DatasetAccessGroupRelation{
+        access_group_id: "ds9",
+        dataset_id: "captains log"
+      }
+
+      Brook.Event.send(
+        Raptor.instance_name(),
+        dataset_access_group_associate(),
+        :testing,
+        association
+      )
+
+      expected_raptor_assoc = %Raptor.Schemas.DatasetAccessGroupRelation{
+        dataset_id: "captains log",
+        access_group_id: "ds9"
+      }
+
+      eventually(fn ->
+        raptor_dataset_access_group_relation = DatasetAccessGroupRelationStore.get("captains log", "ds9")
+        assert expected_raptor_assoc == raptor_dataset_access_group_relation
+      end)
+
+      Brook.Event.send(
+        Raptor.instance_name(),
+        dataset_access_group_disassociate(),
+        :testing,
+        association
+      )
+
+      eventually(fn ->
+        raptor_dataset_access_group_relation = DatasetAccessGroupRelationStore.get("captains log", "ds9")
+        assert %{}== raptor_dataset_access_group_relation
+      end)
+    end
+  end
+
 
   describe "user_organization:disassociate" do
     setup do

--- a/apps/raptor/test/integration/raptor_web/controllers/authorize_controller_test.exs
+++ b/apps/raptor/test/integration/raptor_web/controllers/authorize_controller_test.exs
@@ -74,7 +74,6 @@ defmodule Raptor.AuthorizeControllerTest do
       assert body == "{\"is_authorized\":true}"
     end
 
-
     test "returns is_authorized=false when the user's permissions to access the requested dataset are revoked" do
       is_private_dataset = true
       dataset = create_and_send_dataset_event(is_private_dataset)
@@ -224,10 +223,15 @@ defmodule Raptor.AuthorizeControllerTest do
 
     Brook.Event.send(Raptor.instance_name(), user_access_group_associate(), :testing, association)
 
-    expected_raptor_assoc = %UserAccessGroupRelation{user_id: subject_id, access_group_id: access_group_id}
+    expected_raptor_assoc = %UserAccessGroupRelation{
+      user_id: subject_id,
+      access_group_id: access_group_id
+    }
 
     eventually(fn ->
-      raptor_user_access_group_assoc = UserAccessGroupRelationStore.get(subject_id, access_group_id)
+      raptor_user_access_group_assoc =
+        UserAccessGroupRelationStore.get(subject_id, access_group_id)
+
       assert expected_raptor_assoc == raptor_user_access_group_assoc
     end)
   end
@@ -238,10 +242,17 @@ defmodule Raptor.AuthorizeControllerTest do
       subject_id: subject_id
     }
 
-    Brook.Event.send(Raptor.instance_name(), user_access_group_disassociate(), :testing, association)
+    Brook.Event.send(
+      Raptor.instance_name(),
+      user_access_group_disassociate(),
+      :testing,
+      association
+    )
 
     eventually(fn ->
-      raptor_user_access_group_assoc = UserAccessGroupRelationStore.get(subject_id, access_group_id)
+      raptor_user_access_group_assoc =
+        UserAccessGroupRelationStore.get(subject_id, access_group_id)
+
       assert %{} == raptor_user_access_group_assoc
     end)
   end
@@ -252,12 +263,22 @@ defmodule Raptor.AuthorizeControllerTest do
       dataset_id: dataset_id
     }
 
-    Brook.Event.send(Raptor.instance_name(), dataset_access_group_associate(), :testing, association)
+    Brook.Event.send(
+      Raptor.instance_name(),
+      dataset_access_group_associate(),
+      :testing,
+      association
+    )
 
-    expected_raptor_assoc = %DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id}
+    expected_raptor_assoc = %DatasetAccessGroupRelation{
+      dataset_id: dataset_id,
+      access_group_id: access_group_id
+    }
 
     eventually(fn ->
-      raptor_dataset_access_group_assoc = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+      raptor_dataset_access_group_assoc =
+        DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+
       assert expected_raptor_assoc == raptor_dataset_access_group_assoc
     end)
   end
@@ -268,10 +289,17 @@ defmodule Raptor.AuthorizeControllerTest do
       dataset_id: dataset_id
     }
 
-    Brook.Event.send(Raptor.instance_name(), dataset_access_group_disassociate(), :testing, association)
+    Brook.Event.send(
+      Raptor.instance_name(),
+      dataset_access_group_disassociate(),
+      :testing,
+      association
+    )
 
     eventually(fn ->
-      raptor_dataset_access_group_assoc = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+      raptor_dataset_access_group_assoc =
+        DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+
       assert %{} == raptor_dataset_access_group_assoc
     end)
   end

--- a/apps/raptor/test/integration/raptor_web/controllers/authorize_controller_test.exs
+++ b/apps/raptor/test/integration/raptor_web/controllers/authorize_controller_test.exs
@@ -13,6 +13,10 @@ defmodule Raptor.AuthorizeControllerTest do
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Schemas.UserOrgAssoc
   alias Raptor.Services.Auth0Management
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Schemas.UserAccessGroupRelation
+  alias Raptor.Services.DatasetAccessGroupRelationStore
+  alias Raptor.Schemas.DatasetAccessGroupRelation
 
   @instance_name Raptor.instance_name()
 
@@ -55,6 +59,22 @@ defmodule Raptor.AuthorizeControllerTest do
       assert body == "{\"is_authorized\":true}"
     end
 
+    test "returns is_authorized=true when the user has permissions to access the requested dataset via an access group" do
+      is_private_dataset = true
+      dataset = create_and_send_dataset_event(is_private_dataset)
+      system_name = dataset.technical.systemName
+      send_dataset_access_group_associate_event("access_group_id", dataset.id)
+      send_user_access_group_associate_event("access_group_id", "123")
+
+      {:ok, %Tesla.Env{body: body}} =
+        get("/api/authorize?apiKey=fakeApiKey&systemName=#{system_name}",
+          headers: [{"content-type", "application/json"}]
+        )
+
+      assert body == "{\"is_authorized\":true}"
+    end
+
+
     test "returns is_authorized=false when the user's permissions to access the requested dataset are revoked" do
       is_private_dataset = true
       dataset = create_and_send_dataset_event(is_private_dataset)
@@ -68,6 +88,30 @@ defmodule Raptor.AuthorizeControllerTest do
 
       assert body == "{\"is_authorized\":true}"
       send_user_org_disassociate_event(dataset.technical.orgId, "123")
+
+      {:ok, %Tesla.Env{body: body}} =
+        get("/api/authorize?apiKey=fakeApiKey&systemName=#{system_name}",
+          headers: [{"content-type", "application/json"}]
+        )
+
+      assert body == "{\"is_authorized\":false}"
+    end
+
+    test "returns is_authorized=false when the user's permissions to access the requested dataset are revoked via access groups" do
+      is_private_dataset = true
+      dataset = create_and_send_dataset_event(is_private_dataset)
+      system_name = dataset.technical.systemName
+      send_user_access_group_associate_event("access_group_id", "123")
+      send_dataset_access_group_associate_event("access_group_id", dataset.id)
+
+      {:ok, %Tesla.Env{body: body}} =
+        get("/api/authorize?apiKey=fakeApiKey&systemName=#{system_name}",
+          headers: [{"content-type", "application/json"}]
+        )
+
+      assert body == "{\"is_authorized\":true}"
+      send_user_access_group_disassociate_event("access_group_id", "123")
+      send_dataset_access_group_disassociate_event("access_group_id", dataset.id)
 
       {:ok, %Tesla.Env{body: body}} =
         get("/api/authorize?apiKey=fakeApiKey&systemName=#{system_name}",
@@ -169,6 +213,66 @@ defmodule Raptor.AuthorizeControllerTest do
     eventually(fn ->
       raptor_user_org_assoc = UserOrgAssocStore.get(subject_id, org_id)
       assert expected_raptor_assoc == raptor_user_org_assoc
+    end)
+  end
+
+  def send_user_access_group_associate_event(access_group_id, subject_id) do
+    association = %SmartCity.UserAccessGroupRelation{
+      access_group_id: access_group_id,
+      subject_id: subject_id
+    }
+
+    Brook.Event.send(Raptor.instance_name(), user_access_group_associate(), :testing, association)
+
+    expected_raptor_assoc = %UserAccessGroupRelation{user_id: subject_id, access_group_id: access_group_id}
+
+    eventually(fn ->
+      raptor_user_access_group_assoc = UserAccessGroupRelationStore.get(subject_id, access_group_id)
+      assert expected_raptor_assoc == raptor_user_access_group_assoc
+    end)
+  end
+
+  def send_user_access_group_disassociate_event(access_group_id, subject_id) do
+    association = %SmartCity.UserAccessGroupRelation{
+      access_group_id: access_group_id,
+      subject_id: subject_id
+    }
+
+    Brook.Event.send(Raptor.instance_name(), user_access_group_disassociate(), :testing, association)
+
+    eventually(fn ->
+      raptor_user_access_group_assoc = UserAccessGroupRelationStore.get(subject_id, access_group_id)
+      assert %{} == raptor_user_access_group_assoc
+    end)
+  end
+
+  def send_dataset_access_group_associate_event(access_group_id, dataset_id) do
+    association = %SmartCity.DatasetAccessGroupRelation{
+      access_group_id: access_group_id,
+      dataset_id: dataset_id
+    }
+
+    Brook.Event.send(Raptor.instance_name(), dataset_access_group_associate(), :testing, association)
+
+    expected_raptor_assoc = %DatasetAccessGroupRelation{dataset_id: dataset_id, access_group_id: access_group_id}
+
+    eventually(fn ->
+      raptor_dataset_access_group_assoc = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+      assert expected_raptor_assoc == raptor_dataset_access_group_assoc
+    end)
+  end
+
+  def send_dataset_access_group_disassociate_event(access_group_id, dataset_id) do
+    association = %SmartCity.DatasetAccessGroupRelation{
+      access_group_id: access_group_id,
+      dataset_id: dataset_id
+    }
+
+    Brook.Event.send(Raptor.instance_name(), dataset_access_group_disassociate(), :testing, association)
+
+    eventually(fn ->
+      raptor_dataset_access_group_assoc = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+      assert %{} == raptor_dataset_access_group_assoc
     end)
   end
 end

--- a/apps/raptor/test/unit/raptor/event/event_handler_test.exs
+++ b/apps/raptor/test/unit/raptor/event/event_handler_test.exs
@@ -6,15 +6,91 @@ defmodule Raptor.Event.EventHandlerTest do
     only: [
       user_organization_associate: 0,
       user_organization_disassociate: 0,
-      dataset_update: 0
+      user_access_group_associate: 0,
+      user_access_group_disassociate: 0,
+      dataset_update: 0,
+      dataset_access_group_associate: 0,
+      dataset_access_group_disassociate: 0
     ]
 
   alias Raptor.Event.EventHandler
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Services.DatasetStore
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Services.DatasetAccessGroupRelationStore
   alias Raptor.Schemas.UserOrgAssoc
   alias Raptor.Schemas.Dataset
   alias SmartCity.TestDataGenerator, as: TDG
+
+  describe "handle_event/1 user_access_group_associate" do
+    setup do
+      {:ok, association_event} =
+        SmartCity.UserAccessGroupRelation.new(%{
+          subject_id: "user_id",
+          access_group_id: "access_group_id"
+        })
+
+      allow(UserAccessGroupRelationStore.persist(any()), return: {:ok, "success"})
+
+      %{association_event: association_event}
+    end
+
+    test "should persist to the UserAccessGroupRelationStore when an event is received", %{
+      association_event: association_event
+    } do
+      result =
+        EventHandler.handle_event(
+          Brook.Event.new(
+            type: user_access_group_associate(),
+            data: association_event,
+            author: :author
+          )
+        )
+
+      expected_assoc_event = %Raptor.Schemas.UserAccessGroupRelation{
+        user_id: "user_id",
+        access_group_id: "access_group_id"
+      }
+
+      assert_called(UserAccessGroupRelationStore.persist(expected_assoc_event))
+      assert result == :discard
+    end
+  end
+
+  describe "handle_event/1 dataset_access_group_associate" do
+    setup do
+      {:ok, association_event} =
+        SmartCity.DatasetAccessGroupRelation.new(%{
+          dataset_id: "dataset_id",
+          access_group_id: "access_group_id"
+        })
+
+      allow(DatasetAccessGroupRelationStore.persist(any()), return: {:ok, "success"})
+
+      %{association_event: association_event}
+    end
+
+    test "should persist to the DatasetAccessGroupRelationStore when an event is received", %{
+      association_event: association_event
+    } do
+      result =
+        EventHandler.handle_event(
+          Brook.Event.new(
+            type: dataset_access_group_associate(),
+            data: association_event,
+            author: :author
+          )
+        )
+
+      expected_assoc_event = %Raptor.Schemas.DatasetAccessGroupRelation{
+        dataset_id: "dataset_id",
+        access_group_id: "access_group_id"
+      }
+
+      assert_called(DatasetAccessGroupRelationStore.persist(expected_assoc_event))
+      assert result == :discard
+    end
+  end
 
   describe "handle_event/1 user_organization_associate" do
     setup do
@@ -49,6 +125,76 @@ defmodule Raptor.Event.EventHandlerTest do
       }
 
       assert_called(UserOrgAssocStore.persist(expected_assoc_event))
+      assert result == :discard
+    end
+  end
+
+  describe "handle_event/1 user_access_group_disassociate" do
+    setup do
+      {:ok, disassociation_event} =
+        SmartCity.UserAccessGroupRelation.new(%{
+          subject_id: "subject_id",
+          access_group_id: "group_id"
+        })
+
+      allow(UserAccessGroupRelationStore.delete(any()), return: {:ok, "success"})
+      %{disassociation_event: disassociation_event}
+    end
+
+    test "should delete an entry from the UserAccessGroupRelationStore when an event is received",
+         %{
+           disassociation_event: disassociation_event
+         } do
+      result =
+        EventHandler.handle_event(
+          Brook.Event.new(
+            type: user_access_group_disassociate(),
+            data: disassociation_event,
+            author: :author
+          )
+        )
+
+      expected_disassoc_event = %Raptor.Schemas.UserAccessGroupRelation{
+        user_id: "subject_id",
+        access_group_id: "group_id"
+      }
+
+      assert_called(UserAccessGroupRelationStore.delete(expected_disassoc_event))
+      assert result == :discard
+    end
+  end
+
+  describe "handle_event/1 dataset_access_group_disassociate" do
+    setup do
+      {:ok, disassociation_event} =
+        SmartCity.DatasetAccessGroupRelation.new(%{
+          dataset_id: "dataset_id",
+          access_group_id: "group_id"
+        })
+
+      allow(DatasetAccessGroupRelationStore.delete(any()), return: {:ok, "success"})
+      %{disassociation_event: disassociation_event}
+    end
+
+    test "should delete an entry from the DatasetAccessGroupRelationStore when an event is received",
+         %{
+           disassociation_event: disassociation_event
+         } do
+      result =
+        EventHandler.handle_event(
+          Brook.Event.new(
+            type: dataset_access_group_disassociate(),
+            data: disassociation_event,
+            author: :author
+          )
+        )
+
+      expected_disassoc_event = %Raptor.Schemas.DatasetAccessGroupRelation{
+        dataset_id: "dataset_id",
+        access_group_id: "group_id"
+      }
+
+      assert_called(DatasetAccessGroupRelationStore.delete(expected_disassoc_event))
       assert result == :discard
     end
   end

--- a/apps/raptor/test/unit/raptor/schemas/dataset_access_group_relation_test.exs
+++ b/apps/raptor/test/unit/raptor/schemas/dataset_access_group_relation_test.exs
@@ -1,0 +1,19 @@
+defmodule Raptor.Schemas.DatasetAccessGroupRelationTest do
+  use RaptorWeb.ConnCase
+  alias Raptor.Schemas.DatasetAccessGroupRelation
+
+  test "convert from smrt event to Raptor dataset-access_group relation schema" do
+    expected = %DatasetAccessGroupRelation{
+      dataset_id: "dataset",
+      access_group_id: "my_cool_group"
+    }
+
+    {:ok, actual_relation} =
+      DatasetAccessGroupRelation.from_smrt_relation(%SmartCity.DatasetAccessGroupRelation{
+        dataset_id: "dataset",
+        access_group_id: "my_cool_group"
+      })
+
+    assert expected == actual_relation
+  end
+end

--- a/apps/raptor/test/unit/raptor/schemas/user_access_group_relation_test.exs
+++ b/apps/raptor/test/unit/raptor/schemas/user_access_group_relation_test.exs
@@ -1,0 +1,16 @@
+defmodule Raptor.Schemas.UserAccessGroupRelationTest do
+  use RaptorWeb.ConnCase
+  alias Raptor.Schemas.UserAccessGroupRelation
+
+  test "convert from smrt event to Raptor user-access_group relation schema" do
+    expected = %UserAccessGroupRelation{user_id: "user", access_group_id: "my_cool_group"}
+
+    {:ok, actual_relation} =
+      UserAccessGroupRelation.from_smrt_relation(%SmartCity.UserAccessGroupRelation{
+        subject_id: "user",
+        access_group_id: "my_cool_group"
+      })
+
+    assert expected == actual_relation
+  end
+end

--- a/apps/raptor/test/unit/raptor/services/dataset_access_group_relation_store_test.exs
+++ b/apps/raptor/test/unit/raptor/services/dataset_access_group_relation_store_test.exs
@@ -33,7 +33,10 @@ defmodule Raptor.Services.DatasetAccessGroupRelationStoreTest do
 
       expectedRelations = [
         %DatasetAccessGroupRelation{dataset_id: "dataset_id", access_group_id: "access_group_id"},
-        %DatasetAccessGroupRelation{dataset_id: "dataset_id1", access_group_id: "access_group_id1"}
+        %DatasetAccessGroupRelation{
+          dataset_id: "dataset_id1",
+          access_group_id: "access_group_id1"
+        }
       ]
 
       actualRelations = DatasetAccessGroupRelationStore.get_all()

--- a/apps/raptor/test/unit/raptor/services/dataset_access_group_relation_store_test.exs
+++ b/apps/raptor/test/unit/raptor/services/dataset_access_group_relation_store_test.exs
@@ -1,0 +1,157 @@
+defmodule Raptor.Services.DatasetAccessGroupRelationStoreTest do
+  use RaptorWeb.ConnCase
+  use Placebo
+  alias Raptor.Services.DatasetAccessGroupRelationStore
+  alias Raptor.Schemas.DatasetAccessGroupRelation
+
+  @namespace "raptor:dataset_access_group_relation:"
+  @redix Raptor.Application.redis_client()
+
+  describe "get_all/0" do
+    test "returns empty list when no dataset access group relations in redis" do
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> "*"]), return: [])
+
+      actualRelations = DatasetAccessGroupRelationStore.get_all()
+
+      assert [] == actualRelations
+    end
+
+    test "returns list of dataset-access_group relations when they exist in redis" do
+      keys = [
+        "raptor:dataset_access_group_relation:dataset_id:access_group_id",
+        "raptor:dataset_access_group_relation:dataset_id1:access_group_id1"
+      ]
+
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> "*"]), return: keys)
+
+      allow(Redix.command!(@redix, ["MGET" | keys]),
+        return: [
+          "{\"dataset_id\":\"dataset_id\",\"access_group_id\":\"access_group_id\"}",
+          "{\"dataset_id\":\"dataset_id1\",\"access_group_id\":\"access_group_id1\"}"
+        ]
+      )
+
+      expectedRelations = [
+        %DatasetAccessGroupRelation{dataset_id: "dataset_id", access_group_id: "access_group_id"},
+        %DatasetAccessGroupRelation{dataset_id: "dataset_id1", access_group_id: "access_group_id1"}
+      ]
+
+      actualRelations = DatasetAccessGroupRelationStore.get_all()
+
+      assert expectedRelations == actualRelations
+    end
+  end
+
+  describe "get/1" do
+    test "an empty map is returned when there are no entries in redis matching the datasetId and accessGroupId" do
+      dataset_id = "picard"
+      access_group_id = "enterprise"
+      key = "#{dataset_id}:#{access_group_id}"
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> key]), return: [])
+
+      actualRelation = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+
+      assert %{} == actualRelation
+    end
+
+    test "a Raptor dataset access group assoc is returned when there is one entry in redis matching the dataset id and access group id" do
+      dataset_id = "picard"
+      access_group_id = "enterprise"
+      key = "#{dataset_id}:#{access_group_id}"
+
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> key]),
+        return: ["raptor:dataset_access_group_relation:picard:enterprise"]
+      )
+
+      allow(
+        Redix.command!(@redix, ["MGET", "raptor:dataset_access_group_relation:picard:enterprise"]),
+        return: [
+          "{\"dataset_id\":\"picard\",\"access_group_id\":\"enterprise\"}"
+        ]
+      )
+
+      expected_relation = %DatasetAccessGroupRelation{
+        dataset_id: "picard",
+        access_group_id: "enterprise"
+      }
+
+      actual_relation = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+
+      assert expected_relation == actual_relation
+    end
+
+    test "an empty map is returned when there are multiple entries in redis matching the dataset id and access group id" do
+      dataset_id = "picard"
+      access_group_id = "enterprise"
+
+      keys = [
+        "raptor:dataset_access_group_relation:picard:enterprise",
+        "raptor:dataset_access_group_relation:picard:enterprise"
+      ]
+
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> "#{dataset_id}:#{access_group_id}"]),
+        return: keys
+      )
+
+      actual_relation = DatasetAccessGroupRelationStore.get(dataset_id, access_group_id)
+
+      assert %{} == actual_relation
+    end
+  end
+
+  describe "persist/1" do
+    test "Redis is successfully called with a dataset access group relation entry" do
+      dataset_id = "picard"
+      access_group_id = "enterprise"
+
+      dataset_access_group_relation = %DatasetAccessGroupRelation{
+        dataset_id: "picard",
+        access_group_id: "enterprise"
+      }
+
+      dataset_access_group_relation_json =
+        "{\"access_group_id\":\"enterprise\",\"dataset_id\":\"picard\"}"
+
+      allow(
+        Redix.command!(@redix, [
+          "SET",
+          @namespace <> "#{dataset_id}:#{access_group_id}",
+          dataset_access_group_relation_json
+        ]),
+        return: :ok
+      )
+
+      DatasetAccessGroupRelationStore.persist(dataset_access_group_relation)
+
+      assert_called(
+        Redix.command!(@redix, [
+          "SET",
+          @namespace <> "#{dataset_id}:#{access_group_id}",
+          dataset_access_group_relation_json
+        ])
+      )
+    end
+  end
+
+  describe "delete/1" do
+    test "Redis' delete is successfully called with a dataset access group disassoc entry" do
+      dataset_id = "picard"
+      access_group_id = "enterprise"
+
+      datasetAccessGroupRelation = %DatasetAccessGroupRelation{
+        dataset_id: "picard",
+        access_group_id: "enterprise"
+      }
+
+      allow(Redix.command!(@redix, ["DEL", @namespace <> "#{dataset_id}:#{access_group_id}"]),
+        return: :ok
+      )
+
+      DatasetAccessGroupRelationStore.delete(datasetAccessGroupRelation)
+
+      assert_called(
+        Redix.command!(@redix, ["DEL", @namespace <> "#{dataset_id}:#{access_group_id}"])
+      )
+    end
+  end
+end

--- a/apps/raptor/test/unit/raptor/services/user_access_group_relation_store_test.exs
+++ b/apps/raptor/test/unit/raptor/services/user_access_group_relation_store_test.exs
@@ -1,0 +1,157 @@
+defmodule Raptor.Services.UserAccessGroupRelationStoreTest do
+  use RaptorWeb.ConnCase
+  use Placebo
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Schemas.UserAccessGroupRelation
+
+  @namespace "raptor:user_access_group_relation:"
+  @redix Raptor.Application.redis_client()
+
+  describe "get_all/0" do
+    test "returns empty list when no user access group relations in redis" do
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> "*"]), return: [])
+
+      actualRelations = UserAccessGroupRelationStore.get_all()
+
+      assert [] == actualRelations
+    end
+
+    test "returns list of user-access_group relations when they exist in redis" do
+      keys = [
+        "raptor:user_access_group_relation:user_id:access_group_id",
+        "raptor:user_access_group_relation:user_id1:access_group_id1"
+      ]
+
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> "*"]), return: keys)
+
+      allow(Redix.command!(@redix, ["MGET" | keys]),
+        return: [
+          "{\"user_id\":\"user_id\",\"access_group_id\":\"access_group_id\"}",
+          "{\"user_id\":\"user_id1\",\"access_group_id\":\"access_group_id1\"}"
+        ]
+      )
+
+      expectedRelations = [
+        %UserAccessGroupRelation{user_id: "user_id", access_group_id: "access_group_id"},
+        %UserAccessGroupRelation{user_id: "user_id1", access_group_id: "access_group_id1"}
+      ]
+
+      actualRelations = UserAccessGroupRelationStore.get_all()
+
+      assert expectedRelations == actualRelations
+    end
+  end
+
+  describe "get/1" do
+    test "an empty map is returned when there are no entries in redis matching the userId and accessGroupId" do
+      user_id = "picard"
+      access_group_id = "enterprise"
+      key = "#{user_id}:#{access_group_id}"
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> key]), return: [])
+
+      actualRelation = UserAccessGroupRelationStore.get(user_id, access_group_id)
+
+      assert %{} == actualRelation
+    end
+
+    test "a Raptor user access group assoc is returned when there is one entry in redis matching the user id and access group id" do
+      user_id = "picard"
+      access_group_id = "enterprise"
+      key = "#{user_id}:#{access_group_id}"
+
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> key]),
+        return: ["raptor:user_access_group_relation:picard:enterprise"]
+      )
+
+      allow(
+        Redix.command!(@redix, ["MGET", "raptor:user_access_group_relation:picard:enterprise"]),
+        return: [
+          "{\"user_id\":\"picard\",\"access_group_id\":\"enterprise\"}"
+        ]
+      )
+
+      expected_relation = %UserAccessGroupRelation{
+        user_id: "picard",
+        access_group_id: "enterprise"
+      }
+
+      actual_relation = UserAccessGroupRelationStore.get(user_id, access_group_id)
+
+      assert expected_relation == actual_relation
+    end
+
+    test "an empty map is returned when there are multiple entries in redis matching the user id and access group id" do
+      user_id = "picard"
+      access_group_id = "enterprise"
+
+      keys = [
+        "raptor:user_access_group_relation:picard:enterprise",
+        "raptor:user_access_group_relation:picard:enterprise"
+      ]
+
+      allow(Redix.command!(@redix, ["KEYS", @namespace <> "#{user_id}:#{access_group_id}"]),
+        return: keys
+      )
+
+      actual_relation = UserAccessGroupRelationStore.get(user_id, access_group_id)
+
+      assert %{} == actual_relation
+    end
+  end
+
+  describe "persist/1" do
+    test "Redis is successfully called with a user access group relation entry" do
+      user_id = "picard"
+      access_group_id = "enterprise"
+
+      user_access_group_relation = %UserAccessGroupRelation{
+        user_id: "picard",
+        access_group_id: "enterprise"
+      }
+
+      user_access_group_relation_json =
+        "{\"access_group_id\":\"enterprise\",\"user_id\":\"picard\"}"
+
+      allow(
+        Redix.command!(@redix, [
+          "SET",
+          @namespace <> "#{user_id}:#{access_group_id}",
+          user_access_group_relation_json
+        ]),
+        return: :ok
+      )
+
+      UserAccessGroupRelationStore.persist(user_access_group_relation)
+
+      assert_called(
+        Redix.command!(@redix, [
+          "SET",
+          @namespace <> "#{user_id}:#{access_group_id}",
+          user_access_group_relation_json
+        ])
+      )
+    end
+  end
+
+  describe "delete/1" do
+    test "Redis' delete is successfully called with a user access group disassoc entry" do
+      user_id = "picard"
+      access_group_id = "enterprise"
+
+      userAccessGroupRelation = %UserAccessGroupRelation{
+        user_id: "picard",
+        access_group_id: "enterprise"
+      }
+
+      allow(Redix.command!(@redix, ["DEL", @namespace <> "#{user_id}:#{access_group_id}"]),
+        return: :ok
+      )
+
+      UserAccessGroupRelationStore.delete(userAccessGroupRelation)
+
+      assert_called(
+        Redix.command!(@redix, ["DEL", @namespace <> "#{user_id}:#{access_group_id}"])
+      )
+    end
+  end
+end

--- a/apps/raptor/test/unit/raptor_web/authorize_controller_test.exs
+++ b/apps/raptor/test/unit/raptor_web/authorize_controller_test.exs
@@ -57,7 +57,9 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       assert actual == expected
     end
 
-    test "returns false when the dataset org does not match the user org or any access groups", %{conn: conn} do
+    test "returns false when the dataset org does not match the user org or any access groups", %{
+      conn: conn
+    } do
       api_key = "enterprise"
       system_name = "system__name"
       dataset_org_id = "dataset_org"

--- a/apps/raptor/test/unit/raptor_web/authorize_controller_test.exs
+++ b/apps/raptor/test/unit/raptor_web/authorize_controller_test.exs
@@ -57,7 +57,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       assert actual == expected
     end
 
-    test "returns false when the dataset org does not match the user org", %{conn: conn} do
+    test "returns false when the dataset org does not match the user org or any access groups", %{conn: conn} do
       api_key = "enterprise"
       system_name = "system__name"
       dataset_org_id = "dataset_org"
@@ -79,6 +79,14 @@ defmodule RaptorWeb.AuthorizeControllerTest do
         return: %{}
       )
 
+      expect(UserAccessGroupRelationStore.get_all_by_user(user_id),
+        return: []
+      )
+
+      expect(DatasetAccessGroupRelationStore.get_all_by_dataset("wags"),
+        return: []
+      )
+
       actual =
         conn
         |> get("/api/authorize?apiKey=#{api_key}&systemName=#{system_name}")
@@ -87,7 +95,8 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       assert actual == expected
     end
 
-    test "returns true when the dataset org does not match the user org but there is a matching access group", %{conn: conn} do
+    test "returns true when the dataset org does not match the user org but there is a matching access group",
+         %{conn: conn} do
       api_key = "enterprise"
       system_name = "system__name"
       dataset_org_id = "dataset_org"
@@ -126,7 +135,8 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       assert actual == expected
     end
 
-    test "returns false when the dataset org does not match the user org and there is not a matching access group", %{conn: conn} do
+    test "returns false when the dataset org does not match the user org and there is not a matching access group",
+         %{conn: conn} do
       api_key = "enterprise"
       system_name = "system__name"
       dataset_org_id = "dataset_org"


### PR DESCRIPTION
## [Ticket Link #574](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/574)

## Description

- Adding a user to an access group with a dataset allows that user to interact with that dataset.
- Adding a dataset to an access group with a user allows that user to see the new dataset.
- It can be streamed from discovery streams.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
