### PR TITLE
fix svg loading for asset/resource type in webpack5

### DIFF
--- a/apps/andi/assets/webpack.config.js
+++ b/apps/andi/assets/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = (env, options) => ({
         ]
       },
       {
-        test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
         use: [
           {
             loader: 'file-loader',
@@ -45,7 +45,11 @@ module.exports = (env, options) => ({
             }
           }
         ]
-      }
+      },
+      {
+        test: /\.svg/,
+        type: "asset/resource",
+      },
     ]
   },
   plugins: [

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.1.22",
+      version: "2.1.23",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #671](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/671)

## Description

- Re-enabled SVG icons showing up in Andi, by using "type asset/resource" as an alternative to "file-loader" 

ref:
- [asset modules](https://webpack.js.org/guides/asset-modules/)
- This was our issue: [missing image content](https://github.com/webpack-contrib/css-loader/issues/1358)

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
