### PR TITLE
Ensuring unhandled exception are dead lettered

### DIFF
--- a/apps/valkyrie/lib/valkyrie.ex
+++ b/apps/valkyrie/lib/valkyrie.ex
@@ -23,9 +23,13 @@ defmodule Valkyrie do
   defp standardize_schema(schema, payload) do
     schema
     |> Enum.reduce(%{data: %{}, errors: %{}}, fn %{name: name} = field, acc ->
-      case standardize(field, payload[name]) do
-        {:ok, value} -> %{acc | data: Map.put(acc.data, name, value)}
-        {:error, reason} -> %{acc | errors: Map.put(acc.errors, name, reason)}
+      try do
+        case standardize(field, payload[name]) do
+          {:ok, value} -> %{acc | data: Map.put(acc.data, name, value)}
+          {:error, reason} -> %{acc | errors: Map.put(acc.errors, name, reason)}
+        end
+      rescue
+        exception -> %{acc | errors: Map.put(acc.errors, name, %{unhandled_standardization_exception: exception})}
       end
     end)
   end

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.7.12",
+      version: "1.7.13",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/valkyrie/test/unit/valkyrie_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie_test.exs
@@ -443,6 +443,28 @@ defmodule ValkyrieTest do
 
       assert {:error, %{"geometry" => :invalid_type}} == Valkyrie.standardize_data(dataset, payload)
     end
+
+    test "returns error if cannot parse list of lists" do
+      dataset =
+        TDG.create_dataset(
+          id: "ds1",
+          technical: %{
+            schema: [
+              %{name: "name", type: "string"},
+              %{name: "luckyNumbers", type: "list", itemType: "string"},
+            ]
+          }
+        )
+
+      payload = %{
+        "name" => "Pete",
+        "luckyNumbers" => [[-83.01347, 42.38928],[-83.01347, 42.38928],[-83.01347, 42.38928]]
+      }
+
+      result = Valkyrie.standardize_data(dataset, payload)
+
+      assert {:error, %{"luckyNumbers" => %{unhandled_standardization_exception: %ArgumentError{}}}} = result
+    end
   end
 
   describe "json is converted" do

--- a/apps/valkyrie/test/unit/valkyrie_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie_test.exs
@@ -451,14 +451,14 @@ defmodule ValkyrieTest do
           technical: %{
             schema: [
               %{name: "name", type: "string"},
-              %{name: "luckyNumbers", type: "list", itemType: "string"},
+              %{name: "luckyNumbers", type: "list", itemType: "string"}
             ]
           }
         )
 
       payload = %{
         "name" => "Pete",
-        "luckyNumbers" => [[-83.01347, 42.38928],[-83.01347, 42.38928],[-83.01347, 42.38928]]
+        "luckyNumbers" => [[-83.01347, 42.38928], [-83.01347, 42.38928], [-83.01347, 42.38928]]
       }
 
       result = Valkyrie.standardize_data(dataset, payload)


### PR DESCRIPTION
## Description

Found a bug in Valkyrie where if it didn't recognize certain kinds of data during standardization, it would throw an ArgumentError and not dead letter the message. This forces it to dead letter under any unhandled cases.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
