### PR TITLE
22.0.3 -> 22.3.4.19

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.0.3
+erlang 22.3.4.19
 elixir 1.10.4-otp-22


### PR DESCRIPTION
## Description

- Update the erlang version to one that's more easily compatible with the M1 chip.

## Reminders:

- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
