### PR TITLE
Less finicky keywords

### DIFF
--- a/apps/andi/lib/andi/input_schemas/input_converter.ex
+++ b/apps/andi/lib/andi/input_schemas/input_converter.ex
@@ -482,7 +482,7 @@ defmodule Andi.InputSchemas.InputConverter do
 
   def keywords_to_list(keywords) when is_binary(keywords) do
     keywords
-    |> String.split(", ")
+    |> String.split(",")
     |> Enum.map(&String.trim/1)
   end
 

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.2.2",
+      version: "2.2.3",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
@@ -517,4 +517,39 @@ defmodule Andi.InputSchemas.InputConverterTest do
       assert %{id: ^valid_id} = Ecto.Changeset.apply_changes(changeset)
     end
   end
+
+  describe "keywords_to_list" do
+    test "turns nil into empty array" do
+      assert [] = InputConverter.keywords_to_list(nil)
+    end
+
+    test "turns empty string into empty array" do
+      assert [] = InputConverter.keywords_to_list("")
+    end
+
+    test "returns list unchanged" do
+      keywords = ["one", "blue", "sky"]
+      assert keywords = InputConverter.keywords_to_list(keywords)
+    end
+
+    test "comma space separated string turns into array of strings" do
+      keywords = "one, blue, sky"
+      assert ["one", "blue", "sky"] = InputConverter.keywords_to_list(keywords)
+    end
+
+    test "comma separated string with no spaces turns into array of strings" do
+      keywords = "one,blue,sky"
+      assert ["one", "blue", "sky"] = InputConverter.keywords_to_list(keywords)
+    end
+
+    test "internal spaces are preserved within a keyword" do
+      keywords = "example, one blue sky"
+      assert = ["example", "one blue sky"] = InputConverter.keywords_to_list(keywords)
+    end
+
+    test "leading and trailing spaces are trimmed from a keyword" do
+      keywords = "  one,  blue  , sky  "
+      assert ["one", "blue", "sky"] = InputConverter.keywords_to_list(keywords)
+    end
+  end
 end


### PR DESCRIPTION
- High level overview of changes

Data curators and define a dataset's keywords using comma or comma-space separation

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
