### PR TITLE
Add Upload Button to Ingestions

### DIFF
--- a/apps/andi/assets/css/ingestions.scss
+++ b/apps/andi/assets/css/ingestions.scss
@@ -4,6 +4,7 @@
 
 .ingestion-metadata-form {
   margin-bottom: 1rem;
+  margin-top: 1rem;
 }
 
 .selected-results-from-search.selected-dataset {

--- a/apps/andi/lib/andi_web/live/helpers/metadata_form_helpers.ex
+++ b/apps/andi/lib/andi_web/live/helpers/metadata_form_helpers.ex
@@ -28,6 +28,7 @@ defmodule AndiWeb.Helpers.MetadataFormHelpers do
   end
 
   def get_source_format_options(_), do: Options.source_format()
+  def get_source_format_options(), do: Options.source_format()
 
   def get_language(nil), do: "english"
   def get_language(lang), do: lang

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
@@ -79,8 +79,6 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
 
           <div class="component-edit-section--<%= @visibility %>">
 
-            <%= ErrorHelpers.error_tag(f, :schema, bind_to_input: false, class: "full-width") %>
-
             <div class="data-dictionary-form-edit-section form-grid">
 
               <div class="upload-section">

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -14,27 +14,30 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
     ~L"""
     <%= header_render(@socket, @is_curator) %>
     <div class="edit-page" id="ingestions-edit-page">
-      <div class="edit-ingestion-title">
-        <h2 class="component-title-text">Define Data Ingestion</h2>
-      </div>
-
-      <div>
-        <%= live_render(@socket, AndiWeb.IngestionLiveView.MetadataForm, id: :ingestion_metadata_form_editor, session: %{"ingestion" => @ingestion}) %>
-      </div>
-
-      <div>
-        <div class="extract-steps-form-component">
-          <%= live_render(@socket, AndiWeb.IngestionLiveView.ExtractSteps.ExtractStepForm, id: :extract_step_form_editor, session: %{"ingestion" => @ingestion, "order" => "1"}) %>
+      <%= f = form_for @changeset, "" %>
+        <%= hidden_input(f, :sourceFormat) %>
+        <div class="edit-ingestion-title">
+          <h2 class="component-title-text">Define Data Ingestion</h2>
         </div>
 
-        <div class="data-dictionary-form-component">
-          <%= live_render(@socket, AndiWeb.IngestionLiveView.DataDictionaryForm, id: :data_dictionary_form_editor, session: %{"ingestion" => @ingestion, "is_curator" => @is_curator, "order" => "2"}) %>
+        <div>
+          <%= live_render(@socket, AndiWeb.IngestionLiveView.MetadataForm, id: :ingestion_metadata_form_editor, session: %{"ingestion" => @ingestion}) %>
         </div>
 
-        <div class="finalize-form-component ">
-          <%= live_render(@socket, AndiWeb.IngestionLiveView.FinalizeForm, id: :finalize_form_editor, session: %{"ingestion" => @ingestion, "order" => "4"}) %>
+        <div>
+          <div class="extract-steps-form-component">
+            <%= live_render(@socket, AndiWeb.IngestionLiveView.ExtractSteps.ExtractStepForm, id: :extract_step_form_editor, session: %{"ingestion" => @ingestion, "order" => "1"}) %>
+          </div>
+
+          <div class="data-dictionary-form-component">
+            <%= live_render(@socket, AndiWeb.IngestionLiveView.DataDictionaryForm, id: :data_dictionary_form_editor, session: %{"ingestion" => @ingestion, "is_curator" => @is_curator, "order" => "2"}) %>
+          </div>
+
+          <div class="finalize-form-component ">
+            <%= live_render(@socket, AndiWeb.IngestionLiveView.FinalizeForm, id: :finalize_form_editor, session: %{"ingestion" => @ingestion, "order" => "4"}) %>
+          </div>
         </div>
-      </div>
+      </form>
 
       <div class="edit-page__btn-group">
         <div class="btn-group__standard">

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.2.8",
+      version: "2.2.9",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
@@ -606,7 +606,6 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
     end
   end
 
-  @tag :skip
   test "required schema field displays proper error message", %{conn: conn} do
     ingestion = create_ingestion_with_schema([])
 
@@ -1096,8 +1095,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       select_source_format("application/json", view)
       data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
 
-      json_sample =
-        "header {\n  gtfs_realtime_version: \"2.0\"\n  incrementality: FULL_DATASET\n  timestamp: 1582913296\n}\nentity {\n  id: \"2551\"\n  vehicle {\n    trip {\n      trip_id: \"2290874_MRG_1\"\n      start_date: \"20200228\"\n      route_id: \"661\"\n    }\n"
+      json_sample = "header"
 
       html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "application/json", "file" => json_sample})
 

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
@@ -1086,13 +1086,12 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       assert generated_schema == expected_schema
     end
 
-    @tag :skip
     test "handles invalid json", %{conn: conn} do
       dataset = TDG.create_dataset(%{})
       {:ok, _} = Datasets.update(dataset)
-      ingestion = Ingestions.create(dataset.id)
+      ingestion = TDG.create_ingestion(%{sourceFormat: "application/json", targetDataset: dataset.id})
+      {:ok, _} = Ingestions.update(ingestion)
       assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
-      select_source_format("application/json", view)
       data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
 
       json_sample = "header"
@@ -1102,13 +1101,12 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       refute Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
     end
 
-    @tag :skip
     test "should throw error when empty json file is passed", %{conn: conn} do
       dataset = TDG.create_dataset(%{})
       {:ok, _} = Datasets.update(dataset)
-      ingestion = Ingestions.create(dataset.id)
+      ingestion = TDG.create_ingestion(%{sourceFormat: "application/json", targetDataset: dataset.id})
+      {:ok, _} = Ingestions.update(ingestion)
       assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
-      select_source_format("application/json", view)
       data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
 
       json_sample = "[]"

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary_form_test.exs
@@ -6,6 +6,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
   import SmartCity.Event, only: [ingestion_update: 0, dataset_update: 0]
   import SmartCity.TestHelper, only: [eventually: 1, eventually: 3]
   import Phoenix.LiveViewTest
+  import Checkov
 
   alias SmartCity.TestDataGenerator, as: TDG
   alias Andi.InputSchemas.DataDictionaryFields
@@ -605,6 +606,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
     end
   end
 
+  @tag :skip
   test "required schema field displays proper error message", %{conn: conn} do
     ingestion = create_ingestion_with_schema([])
 
@@ -895,6 +897,251 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
     end
   end
 
+  describe "schema sample upload" do
+    test "is shown when sourceFormat is CSV or JSON", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "application/json", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+      html = render(data_dictionary_view)
+
+      refute Enum.empty?(find_elements(html, ".data-dictionary-form__file-upload"))
+    end
+
+    test "is hidden when sourceFormat is not CSV nor JSON", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "application/geo+json", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+      html = render(data_dictionary_view)
+
+      assert Enum.empty?(find_elements(html, ".data-dictionary-form__file-upload"))
+    end
+
+    test "does not allow file uploads greater than 200MB", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "text/csv", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 200_000_001})
+
+      refute Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
+    end
+
+    test "should throw error when empty csv file is passed", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "text/csv", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample = ""
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "text/csv", "file" => csv_sample})
+
+      refute Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
+    end
+
+    data_test "accepts common csv file type #{type}", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "text/csv", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample = "string,int,float,bool,date\nabc,9,1.5,true,2020-07-22T21:24:40"
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 10, "fileType" => type, "file" => csv_sample})
+
+      assert Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
+
+      where([
+        [:type],
+        ["text/csv"],
+        ["application/vnd.ms-excel"]
+      ])
+    end
+
+    test "should throw error when empty csv file with `\n` is passed", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "text/csv", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample = "\n"
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "text/csv", "file" => csv_sample})
+
+      refute Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
+    end
+
+    test "provides modal when existing schema will be overwritten", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      ingestion = TDG.create_ingestion(%{sourceFormat: "text/csv", targetDataset: dataset.id})
+
+      {:ok, _} = Datasets.update(dataset)
+      {:ok, _} = Ingestions.update(ingestion)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample = "CAM\nrules"
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "text/csv", "file" => csv_sample})
+
+      refute Enum.empty?(find_elements(html, ".overwrite-schema-modal--visible"))
+    end
+
+    test "does not provide modal with no existing schema", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _} = Datasets.update(dataset)
+      ingestion = Ingestions.create(dataset.id)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      select_source_format("text/csv", view)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample = "CAM\nrules"
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "text/csv", "file" => csv_sample})
+
+      assert Enum.empty?(find_elements(html, ".overwrite-schema-modal--visible"))
+
+      updated_ingestion = Ingestions.get(ingestion.id)
+      refute Enum.empty?(updated_ingestion.schema)
+    end
+
+    test "parses CSVs with various types", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _} = Datasets.update(dataset)
+      ingestion = Ingestions.create(dataset.id)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      select_source_format("text/csv", view)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample = "string,int,float,bool,date,timestamp\nabc,9,1.5,true,2020-07-22,2020-07-22T21:24:40"
+
+      render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "text/csv", "file" => csv_sample})
+
+      updated_ingestion = Ingestions.get(ingestion.id)
+
+      generated_schema =
+        updated_ingestion.schema
+        |> Enum.map(fn item -> %{type: item.type, name: item.name} end)
+
+      expected_schema = [
+        %{name: "string", type: "string"},
+        %{name: "int", type: "integer"},
+        %{name: "float", type: "float"},
+        %{name: "bool", type: "boolean"},
+        %{name: "date", type: "date"},
+        %{name: "timestamp", type: "timestamp"}
+      ]
+
+      assert generated_schema == expected_schema
+    end
+
+    test "parses CSV with valid column names", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _} = Datasets.update(dataset)
+      ingestion = Ingestions.create(dataset.id)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      select_source_format("text/csv", view)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      csv_sample =
+        "string\r,i&^%$nt,fl\toat,bool---,date as multi word column,timestamp as multi word column\nabc,9,1.5,true,2020-07-22,2020-07-22T21:24:40"
+
+      render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "text/csv", "file" => csv_sample})
+
+      updated_ingestion = Ingestions.get(ingestion.id)
+
+      generated_schema =
+        updated_ingestion.schema
+        |> Enum.map(fn item -> %{type: item.type, name: item.name} end)
+
+      expected_schema = [
+        %{name: "string", type: "string"},
+        %{name: "int", type: "integer"},
+        %{name: "float", type: "float"},
+        %{name: "bool", type: "boolean"},
+        %{name: "date as multi word column", type: "date"},
+        %{name: "timestamp as multi word column", type: "timestamp"}
+      ]
+
+      assert generated_schema == expected_schema
+    end
+
+    @tag :skip
+    test "handles invalid json", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _} = Datasets.update(dataset)
+      ingestion = Ingestions.create(dataset.id)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      select_source_format("application/json", view)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      json_sample =
+        "header {\n  gtfs_realtime_version: \"2.0\"\n  incrementality: FULL_DATASET\n  timestamp: 1582913296\n}\nentity {\n  id: \"2551\"\n  vehicle {\n    trip {\n      trip_id: \"2290874_MRG_1\"\n      start_date: \"20200228\"\n      route_id: \"661\"\n    }\n"
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "application/json", "file" => json_sample})
+
+      refute Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
+    end
+
+    @tag :skip
+    test "should throw error when empty json file is passed", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _} = Datasets.update(dataset)
+      ingestion = Ingestions.create(dataset.id)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      select_source_format("application/json", view)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      json_sample = "[]"
+
+      html = render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "application/json", "file" => json_sample})
+      refute Enum.empty?(find_elements(html, "#schema_sample-error-msg"))
+    end
+
+    test "generates eligible parents list", %{conn: conn} do
+      dataset = TDG.create_dataset(%{})
+      {:ok, _} = Datasets.update(dataset)
+      ingestion = Ingestions.create(dataset.id)
+      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
+      select_source_format("application/json", view)
+      data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
+
+      json_sample = [%{list_field: [%{child_list_field: []}]}] |> Jason.encode!()
+
+      render_hook(data_dictionary_view, "file_upload", %{"fileSize" => 100, "fileType" => "application/json", "file" => json_sample})
+
+      updated_ingestion = Ingestions.get(ingestion.id)
+
+      generated_bread_crumbs =
+        updated_ingestion
+        |> DataDictionaryFields.get_parent_ids_from_ingestion()
+        |> Enum.map(fn {bread_crumb, _} -> bread_crumb end)
+
+      assert ["Top Level", "list_field", "list_field > child_list_field"] == generated_bread_crumbs
+    end
+  end
+
   defp create_ingestion_with_schema(schema) do
     dataset = TDG.create_dataset(%{})
     ingestion = TDG.create_ingestion(%{targetDataset: dataset.id, schema: schema})
@@ -907,5 +1154,17 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
     end)
 
     Ingestions.get(ingestion.id)
+  end
+
+  defp select_source_format(source_format, view) do
+    new_source_format = source_format
+
+    form_data = %{
+      "sourceFormat" => new_source_format
+    }
+
+    metadata_view = find_live_child(view, "ingestion_metadata_form_editor")
+    render_change(metadata_view, "validate", %{"form_data" => form_data})
+    render_change(view, "save")
   end
 end


### PR DESCRIPTION
## [Ticket Link #654](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/654)

## Description

- The user is able to upload a csv file when csv is selected as source format
- The user is able to upload a json file when json is selected as source format
- The contents of a user uploaded file are reflected in the data dictionary definition

![image](https://user-images.githubusercontent.com/73911735/173438729-93750f1f-2a72-4a3a-8e80-d92722bcda6f.png)

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
