### PR TITLE
Create Transformations Section on Ingestions Page

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -37,6 +37,10 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
             <%= live_render(@socket, AndiWeb.IngestionLiveView.DataDictionaryForm, id: :data_dictionary_form_editor, session: %{"ingestion" => @ingestion, "is_curator" => @is_curator, "order" => "2"}) %>
           </div>
 
+          <div class="transformations-form-component">
+            <%= live_render(@socket, AndiWeb.IngestionLiveView.TransformationsForm, id: :transformations_form_editor, session: %{"ingestion" => @ingestion, "order" => "3"}) %>
+          </div>
+
           <div class="finalize-form-component ">
             <%= live_render(@socket, AndiWeb.IngestionLiveView.FinalizeForm, id: :finalize_form_editor, session: %{"ingestion" => @ingestion, "order" => "4"}) %>
           </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations_form.ex
@@ -1,0 +1,67 @@
+defmodule AndiWeb.IngestionLiveView.TransformationsForm do
+  @moduledoc """
+  LiveComponent for editing dataset extract steps
+  """
+  use Phoenix.LiveView
+  require Logger
+
+  def mount(_params, %{"ingestion" => ingestion, "order" => order}, socket) do
+    AndiWeb.Endpoint.subscribe("form-save")
+
+    {:ok,
+     assign(socket,
+       visibility: "collapsed",
+       validation_status: "collapsed",
+       ingestion_id: ingestion.id,
+       order: order
+     )}
+  end
+
+  def render(assigns) do
+    action =
+      case assigns.visibility do
+        "collapsed" -> "EDIT"
+        "expanded" -> "MINIMIZE"
+      end
+
+    ~L"""
+    <div id="transformations-form" class="form-component">
+      <div class="component-header" phx-click="toggle-component-visibility" phx-value-component="transformations_form">
+        <div class="section-number">
+          <h3 class="component-number component-number--<%= @validation_status %>"><%= @order %></h3>
+          <div class="component-number-status--<%= @validation_status %>"></div>
+        </div>
+        <div class="component-title full-width">
+          <h2 class="component-title-text component-title-text--<%= @visibility %> ">Transformations</h2>
+          <div class="component-title-action">
+            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+            <div class="component-title-icon--<%= @visibility %>"></div>
+          </div>
+        </div>
+      </div>
+
+      <div id="transformations-form-section" class="form-section">
+        <div class="component-edit-section--<%= @visibility %>">
+
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def handle_info(%{topic: "form-save"}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("toggle-component-visibility", _, socket) do
+    current_visibility = Map.get(socket.assigns, :visibility)
+
+    new_visibility =
+      case current_visibility do
+        "expanded" -> "collapsed"
+        "collapsed" -> "expanded"
+      end
+
+    {:noreply, assign(socket, visibility: new_visibility)}
+  end
+end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.2.10",
+      version: "2.2.11",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations_test_form.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations_test_form.exs
@@ -1,0 +1,40 @@
+defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
+  use ExUnit.Case
+  use Placebo
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  alias Andi.InputSchemas.Ingestions
+  alias AndiWeb.IngestionLiveView.TransformationsForm
+  alias Andi.InputSchemas.Datasets
+
+  alias SmartCity.TestDataGenerator, as: TDG
+
+  @endpoint AndiWeb.Endpoint
+
+  describe "Transformations form" do
+    test "can be expanded and collapsed" do
+      ingestion = TDG.create_ingestion(%{name: "Original"})
+      allow Ingestions.get(ingestion.id), return: ingestion
+      allow Ingestions.update(ingestion, %{name: "Updated"}), return: {:ok, ingestion}
+      allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
+
+      assert {:ok, view, html} = live_isolated(build_conn(), TransformationsForm, session: %{"ingestion" => ingestion, "order" => "3"})
+
+      click_form_header(view)
+
+      assert element(view, ".component-edit-section--expanded") |> has_element?
+      refute element(view, ".component-edit-section--collapsed") |> has_element?
+
+      click_form_header(view)
+
+      assert element(view, ".component-edit-section--collapsed") |> has_element?
+      refute element(view, ".component-edit-section--expanded") |> has_element?
+    end
+  end
+
+  defp click_form_header(view) do
+    element(view, ".component-header") |> render_click()
+  end
+end


### PR DESCRIPTION
Datastillery/internal#747

co-authored-by: Benjamin Mitchinson <mitchinson.dev@gmail.com>

## [Ticket Link #747](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/747)

## Description

- A transformations section exists on the ingestions page that can be expanded and minimized. Its' contents are currently empty.

![image](https://user-images.githubusercontent.com/73911735/173637078-e4c0f4af-3b3d-4a60-8529-4735a858fd8f.png)

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?