### PR TITLE
744 transformations header

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -80,6 +80,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
 
   defp transformation_name(form) do
     name_field_value = input_value(form, :name)
+
     if(blank?(name_field_value)) do
       "Transformation"
     else

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -3,6 +3,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
   LiveComponent for editing an individual transformation
   """
   use Phoenix.LiveView
+  use Phoenix.LiveComponent
   require Logger
   import Phoenix.HTML.Form
 
@@ -25,11 +26,12 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
   def render(assigns) do
     ~L"""
 
-    <div class="transformation-header">
-      <p>Transformation</p>
-    </div>
+
 
     <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate, id: :transformation_form] %>
+      <div class="transformation-header">
+        <p> <%= transformation_name(f) %> </p>
+      </div>
     <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>
       <div class="transformation-form">
         <div class="transformation-form__name">
@@ -75,6 +77,17 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
 
     {:noreply, assign(socket, transformation_changeset: new_changeset)}
   end
+
+  defp transformation_name(form) do
+    name_field_value = input_value(form, :name)
+    if(blank?(name_field_value)) do
+      "Transformation"
+    else
+      name_field_value
+    end
+  end
+
+  defp blank?(str_or_nil), do: "" == str_or_nil |> to_string() |> String.trim()
 
   defp get_transformation_types(), do: map_to_dropdown_options(MetadataFormHelpers.get_transformation_type_options())
 

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.2.13",
+      version: "2.2.14",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -23,6 +23,19 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       assert element(view, "#name-error-msg") |> has_element?
     end
 
+    test "Header defaults to Transformation when transformation name is cleared from form" do
+      transformation_changeset = Transformation.changeset_for_draft(%{})
+      assert {:ok, view, html} = render_transformation_form(transformation_changeset)
+
+      form_update = %{
+        "name" => ""
+      }
+
+      element(view, "#transformation_form") |> render_change(form_update)
+
+      assert FlokiHelpers.get_text(html, ".transformation-header") == "Transformation"
+    end
+
     test "Shows errors for missing type field" do
       transformation_changeset = Transformation.changeset_for_draft(%{})
       assert {:ok, view, html} = render_transformation_form(transformation_changeset)

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_step_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_step_test.exs
@@ -55,11 +55,11 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStepTest do
     end
 
     test "add transformation displays transformation header by default", %{ingestion: ingestion} do
-      assert {:ok, view, _html} = live_isolated(build_conn(), TransformationsStep, session: %{"ingestion" => ingestion, "order" => "3"})
+      assert {:ok, view, html} = live_isolated(build_conn(), TransformationsStep, session: %{"ingestion" => ingestion, "order" => "3"})
 
       refute element(view, ".transformation-header") |> has_element?
 
-      click_add_transformation(view)
+      html = click_add_transformation(view)
 
       assert FlokiHelpers.get_text(html, ".transformation-header") == "Transformation"
     end

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_step_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_step_test.exs
@@ -66,8 +66,9 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStepTest do
 
     test "transformation header displays transformation name" do
       transformation_name = "This is the name that should appear"
-      ingestion = TDG.create_ingestion(
-        %{
+
+      ingestion =
+        TDG.create_ingestion(%{
           name: "Original",
           transformations: [
             %{
@@ -84,10 +85,8 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStepTest do
 
       assert {:ok, view, html} = live_isolated(build_conn(), TransformationsStep, session: %{"ingestion" => ingestion, "order" => "3"})
 
-
       assert element(view, ".transformation-header") |> has_element?
       assert FlokiHelpers.get_text(html, ".transformation-header") == transformation_name
-
     end
   end
 

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_step_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_step_test.exs
@@ -53,6 +53,42 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStepTest do
 
       assert Enum.count(find_elements(html, ".transformation-header")) == 2
     end
+
+    test "add transformation displays transformation header by default", %{ingestion: ingestion} do
+      assert {:ok, view, _html} = live_isolated(build_conn(), TransformationsStep, session: %{"ingestion" => ingestion, "order" => "3"})
+
+      refute element(view, ".transformation-header") |> has_element?
+
+      click_add_transformation(view)
+
+      assert FlokiHelpers.get_text(html, ".transformation-header") == "Transformation"
+    end
+
+    test "transformation header displays transformation name" do
+      transformation_name = "This is the name that should appear"
+      ingestion = TDG.create_ingestion(
+        %{
+          name: "Original",
+          transformations: [
+            %{
+              type: "concatenation",
+              name: transformation_name,
+              parameters: %{
+                "sourceFields" => ["other", "name"],
+                "separator" => ".",
+                "targetField" => "name"
+              }
+            }
+          ]
+        })
+
+      assert {:ok, view, html} = live_isolated(build_conn(), TransformationsStep, session: %{"ingestion" => ingestion, "order" => "3"})
+
+
+      assert element(view, ".transformation-header") |> has_element?
+      assert FlokiHelpers.get_text(html, ".transformation-header") == transformation_name
+
+    end
   end
 
   defp click_form_header(view) do


### PR DESCRIPTION
## [Ticket Link #744](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/744)

## Description

- Updating the name field on a transformation updates the text in the rectangle that represents it in step 3

![image](https://user-images.githubusercontent.com/73911735/176031176-c45b9130-4d25-439b-bdb0-8f83d2b0821b.png)


## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
