### PR TITLE
753 ignore events which reference non-existent dataset models

### DIFF
--- a/apps/discovery_api/lib/discovery_api/event/event_handler.ex
+++ b/apps/discovery_api/lib/discovery_api/event/event_handler.ex
@@ -135,6 +135,7 @@ defmodule DiscoveryApi.Event.EventHandler do
     |> add_event_count(author, relation.dataset_id)
 
     dataset_result = Brook.get(@instance_name, :models, relation.dataset_id)
+
     case dataset_result do
       {:ok, nil} -> :discard
       {:ok, dataset} -> handle_dataset_associate(dataset, relation)
@@ -211,9 +212,7 @@ defmodule DiscoveryApi.Event.EventHandler do
     Elasticsearch.Document.update(model)
 
     Logger.debug(fn ->
-      "Successfully handled dataset-access-group #{type} message: `Dataset: #{relation.dataset_id} Access Group: #{
-        relation.access_group_id
-      }`"
+      "Successfully handled dataset-access-group #{type} message: `Dataset: #{relation.dataset_id} Access Group: #{relation.access_group_id}`"
     end)
 
     merge(:models, model.id, model)

--- a/apps/discovery_api/lib/discovery_api/event/event_handler.ex
+++ b/apps/discovery_api/lib/discovery_api/event/event_handler.ex
@@ -199,26 +199,19 @@ defmodule DiscoveryApi.Event.EventHandler do
 
   defp handle_dataset_associate(dataset, relation) do
     model = Mapper.add_access_group(dataset, relation.access_group_id)
-    Elasticsearch.Document.update(model)
-
-    Logger.debug(fn ->
-      "Successfully handled dataset-access-group association message: `Dataset: #{relation.dataset_id} Access Group: #{
-        relation.access_group_id
-      }`"
-    end)
-
-    merge(:models, model.id, model)
-    clear_caches()
-
-    :discard
+    update_dataset_model_with_relation(model, relation, "association")
   end
 
   defp handle_dataset_dissociate(dataset, relation) do
     model = Mapper.remove_access_group(dataset, relation.access_group_id)
+    update_dataset_model_with_relation(model, relation, "disassociation")
+  end
+
+  defp update_dataset_model_with_relation(model, relation, type) do
     Elasticsearch.Document.update(model)
 
     Logger.debug(fn ->
-      "Successfully handled dataset-access-group disassociation message: `Dataset: #{relation.dataset_id} Access Group: #{
+      "Successfully handled dataset-access-group #{type} message: `Dataset: #{relation.dataset_id} Access Group: #{
         relation.access_group_id
       }`"
     end)

--- a/apps/discovery_api/lib/discovery_api/event/event_handler.ex
+++ b/apps/discovery_api/lib/discovery_api/event/event_handler.ex
@@ -172,27 +172,6 @@ defmodule DiscoveryApi.Event.EventHandler do
     end
   end
 
-  defp handle_dataset_dissociate(dataset, relation) do
-    model = Mapper.remove_access_group(dataset, relation.access_group_id)
-    Elasticsearch.Document.update(model)
-
-    Logger.debug(fn ->
-      "Successfully handled dataset-access-group disassociation message: `Dataset: #{relation.dataset_id} Access Group: #{
-        relation.access_group_id
-      }`"
-    end)
-
-    merge(:models, model.id, model)
-    clear_caches()
-
-    :discard
-  end
-
-  defp handle_dataset_error(relation, author, reason) do
-    Logger.error("Unable to process message `#{inspect(relation)}` from `#{inspect(author)}` : ERROR: #{inspect(reason)}")
-    :discard
-  end
-
   def handle_event(%Brook.Event{type: dataset_query(), data: dataset_id, author: author, create_ts: timestamp}) do
     dataset_query()
     |> add_event_count(author, dataset_id)
@@ -229,6 +208,27 @@ defmodule DiscoveryApi.Event.EventHandler do
     |> add_event_count(author, nil)
 
     create_user_if_not_exists(subject_id, email, name)
+  end
+
+  defp handle_dataset_dissociate(dataset, relation) do
+    model = Mapper.remove_access_group(dataset, relation.access_group_id)
+    Elasticsearch.Document.update(model)
+
+    Logger.debug(fn ->
+      "Successfully handled dataset-access-group disassociation message: `Dataset: #{relation.dataset_id} Access Group: #{
+        relation.access_group_id
+      }`"
+    end)
+
+    merge(:models, model.id, model)
+    clear_caches()
+
+    :discard
+  end
+
+  defp handle_dataset_error(relation, author, reason) do
+    Logger.error("Unable to process message `#{inspect(relation)}` from `#{inspect(author)}` : ERROR: #{inspect(reason)}")
+    :discard
   end
 
   defp create_user_if_not_exists(subject_id, email, name) do

--- a/apps/discovery_api/lib/discovery_api/event/event_handler.ex
+++ b/apps/discovery_api/lib/discovery_api/event/event_handler.ex
@@ -166,7 +166,7 @@ defmodule DiscoveryApi.Event.EventHandler do
     dataset_result = Brook.get(@instance_name, :models, relation.dataset_id)
 
     case dataset_result do
-      {:ok, nil} -> :discard
+      {:ok, nil} -> handle_dataset_error(relation, author, "Dataset model is nil")
       {:ok, dataset} -> handle_dataset_dissociate(dataset, relation)
       {:error, reason} -> handle_dataset_error(relation, author, reason)
     end

--- a/apps/discovery_api/lib/discovery_api/event/event_handler.ex
+++ b/apps/discovery_api/lib/discovery_api/event/event_handler.ex
@@ -163,6 +163,15 @@ defmodule DiscoveryApi.Event.EventHandler do
     dataset_access_group_disassociate()
     |> add_event_count(author, relation.dataset_id)
 
+    dataset_result = Brook.get(@instance_name, :models, relation.dataset_id)
+
+    case dataset_result do
+      {:ok, nil} -> :discard
+      {:ok, _} -> handle_non_nil_dataset(relation, author)
+    end
+  end
+
+  defp handle_non_nil_dataset(relation, author) do
     with {:ok, dataset} <- Brook.get(@instance_name, :models, relation.dataset_id),
          model <- Mapper.remove_access_group(dataset, relation.access_group_id) do
       Elasticsearch.Document.update(model)

--- a/apps/discovery_api/lib/discovery_api/event/event_handler.ex
+++ b/apps/discovery_api/lib/discovery_api/event/event_handler.ex
@@ -134,24 +134,11 @@ defmodule DiscoveryApi.Event.EventHandler do
     dataset_access_group_associate()
     |> add_event_count(author, relation.dataset_id)
 
-    with {:ok, dataset} <- Brook.get(@instance_name, :models, relation.dataset_id),
-         model <- Mapper.add_access_group(dataset, relation.access_group_id) do
-      Elasticsearch.Document.update(model)
-
-      Logger.debug(fn ->
-        "Successfully handled dataset-access-group association message: `Dataset: #{relation.dataset_id} Access Group: #{
-          relation.access_group_id
-        }`"
-      end)
-
-      merge(:models, model.id, model)
-      clear_caches()
-
-      :discard
-    else
-      {:error, reason} ->
-        Logger.error("Unable to process message `#{inspect(relation)}` from `#{inspect(author)}` : ERROR: #{inspect(reason)}")
-        :discard
+    dataset_result = Brook.get(@instance_name, :models, relation.dataset_id)
+    case dataset_result do
+      {:ok, nil} -> :discard
+      {:ok, dataset} -> handle_dataset_associate(dataset, relation)
+      {:error, reason} -> handle_dataset_error(relation, author, reason)
     end
   end
 
@@ -208,6 +195,22 @@ defmodule DiscoveryApi.Event.EventHandler do
     |> add_event_count(author, nil)
 
     create_user_if_not_exists(subject_id, email, name)
+  end
+
+  defp handle_dataset_associate(dataset, relation) do
+    model = Mapper.add_access_group(dataset, relation.access_group_id)
+    Elasticsearch.Document.update(model)
+
+    Logger.debug(fn ->
+      "Successfully handled dataset-access-group association message: `Dataset: #{relation.dataset_id} Access Group: #{
+        relation.access_group_id
+      }`"
+    end)
+
+    merge(:models, model.id, model)
+    clear_caches()
+
+    :discard
   end
 
   defp handle_dataset_dissociate(dataset, relation) do

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.2.16",
+      version: "1.2.17",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/test/unit/discovery_api/event/event_handler_test.exs
+++ b/apps/discovery_api/test/unit/discovery_api/event/event_handler_test.exs
@@ -183,6 +183,18 @@ defmodule DiscoveryApi.Event.EventHandlerTest do
     end
   end
 
+  describe "handle_event/1 #{dataset_access_group_disassociate()} error" do
+    test "is ignored if dataset model missing" do
+      allow(Brook.get(any(), any(), any()), return: {:ok, nil})
+      {:ok, relation} = SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: "id_for_missing_dataset", access_group_id: "some_access_group"})
+      event = Brook.Event.new(type: dataset_access_group_disassociate(), data: relation, author: :author)
+
+      result = EventHandler.handle_event(event)
+
+      assert :discard == result
+    end
+  end
+
   describe "handle_event/1 #{dataset_delete()}" do
     setup do
       expect(TelemetryEvent.add_event_metrics(any(), [:events_handled]), return: :ok)

--- a/apps/discovery_api/test/unit/discovery_api/event/event_handler_test.exs
+++ b/apps/discovery_api/test/unit/discovery_api/event/event_handler_test.exs
@@ -160,7 +160,10 @@ defmodule DiscoveryApi.Event.EventHandlerTest do
   describe "handle_event/1 #{dataset_access_group_associate()} error" do
     test "is ignored if dataset model missing" do
       allow(Brook.get(any(), any(), any()), return: {:ok, nil})
-      {:ok, relation} = SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: "id_for_missing_dataset", access_group_id: "some_access_group"})
+
+      {:ok, relation} =
+        SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: "id_for_missing_dataset", access_group_id: "some_access_group"})
+
       event = Brook.Event.new(type: dataset_access_group_associate(), data: relation, author: :author)
 
       result = EventHandler.handle_event(event)
@@ -198,7 +201,10 @@ defmodule DiscoveryApi.Event.EventHandlerTest do
   describe "handle_event/1 #{dataset_access_group_disassociate()} error" do
     test "is ignored if dataset model missing" do
       allow(Brook.get(any(), any(), any()), return: {:ok, nil})
-      {:ok, relation} = SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: "id_for_missing_dataset", access_group_id: "some_access_group"})
+
+      {:ok, relation} =
+        SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: "id_for_missing_dataset", access_group_id: "some_access_group"})
+
       event = Brook.Event.new(type: dataset_access_group_disassociate(), data: relation, author: :author)
 
       result = EventHandler.handle_event(event)

--- a/apps/discovery_api/test/unit/discovery_api/event/event_handler_test.exs
+++ b/apps/discovery_api/test/unit/discovery_api/event/event_handler_test.exs
@@ -157,6 +157,18 @@ defmodule DiscoveryApi.Event.EventHandlerTest do
     end
   end
 
+  describe "handle_event/1 #{dataset_access_group_associate()} error" do
+    test "is ignored if dataset model missing" do
+      allow(Brook.get(any(), any(), any()), return: {:ok, nil})
+      {:ok, relation} = SmartCity.DatasetAccessGroupRelation.new(%{dataset_id: "id_for_missing_dataset", access_group_id: "some_access_group"})
+      event = Brook.Event.new(type: dataset_access_group_associate(), data: relation, author: :author)
+
+      result = EventHandler.handle_event(event)
+
+      assert :discard == result
+    end
+  end
+
   describe "handle_event/1 #{dataset_access_group_disassociate()}" do
     setup do
       model_without_group = Helper.sample_model()

--- a/apps/discovery_api/test/unit/test_helper.exs
+++ b/apps/discovery_api/test/unit/test_helper.exs
@@ -1,2 +1,2 @@
-ExUnit.start(exclude: [:skip])
+ExUnit.start(exclude: [:skip], capture_log: true)
 Faker.start()


### PR DESCRIPTION
## [Ticket Link #759](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/759)

## Description

Fixing an issue where discovery api would fail to process an associate or disassociate event if the dataset model was missing, and then would not process further events.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
