### PR TITLE
Skip Actions on Draft PRs

### DIFF
--- a/.github/workflows/alchemist.yml
+++ b/.github/workflows/alchemist.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/alchemist.yml
+++ b/.github/workflows/alchemist.yml
@@ -7,6 +7,7 @@ on:
       - "apps/alchemist/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/andi.yml
+++ b/.github/workflows/andi.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/andi/**'
-    - 'mix.lock'
+      - "apps/andi/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/andi/**'
-    - 'mix.lock'
+      - "apps/andi/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/andi.yml
+++ b/.github/workflows/andi.yml
@@ -7,6 +7,7 @@ on:
       - "apps/andi/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/annotated_retry.yml
+++ b/.github/workflows/annotated_retry.yml
@@ -7,6 +7,7 @@ on:
       - "apps/annotated_retry/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/annotated_retry.yml
+++ b/.github/workflows/annotated_retry.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/annotated_retry/**'
-    - 'mix.lock'
+      - "apps/annotated_retry/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/annotated_retry/**'
-    - 'mix.lock'
+      - "apps/annotated_retry/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/auth/**'
-    - 'mix.lock'
+      - "apps/auth/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/auth/**'
-    - 'mix.lock'
+      - "apps/auth/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -7,6 +7,7 @@ on:
       - "apps/auth/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/dead_letter.yml
+++ b/.github/workflows/dead_letter.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/dead_letter/**'
-    - 'mix.lock'
+      - "apps/dead_letter/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/dead_letter/**'
-    - 'mix.lock'
+      - "apps/dead_letter/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dead_letter.yml
+++ b/.github/workflows/dead_letter.yml
@@ -7,6 +7,7 @@ on:
       - "apps/dead_letter/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/definition.yml
+++ b/.github/workflows/definition.yml
@@ -7,6 +7,7 @@ on:
       - "apps/definition/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/definition.yml
+++ b/.github/workflows/definition.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/definition/**'
-    - 'mix.lock'
+      - "apps/definition/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/definition/**'
-    - 'mix.lock'
+      - "apps/definition/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/definition_deadletter.yml
+++ b/.github/workflows/definition_deadletter.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/definition_deadletter/**'
-    - 'mix.lock'
+      - "apps/definition_deadletter/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/definition_deadletter/**'
-    - 'mix.lock'
+      - "apps/definition_deadletter/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/definition_deadletter.yml
+++ b/.github/workflows/definition_deadletter.yml
@@ -7,6 +7,7 @@ on:
       - "apps/definition_deadletter/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/definition_kafka.yml
+++ b/.github/workflows/definition_kafka.yml
@@ -7,6 +7,7 @@ on:
       - "apps/definition_kafka/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/definition_kafka.yml
+++ b/.github/workflows/definition_kafka.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/definition_kafka/**'
-    - 'mix.lock'
+      - "apps/definition_kafka/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/definition_kafka/**'
-    - 'mix.lock'
+      - "apps/definition_kafka/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/discovery_api.yml
+++ b/.github/workflows/discovery_api.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/discovery_api/**'
-    - 'mix.lock'
+      - "apps/discovery_api/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/discovery_api/**'
-    - 'mix.lock'
+      - "apps/discovery_api/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +30,7 @@ jobs:
           experimental-otp: true
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '10'
+          node-version: "10"
       - name: Get dependencies
         run: |
           bash scripts/gh-action-get-deps.sh

--- a/.github/workflows/discovery_api.yml
+++ b/.github/workflows/discovery_api.yml
@@ -7,6 +7,7 @@ on:
       - "apps/discovery_api/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/discovery_streams.yml
+++ b/.github/workflows/discovery_streams.yml
@@ -7,6 +7,7 @@ on:
       - "apps/discovery_streams/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/discovery_streams.yml
+++ b/.github/workflows/discovery_streams.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/discovery_streams/**'
-    - 'mix.lock'
+      - "apps/discovery_streams/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/discovery_streams/**'
-    - 'mix.lock'
+      - "apps/discovery_streams/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dlq.yml
+++ b/.github/workflows/dlq.yml
@@ -7,6 +7,7 @@ on:
       - "apps/dlq/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/dlq.yml
+++ b/.github/workflows/dlq.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/dlq/**'
-    - 'mix.lock'
+      - "apps/dlq/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/dlq/**'
-    - 'mix.lock'
+      - "apps/dlq/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/estuary.yml
+++ b/.github/workflows/estuary.yml
@@ -7,6 +7,7 @@ on:
       - "apps/estuary/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/estuary.yml
+++ b/.github/workflows/estuary.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/estuary/**'
-    - 'mix.lock'
+      - "apps/estuary/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/estuary/**'
-    - 'mix.lock'
+      - "apps/estuary/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/flair.yml
+++ b/.github/workflows/flair.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/flair/**'
-    - 'mix.lock'
+      - "apps/flair/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/flair/**'
-    - 'mix.lock'
+      - "apps/flair/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/flair.yml
+++ b/.github/workflows/flair.yml
@@ -7,6 +7,7 @@ on:
       - "apps/flair/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/forklift.yml
+++ b/.github/workflows/forklift.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/forklift/**'
-    - 'mix.lock'
+      - "apps/forklift/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/forklift/**'
-    - 'mix.lock'
+      - "apps/forklift/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/forklift.yml
+++ b/.github/workflows/forklift.yml
@@ -7,6 +7,7 @@ on:
       - "apps/forklift/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/initializer.yml
+++ b/.github/workflows/initializer.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/initializer/**'
-    - 'mix.lock'
+      - "apps/initializer/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/initializer/**'
-    - 'mix.lock'
+      - "apps/initializer/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/initializer.yml
+++ b/.github/workflows/initializer.yml
@@ -7,6 +7,7 @@ on:
       - "apps/initializer/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/management.yml
+++ b/.github/workflows/management.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/management/**'
-    - 'mix.lock'
+      - "apps/management/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/management/**'
-    - 'mix.lock'
+      - "apps/management/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/management.yml
+++ b/.github/workflows/management.yml
@@ -7,6 +7,7 @@ on:
       - "apps/management/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/ok.yml
+++ b/.github/workflows/ok.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/ok/**'
-    - 'mix.lock'
+      - "apps/ok/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/ok/**'
-    - 'mix.lock'
+      - "apps/ok/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ok.yml
+++ b/.github/workflows/ok.yml
@@ -7,6 +7,7 @@ on:
       - "apps/ok/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,6 +7,7 @@ on:
       - "apps/pipeline/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/pipeline/**'
-    - 'mix.lock'
+      - "apps/pipeline/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/pipeline/**'
-    - 'mix.lock'
+      - "apps/pipeline/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:
@@ -33,4 +34,3 @@ jobs:
       - name: Run integration tests
         run: |
           bash scripts/gh-action-integration-test.sh ${GITHUB_WORKFLOW}
-

--- a/.github/workflows/protocol_source.yml
+++ b/.github/workflows/protocol_source.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/protocol_source/**'
-    - 'mix.lock'
+      - "apps/protocol_source/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/protocol_source/**'
-    - 'mix.lock'
+      - "apps/protocol_source/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/protocol_source.yml
+++ b/.github/workflows/protocol_source.yml
@@ -7,6 +7,7 @@ on:
       - "apps/protocol_source/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/providers.yml
+++ b/.github/workflows/providers.yml
@@ -7,6 +7,7 @@ on:
       - "apps/providers/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/providers.yml
+++ b/.github/workflows/providers.yml
@@ -4,17 +4,18 @@ on:
     branches:
       - master
     paths:
-    - 'apps/providers/**'
-    - 'mix.lock'
+      - "apps/providers/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/providers/**'
-    - 'mix.lock'
+      - "apps/providers/**"
+      - "mix.lock"
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/raptor.yml
+++ b/.github/workflows/raptor.yml
@@ -7,6 +7,7 @@ on:
       - "apps/raptor/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/raptor.yml
+++ b/.github/workflows/raptor.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/raptor/**'
-    - 'mix.lock'
+      - "apps/raptor/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/raptor/**'
-    - 'mix.lock'
+      - "apps/raptor/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -7,6 +7,7 @@ on:
       - "apps/reaper/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/reaper/**'
-    - 'mix.lock'
+      - "apps/reaper/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/reaper/**'
-    - 'mix.lock'
+      - "apps/reaper/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/transformers.yml
+++ b/.github/workflows/transformers.yml
@@ -7,6 +7,7 @@ on:
       - "apps/transformers/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/transformers.yml
+++ b/.github/workflows/transformers.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/valkyrie.yml
+++ b/.github/workflows/valkyrie.yml
@@ -4,20 +4,21 @@ on:
     branches:
       - master
     paths:
-    - 'apps/valkyrie/**'
-    - 'mix.lock'
+      - "apps/valkyrie/**"
+      - "mix.lock"
   pull_request:
     branches:
       - master
     paths:
-    - 'apps/valkyrie/**'
-    - 'mix.lock'
+      - "apps/valkyrie/**"
+      - "mix.lock"
   workflow_dispatch:
     branches:
       - master
 
 jobs:
   ci:
+    if: github.event.pull_request.draft == false
     name: Verify Application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/valkyrie.yml
+++ b/.github/workflows/valkyrie.yml
@@ -7,6 +7,7 @@ on:
       - "apps/valkyrie/**"
       - "mix.lock"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
     paths:

--- a/.github/workflows/version_checker.yml
+++ b/.github/workflows/version_checker.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   check-apps-for-update:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/version_checker.yml
+++ b/.github/workflows/version_checker.yml
@@ -1,5 +1,7 @@
 name: version_checker
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   check-apps-for-update:


### PR DESCRIPTION
## Description

- Skip actions from running on PRs in a draft state
- Ensure that actions are triggered to run when a PR exits draft state

## Reminders:

- NA: If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- NA: If altering an API endpoint, was the relevant postman collection updated?
  - NA: If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?

### Screenshots

This PR was a draft, actions didn't run, when marked as non draft (ready for review), actions were triggered

| draft state | exiting draft state |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33632286/179822675-fd8267ae-8f99-429e-bf89-c22d050f06e1.png) | ![image](https://user-images.githubusercontent.com/33632286/179822727-fc27d753-368b-4708-b56a-1c23e45738de.png) |
 