### PR TITLE
Upgrading to use build image which uses latest alpine keys

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.3.4.19
-elixir 1.10.4-otp-22
+erlang 23.2.7.5
+elixir 1.10.4-otp-23

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir:1.13.4
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ARG app_name
 COPY . /app
 WORKDIR /app

--- a/apps/alchemist/Dockerfile
+++ b/apps/alchemist/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name alchemist
 
-FROM bitwalker/alpine-elixir:1.10.4
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk upgrade \
   && apk add --no-cache bash openssl \

--- a/apps/andi/Dockerfile
+++ b/apps/andi/Dockerfile
@@ -8,7 +8,6 @@ RUN cd apps/andi/assets/ && \
 RUN MIX_ENV=prod mix distillery.release --name andi
 
 FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
-WORKDIR ${HOME}
 ENV REPLACE_OS_VARS=true
 ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt
 RUN apk update && \

--- a/apps/andi/Dockerfile
+++ b/apps/andi/Dockerfile
@@ -7,7 +7,7 @@ RUN cd apps/andi/assets/ && \
     mix cmd --app andi mix do compile, phx.digest
 RUN MIX_ENV=prod mix distillery.release --name andi
 
-FROM bitwalker/alpine-elixir:1.13.3
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 WORKDIR ${HOME}
 ENV REPLACE_OS_VARS=true
 ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt

--- a/apps/discovery_api/Dockerfile
+++ b/apps/discovery_api/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name discovery_api
 
-FROM bitwalker/alpine-elixir:1.13.3
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt
 RUN apk update && \

--- a/apps/discovery_streams/Dockerfile
+++ b/apps/discovery_streams/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name discovery_streams
 
-FROM bitwalker/alpine-elixir:1.10.4
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk upgrade && \
     apk add --no-cache bash openssl && \

--- a/apps/estuary/Dockerfile
+++ b/apps/estuary/Dockerfile
@@ -7,7 +7,7 @@ RUN cd apps/estuary/assets/ && \
     mix cmd --app estuary mix do compile, phx.digest
 RUN MIX_ENV=prod mix distillery.release --name estuary
 
-FROM bitwalker/alpine-elixir:1.10.4
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk upgrade \
   && apk add --no-cache bash openssl \

--- a/apps/flair/Dockerfile
+++ b/apps/flair/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name flair
 
-FROM alpine:3.9
+FROM alpine:3.16
 ENV REPLACE_OS_VARS=true
 RUN apk update && \
     apk add --no-cache bash openssl && \

--- a/apps/forklift/Dockerfile
+++ b/apps/forklift/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name forklift
 
-FROM bitwalker/alpine-elixir:1.10.4
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk upgrade \
   && apk add --no-cache bash openssl \

--- a/apps/raptor/Dockerfile
+++ b/apps/raptor/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name raptor
 
-FROM bitwalker/alpine-elixir:1.13.3
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk update && \
     apk add --no-cache bash openssl && \

--- a/apps/reaper/Dockerfile
+++ b/apps/reaper/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name reaper
 
-FROM bitwalker/alpine-elixir:1.13.3
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk upgrade \
   && apk add --no-cache bash openssl \

--- a/apps/valkyrie/Dockerfile
+++ b/apps/valkyrie/Dockerfile
@@ -1,7 +1,7 @@
 FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name valkyrie
 
-FROM bitwalker/alpine-elixir:1.10.4
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
 ENV REPLACE_OS_VARS=true
 RUN apk upgrade \
   && apk add --no-cache bash openssl \


### PR DESCRIPTION
## [Ticket Link #778](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/778)

## Description

All docker builds are broken because alpine changed its signing keys, and we're using a base image which has the old keys. Swapping to use the official hex images for elixir 1.10.4, erlang 23, and alpine 3.16.