### PR TITLE
Animations in Transformation Page

### DIFF
--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -36,14 +36,16 @@
 }
 
 .transformation-item {
-  animation: pulse 5s infinite;
+  animation: open .3;
 }
 
-@keyframes pulse {
-  0% {
-    background-color: #001F3F;
-  }
-  100% {
-    background-color: #FF4136;
-  }
+  @keyframes open {
+    from {
+      max-height: 0;
+      opacity: 0%
+    }
+    to {
+      max-height: 277px;
+      opacity: 100%
+    }
 }

--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -34,3 +34,16 @@
 .transformation-form__type {
   margin-top: 1rem;
 }
+
+.transformation-item {
+  animation: pulse 5s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-color: #001F3F;
+  }
+  100% {
+    background-color: #FF4136;
+  }
+}

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -26,28 +26,30 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
   def render(assigns) do
     ~L"""
 
-    <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate, id: :transformation_form] %>
-      <div class="transformation-header">
-        <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
-        <div class="transformation-edit-buttons">
-          <span class="material-icons move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1">arrow_upward</span>
-          <span class="material-icons move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1">arrow_downward</span>
+    <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate] %>
+     <div class="transformation-item">
+        <div class="transformation-header">
+          <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
+          <div class="transformation-edit-buttons">
+            <span class="material-icons move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1">arrow_upward</span>
+            <span class="material-icons move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1">arrow_downward</span>
+          </div>
+        </div>
+        <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>
+        <div class="transformation-form">
+          <div class="transformation-form__name">
+            <%= label(f, :name, "Name", class: "label label--required") %>
+            <%= text_input(f, :name, class: "transformation-name input transformation-form-fields", phx_debounce: "1000") %>
+            <%= ErrorHelpers.error_tag(f.source, :name, bind_to_input: false) %>
+          </div>
+
+          <div class="transformation-form__type">
+            <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required") %>
+            <%= select(f, :type, get_transformation_types(), [class: "select"]) %>
+            <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
+          </div>
         </div>
       </div>
-    <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>
-      <div class="transformation-form">
-        <div class="transformation-form__name">
-          <%= label(f, :name, "Name", class: "label label--required") %>
-          <%= text_input(f, :name, class: "transformation-name input transformation-form-fields", phx_debounce: "1000") %>
-          <%= ErrorHelpers.error_tag(f.source, :name, bind_to_input: false) %>
-        </div>
-
-        <div class="transformation-form__type">
-          <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required") %>
-          <%= select(f, :type, get_transformation_types(), [class: "select"]) %>
-          <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
-        </div>
-    </div>
     </form>
     """
   end

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -17,7 +17,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       form_update = %{
         "name" => "   "
       }
-
+# to do: use class name sector
       element(view, "#transformation_form") |> render_change(form_update)
 
       assert element(view, "#name-error-msg") |> has_element?


### PR DESCRIPTION
## [Ticket Link #758](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/758)

## TODO:
- [ ] Ensure animations are disabled [for clients with "reduced motion" set](https://css-tricks.com/a-handy-little-system-for-animated-entrances-in-css/#aa-respecting-accessibility-preferences)

## Description

- High level overview of changes
- ...

## Reminders:

- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
