### PR TITLE
780 animate new transformation

### DIFF
--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -36,14 +36,16 @@
 }
 
 .transformation-item {
-  animation: pulse 5s infinite;
+  animation: open .3;
 }
 
-@keyframes pulse {
-  0% {
-    background-color: #001F3F;
-  }
-  100% {
-    background-color: #FF4136;
-  }
+  @keyframes open {
+    from {
+      max-height: 0;
+      opacity: 0%
+    }
+    to {
+      max-height: 277px;
+      opacity: 100%
+    }
 }

--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -34,3 +34,16 @@
 .transformation-form__type {
   margin-top: 1rem;
 }
+
+.transformation-item {
+  animation: pulse 5s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-color: #001F3F;
+  }
+  100% {
+    background-color: #FF4136;
+  }
+}

--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -39,13 +39,17 @@
   animation: open .3;
 }
 
-  @keyframes open {
-    from {
-      max-height: 0;
-      opacity: 0%
-    }
-    to {
-      max-height: 277px;
-      opacity: 100%
-    }
+@keyframes open {
+  from {
+    max-height: 0;
+    opacity: 0%
+  }
+  to {
+    max-height: 277px;
+    opacity: 100%
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .transformation-item { animation: none !important; }
 }

--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -36,7 +36,7 @@
 }
 
 .transformation-item {
-  animation: open .3;
+  animation: open 300ms;
 }
 
 @keyframes open {

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -26,8 +26,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
   def render(assigns) do
     ~L"""
 
-    <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate] %>
-     <div class="transformation-item">
+    <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate, class: "transformation-item"] %>
         <div class="transformation-header">
           <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
           <div class="transformation-edit-buttons">
@@ -49,7 +48,6 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
             <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
           </div>
         </div>
-      </div>
     </form>
     """
   end

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -26,28 +26,30 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
   def render(assigns) do
     ~L"""
 
-    <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate, id: :transformation_form] %>
-      <div class="transformation-header">
-        <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
-        <div class="transformation-edit-buttons">
-          <span class="material-icons move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1">arrow_upward</span>
-          <span class="material-icons move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1">arrow_downward</span>
+    <%= f = form_for @transformation_changeset, "#", [ as: :form_data, phx_change: :validate] %>
+     <div class="transformation-item">
+        <div class="transformation-header">
+          <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
+          <div class="transformation-edit-buttons">
+            <span class="material-icons move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1">arrow_upward</span>
+            <span class="material-icons move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1">arrow_downward</span>
+          </div>
+        </div>
+        <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>
+        <div class="transformation-form">
+          <div class="transformation-form__name">
+            <%= label(f, :name, "Name", class: "label label--required") %>
+            <%= text_input(f, :name, class: "transformation-name input transformation-form-fields", phx_debounce: "1000") %>
+            <%= ErrorHelpers.error_tag(f.source, :name, bind_to_input: false) %>
+          </div>
+
+          <div class="transformation-form__type">
+            <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required") %>
+            <%= select(f, :type, get_transformation_types(), [class: "select"]) %>
+            <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
+          </div>
         </div>
       </div>
-    <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>
-      <div class="transformation-form">
-        <div class="transformation-form__name">
-          <%= label(f, :name, "Name", class: "label label--required") %>
-          <%= text_input(f, :name, class: "transformation-name input transformation-form-fields", phx_debounce: "1000") %>
-          <%= ErrorHelpers.error_tag(f.source, :name, bind_to_input: false) %>
-        </div>
-
-        <div class="transformation-form__type">
-          <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required") %>
-          <%= select(f, :type, get_transformation_types(), [class: "select"]) %>
-          <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
-        </div>
-    </div>
     </form>
     """
   end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.2.19",
+      version: "2.2.20",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -17,7 +17,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       form_update = %{
         "name" => "   "
       }
-
+# to do: use class name sector
       element(view, "#transformation_form") |> render_change(form_update)
 
       assert element(view, "#name-error-msg") |> has_element?

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -17,8 +17,8 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       form_update = %{
         "name" => "   "
       }
-# to do: use class name sector
-      element(view, "#transformation_form") |> render_change(form_update)
+
+      element(view, ".transformation-item") |> render_change(form_update)
 
       assert element(view, "#name-error-msg") |> has_element?
     end
@@ -31,7 +31,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
         "name" => ""
       }
 
-      element(view, "#transformation_form") |> render_change(form_update)
+      element(view, ".transformation-item") |> render_change(form_update)
 
       assert FlokiHelpers.get_text(html, ".transformation-header") =~ "New Transformation"
     end
@@ -44,7 +44,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
         "type" => ""
       }
 
-      element(view, "#transformation_form") |> render_change(form_update)
+      element(view, ".transformation-item") |> render_change(form_update)
 
       assert element(view, "#type-error-msg") |> has_element?
     end


### PR DESCRIPTION
## [Ticket Link #780](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/780)

## Description

- Adds animation to new transformations when added
- [Video of animation](https://user-images.githubusercontent.com/33632286/180857567-c9aab3b3-d22a-47f8-81d6-87528e94844d.mp4) 9.3MB

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- NA: If altering an API endpoint, was the relevant postman collection updated?
  - NA: If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?



