### PR TITLE
Adding a workdir back to fix docker startup error

### DIFF
--- a/apps/andi/Dockerfile
+++ b/apps/andi/Dockerfile
@@ -8,6 +8,7 @@ RUN cd apps/andi/assets/ && \
 RUN MIX_ENV=prod mix distillery.release --name andi
 
 FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
+WORKDIR /opt/app
 ENV REPLACE_OS_VARS=true
 ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt
 RUN apk update && \


### PR DESCRIPTION
## [Ticket Link #778](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/778)

## Description

Putting something down for home workdir in docker file

