### PR TITLE
Updating home and permissions for reaper

### DIFF
--- a/apps/reaper/Dockerfile
+++ b/apps/reaper/Dockerfile
@@ -2,8 +2,12 @@ FROM smartcitiesdata:build as builder
 RUN MIX_ENV=prod mix distillery.release --name reaper
 
 FROM hexpm/elixir:1.10.4-erlang-23.2.7.5-alpine-3.16.0
+ENV HOME /opt/app
 ENV REPLACE_OS_VARS=true
-RUN apk upgrade \
+WORKDIR ${HOME}
+RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
+  chown -R 1001:0 "${HOME}" && \
+  apk upgrade \
   && apk add --no-cache bash openssl \
   && rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/reaper/ .


### PR DESCRIPTION
## Description

Specifically setting reaper's HOME variable and changing permissions for that directory. This is because with the new base image the default user is no longer root and HOME is not set.