### PR TITLE
Add missing task args back to forklift jobs

### DIFF
--- a/apps/forklift/README.md
+++ b/apps/forklift/README.md
@@ -34,12 +34,10 @@ An application for reading data off kafka topics, batching it up and sending it 
 Compaction is a process that runs that consolidates the data that is being stored in Presto.  This process greatly improves read performance.
 ```elixir
 # Deactive Compaction
-Forklift.Quantum.Scheduler.deactivate_job(:compactor)
 Forklift.Quantum.Scheduler.deactivate_job(:data_migrator)
 Forklift.Quantum.Scheduler.deactivate_job(:partitioned_compactor)
 
 # Active Compaction
-Forklift.Quantum.Scheduler.activate_job(:compactor)
 Forklift.Quantum.Scheduler.activate_job(:data_migrator)
 Forklift.Quantum.Scheduler.activate_job(:partitioned_compactor)
 ```

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.17.27",
+      version: "0.17.28",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/runtime.exs
+++ b/apps/forklift/runtime.exs
@@ -136,12 +136,12 @@ if System.get_env("COMPACTION_SCHEDULE") do
     jobs: [
       data_migrator: [
         schedule: System.get_env("COMPACTION_SCHEDULE"),
-        task: {Forklift.Jobs.DataMigration, :run},
+        task: {Forklift.Jobs.DataMigration, :run, []},
         timezone: "America/New_York"
       ],
       partitioned_compactor: [
         schedule: "45 0 * * *",
-        task: {Forklift.Jobs.PartitionedCompaction, :run},
+        task: {Forklift.Jobs.PartitionedCompaction, :run, []},
         timezone: "America/New_York"
       ]
     ]


### PR DESCRIPTION
## Description

- Adds missing task args back to forklift jobs. 
  - Had removed `[]` previously.

## Reminders:

- [X] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- NA: If altering an API endpoint, was the relevant postman collection updated?
  - NA: If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
