### PR TITLE
Attempting to fix flaky move transformation test

### DIFF
--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/move_buttons_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/move_buttons_test.exs
@@ -8,6 +8,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.MoveButtonsTest do
   @moduletag shared_data_connection: true
 
   import Phoenix.LiveViewTest
+  import SmartCity.TestHelper, only: [eventually: 1]
 
   alias Andi.InputSchemas.Ingestions
   alias Andi.InputSchemas.Ingestions.Transformations
@@ -80,9 +81,10 @@ defmodule AndiWeb.IngestionLiveView.Transformations.MoveButtonsTest do
 
     save(view)
 
-    {:ok, _, refreshed_html} = navigate_to_edit_page(conn, ingestion)
-
-    assert ["Blue", "Black", "Green"] == find_ordered_names(refreshed_html)
+    eventually fn ->
+      {:ok, _, refreshed_html} = navigate_to_edit_page(conn, ingestion)
+      assert ["Blue", "Black", "Green"] == find_ordered_names(refreshed_html)
+    end
   end
 
   test "cancelling with unsaved move changes prompts confirmation", %{conn: conn, view: view, html: html, ingestion: ingestion} do

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/move_buttons_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/move_buttons_test.exs
@@ -81,10 +81,10 @@ defmodule AndiWeb.IngestionLiveView.Transformations.MoveButtonsTest do
 
     save(view)
 
-    eventually fn ->
+    eventually(fn ->
       {:ok, _, refreshed_html} = navigate_to_edit_page(conn, ingestion)
       assert ["Blue", "Black", "Green"] == find_ordered_names(refreshed_html)
-    end
+    end)
   end
 
   test "cancelling with unsaved move changes prompts confirmation", %{conn: conn, view: view, html: html, ingestion: ingestion} do


### PR DESCRIPTION
## Description

One of the move button tests for transformations sporadically fails. I hypothesize that it's because sometimes the save doesn't fully finish before the view is refreshed and checked for the updated transformation order. If that's correct, this should reduce or eliminate the flakiness.