### PR TITLE
Remove andi warnings

### DIFF
--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -15,18 +15,12 @@ defmodule Andi.Event.EventHandler do
       dataset_harvest_end: 0,
       user_login: 0,
       ingestion_update: 0,
-      ingestion_delete: 0,
-      dataset_access_group_associate: 0,
-      dataset_access_group_disassociate: 0,
-      user_access_group_associate: 0,
-      user_access_group_disassociate: 0
+      ingestion_delete: 0
     ]
 
   alias SmartCity.{Dataset, Organization, Ingestion}
   alias SmartCity.UserOrganizationAssociate
   alias SmartCity.UserOrganizationDisassociate
-  alias SmartCity.DatasetAccessGroupRelation
-  alias SmartCity.UserAccessGroupRelation
 
   alias Andi.Services.DatasetStore
   alias Andi.Services.OrgStore
@@ -86,7 +80,7 @@ defmodule Andi.Event.EventHandler do
 
   def handle_event(%Brook.Event{
         type: user_organization_associate(),
-        data: %UserOrganizationAssociate{subject_id: subject_id, org_id: org_id, email: email},
+        data: %UserOrganizationAssociate{subject_id: subject_id, org_id: org_id, email: _email},
         author: author
       }) do
     user_organization_associate()
@@ -104,7 +98,7 @@ defmodule Andi.Event.EventHandler do
   end
 
   def handle_event(
-        %Brook.Event{type: user_organization_disassociate(), data: %UserOrganizationDisassociate{} = disassociation, author: author} = event
+        %Brook.Event{type: user_organization_disassociate(), data: %UserOrganizationDisassociate{} = disassociation, author: author} = _event
       ) do
     user_organization_disassociate()
     |> add_event_count(author, nil)
@@ -181,9 +175,6 @@ defmodule Andi.Event.EventHandler do
         :ok
     end
   end
-
-  defp add_to_set(nil, id), do: MapSet.new([id])
-  defp add_to_set(set, id), do: MapSet.put(set, id)
 
   defp add_event_count(event_type, author, dataset_id) do
     [

--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -98,7 +98,8 @@ defmodule Andi.Event.EventHandler do
   end
 
   def handle_event(
-        %Brook.Event{type: user_organization_disassociate(), data: %UserOrganizationDisassociate{} = disassociation, author: author} = _event
+        %Brook.Event{type: user_organization_disassociate(), data: %UserOrganizationDisassociate{} = disassociation, author: author} =
+          _event
       ) do
     user_organization_disassociate()
     |> add_event_count(author, nil)

--- a/apps/andi/lib/andi/input_schemas/access_groups.ex
+++ b/apps/andi/lib/andi/input_schemas/access_groups.ex
@@ -6,8 +6,6 @@ defmodule Andi.InputSchemas.AccessGroups do
   alias Andi.InputSchemas.AccessGroup
   alias Andi.InputSchemas.StructTools
 
-  import Ecto.Query, only: [from: 2]
-
   require Logger
 
   def get(id), do: Repo.get(AccessGroup, id)

--- a/apps/andi/lib/andi/input_schemas/data_dictionary_fields.ex
+++ b/apps/andi/lib/andi/input_schemas/data_dictionary_fields.ex
@@ -109,7 +109,7 @@ defmodule Andi.InputSchemas.DataDictionaryFields do
   defp adjust_parent_details_for_ingestion(field, parent_bread_crumb) do
     case parent_bread_crumb do
       @top_level_bread_crumb ->
-        {id, field} = Map.pop(field, :parent_id)
+        {_id, field} = Map.pop(field, :parent_id)
 
         Map.put(field, :bread_crumb, field.name)
 

--- a/apps/andi/lib/andi/schemas/audit_events.ex
+++ b/apps/andi/lib/andi/schemas/audit_events.ex
@@ -2,13 +2,12 @@ defmodule Andi.Schemas.AuditEvents do
   @moduledoc false
   alias Andi.Schemas.AuditEvent
   alias Andi.Repo
-  alias Andi.InputSchemas.StructTools
 
   import Ecto.Query, only: [from: 2]
 
   require Logger
 
-  def log_audit_event(user_id = :api, event_type, event_data) do
+  def log_audit_event(_user_id = :api, event_type, event_data) do
     audit_event_changes = %{
       user_id: "api",
       event_type: event_type,

--- a/apps/andi/lib/andi/schemas/dataset_access_group.ex
+++ b/apps/andi/lib/andi/schemas/dataset_access_group.ex
@@ -4,7 +4,6 @@ defmodule Andi.Schemas.DatasetAccessGroup do
   """
 
   use Ecto.Schema
-  alias Andi.Schemas.User
   alias Andi.InputSchemas.Datasets.Dataset
 
   @primary_key false

--- a/apps/andi/lib/andi_web/input_schemas/data_dictionary_form_schema.ex
+++ b/apps/andi/lib/andi_web/input_schemas/data_dictionary_form_schema.ex
@@ -8,7 +8,6 @@ defmodule AndiWeb.InputSchemas.DataDictionaryFormSchema do
   alias Andi.InputSchemas.Datasets.DataDictionary
   alias Andi.InputSchemas.DatasetSchemaValidator
   alias SmartCity.SchemaGenerator
-  alias Andi.InputSchemas.Ingestion
 
   schema "data_dictionary" do
     has_many(:schema, DataDictionary, on_replace: :delete)

--- a/apps/andi/lib/andi_web/live/access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view.ex
@@ -8,7 +8,7 @@ defmodule AndiWeb.AccessGroupLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="access-groups-view">
       <div class="access-groups-index">
         <div class="access-groups-index__header">

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -16,7 +16,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="edit-page" id="access-groups-edit-page">
       <div class="edit-access-group-title">
         <h2 class="component-title-text access-groups-component-title-text">Edit Access Group </h2>

--- a/apps/andi/lib/andi_web/live/dataset_live_view.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view.ex
@@ -20,7 +20,7 @@ defmodule AndiWeb.DatasetLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="datasets-view">
       <div class="datasets-index">
         <div class="datasets-index__header">

--- a/apps/andi/lib/andi_web/live/edit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view.ex
@@ -15,7 +15,7 @@ defmodule AndiWeb.EditLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="edit-page" id="dataset-edit-page">
       <%= f = form_for @changeset, "" %>
         <% [business] = inputs_for(f, :business) %>

--- a/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
@@ -256,7 +256,7 @@ defmodule AndiWeb.EditLiveView.DataDictionaryForm do
         },
         %{assigns: %{dataset_id: dataset_id}} = socket
       ) do
-    file_type_for_upload = get_file_type_for_upload(file_type)
+    _file_type_for_upload = get_file_type_for_upload(file_type)
     generate_new_schema(socket, file, file_type)
   end
 

--- a/apps/andi/lib/andi_web/live/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/edit_organization_live_view.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.EditOrganizationLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div id="edit-organization-live-view" class="organization-edit-page edit-page">
       <div class="edit-organization-title">
         <h2 class="component-title-text">Edit Organization </h2>

--- a/apps/andi/lib/andi_web/live/header_live_view.ex
+++ b/apps/andi/lib/andi_web/live/header_live_view.ex
@@ -93,8 +93,8 @@ defmodule AndiWeb.HeaderLiveView do
     "/auth/auth0/logout"
   end
 
-  def header_render(socket, is_curator) do
-    live_component(socket, AndiWeb.HeaderLiveView, is_curator: is_curator)
+  def header_render(is_curator) do
+    live_component(AndiWeb.HeaderLiveView, is_curator: is_curator)
   end
 
   def __redirect__(%{assigns: %{unsaved_changes: true}} = socket, location) do

--- a/apps/andi/lib/andi_web/live/ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view.ex
@@ -12,7 +12,7 @@ defmodule AndiWeb.IngestionLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="ingestions-view">
       <div class="ingestions-index">
         <div class="ingestions-index__header">

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
@@ -234,7 +234,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
         },
         %{assigns: %{ingestion_id: ingestion_id}} = socket
       ) do
-    file_type_for_upload = get_file_type_for_upload(file_type)
+    _file_type_for_upload = get_file_type_for_upload(file_type)
     generate_new_schema(socket, file, file_type)
   end
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -16,7 +16,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="edit-page" id="ingestions-edit-page">
       <%= f = form_for @changeset, "" %>
         <%= hidden_input(f, :sourceFormat) %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_step_form.ex
@@ -205,12 +205,6 @@ defmodule AndiWeb.IngestionLiveView.ExtractSteps.ExtractStepForm do
      |> update_validation_status()}
   end
 
-  defp get_file_name_from_dataset_link(dataset_link) do
-    dataset_link
-    |> String.split("/")
-    |> List.last()
-  end
-
   defp move_extract_step(socket, extract_step_index, target_index) do
     updated_extract_steps =
       socket.assigns.extract_steps

--- a/apps/andi/lib/andi_web/live/organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view.ex
@@ -13,7 +13,7 @@ defmodule AndiWeb.OrganizationLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="organizations-view">
       <div class="organizations-index">
         <div class="organizations-index__header">

--- a/apps/andi/lib/andi_web/live/submit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view.ex
@@ -9,7 +9,7 @@ defmodule AndiWeb.SubmitLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="edit-page" id="dataset-edit-page">
       <div class="preamble">
       <p>You are about to submit a dataset to the Smart Columbus Operating System for review. If approved, your dataset will be made available to the public for download and consumption. The Smart Columbus Operating System currently does not allow any datasets that contain:</p>

--- a/apps/andi/lib/andi_web/live/submit_live_view/upload_data_dictionary.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view/upload_data_dictionary.ex
@@ -105,10 +105,6 @@ defmodule AndiWeb.SubmitLiveView.UploadDataDictionary do
     """
   end
 
-  def handle_event("validate", _, socket) do
-    {:noreply, socket}
-  end
-
   def handle_info(
         %{topic: "toggle-visibility", payload: %{expand: "metadata_form", dataset_id: dataset_id}},
         %{assigns: %{dataset_id: dataset_id}} = socket
@@ -117,6 +113,10 @@ defmodule AndiWeb.SubmitLiveView.UploadDataDictionary do
   end
 
   def handle_info(%{topic: "toggle-visibility"}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("validate", _, socket) do
     {:noreply, socket}
   end
 

--- a/apps/andi/lib/andi_web/live/user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view.ex
@@ -12,7 +12,7 @@ defmodule AndiWeb.UserLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
     <div class="users-view">
       <div class="users-index">
         <div class="users-index__header">

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
@@ -15,7 +15,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
 
   def render(assigns) do
     ~L"""
-    <%= header_render(@socket, @is_curator) %>
+    <%= header_render(@is_curator) %>
       <div id="edit-user-live-view" class="user-edit-page edit-page">
           <div class="edit-user-title">
               <h2 class="component-title-text">Edit User </h2>

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_role_table.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_role_table.ex
@@ -4,7 +4,6 @@ defmodule AndiWeb.EditUserLiveView.EditUserLiveViewRoleTable do
   """
 
   use Phoenix.LiveComponent
-  alias Phoenix.HTML.Link
 
   def render(assigns) do
     ~L"""

--- a/apps/andi/test/unit/andi/event/event_handler_test.exs
+++ b/apps/andi/test/unit/andi/event/event_handler_test.exs
@@ -16,7 +16,6 @@ defmodule Andi.Event.EventHandlerTest do
   alias Andi.Services.OrgStore
   alias Andi.InputSchemas.Ingestions
   alias Andi.Services.IngestionStore
-  alias SmartCity.DatasetAccessGroupRelation
 
   @instance_name Andi.instance_name()
 

--- a/apps/andi/test/unit/andi/input_schemas/ingestion_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/ingestion_test.exs
@@ -331,7 +331,4 @@ defmodule Andi.InputSchemas.Ingestion.IngestionTest do
     end)
   end
 
-  defp delete_in(data, path) do
-    pop_in(data, path) |> elem(1)
-  end
 end

--- a/apps/andi/test/unit/andi/input_schemas/ingestion_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/ingestion_test.exs
@@ -330,5 +330,4 @@ defmodule Andi.InputSchemas.Ingestion.IngestionTest do
       {field, {msg, opts}}
     end)
   end
-
 end

--- a/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
@@ -448,7 +448,7 @@ defmodule Andi.InputSchemas.InputConverterTest do
 
     test "internal spaces are preserved within a keyword" do
       keywords = "example, one blue sky"
-      assert = ["example", "one blue sky"] = InputConverter.keywords_to_list(keywords)
+      assert ["example", "one blue sky"] = InputConverter.keywords_to_list(keywords)
     end
 
     test "leading and trailing spaces are trimmed from a keyword" do

--- a/apps/andi/test/unit/andi_web/controllers/api/ingestion_controller_test.exs
+++ b/apps/andi/test/unit/andi_web/controllers/api/ingestion_controller_test.exs
@@ -64,7 +64,7 @@ defmodule AndiWeb.API.IngestionControllerTest do
       assert MapSet.new(example_ingestions) == MapSet.new(actual_ingestions)
     end
 
-    test "returns a 404", %{conn: conn, example_ingestions: example_ingestions} do
+    test "returns a 404", %{conn: conn} do
       allow(IngestionStore.get_all(),
         return: {:error, "this was an error"},
         meck_options: [:passthrough]
@@ -166,7 +166,7 @@ defmodule AndiWeb.API.IngestionControllerTest do
       ingestion = smrt_ingestion |> struct_to_map_with_string_keys()
       allow(Brook.Event.send(@instance_name, any(), any(), any()), return: :ok)
       allow(Andi.InputSchemas.Datasets.get(any()), return: %{technical: %{sourceType: "ingest"}})
-      conn = put(conn, @route, ingestion)
+      put(conn, @route, ingestion)
       assert_called(Brook.Event.send(@instance_name, ingestion_update(), :andi, smrt_ingestion))
       assert_called(Andi.Schemas.AuditEvents.log_audit_event(:api, ingestion_update(), smrt_ingestion), once())
     end

--- a/apps/andi/test/unit/andi_web/live/extract_date_step_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/extract_date_step_form_test.exs
@@ -1,6 +1,5 @@
 defmodule AndiWeb.ExtractDateFormTest do
   use AndiWeb.Test.AuthConnCase.UnitCase
-  alias SmartCity.TestDataGenerator, as: TDG
   use Placebo
   alias Andi.Schemas.User
   alias IngestionHelpers

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/select_dataset_modal_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/select_dataset_modal_test.exs
@@ -9,13 +9,11 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModalTest do
 
   alias SmartCity.TestDataGenerator, as: TDG
   alias Andi.InputSchemas.Ingestions
-  alias Andi.InputSchemas.Ingestion
   alias Andi.InputSchemas.Datasets.Dataset
   alias Andi.InputSchemas.Datasets
   alias AndiWeb.IngestionLiveView.MetadataForm
 
   @endpoint AndiWeb.Endpoint
-  @url_path "/ingestions"
   @user UserHelpers.create_user()
 
   defp allowAuthUser do
@@ -35,7 +33,7 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModalTest do
   end
 
   describe "Basic dataset search load" do
-    test "shows \"No Matching Datasets\" when there are no rows to show", %{conn: conn} do
+    test "shows \"No Matching Datasets\" when there are no rows to show" do
       ingestion = %Andi.InputSchemas.Ingestion{
         id: "id",
         targetDataset: "dataset_id",
@@ -59,7 +57,7 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModalTest do
       assert get_text(html, ".search-table__cell") =~ "No Matching Datasets"
     end
 
-    test "represents a dataset when one exists", %{conn: conn} do
+    test "represents a dataset when one exists" do
       ingestion = %Andi.InputSchemas.Ingestion{
         id: "id",
         targetDataset: "dataset_id",
@@ -90,7 +88,7 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModalTest do
       assert get_text(html, ".search-table__cell") =~ "Soup"
     end
 
-    test "represents multiple datasets", %{conn: conn} do
+    test "represents multiple datasets" do
       ingestion = %Andi.InputSchemas.Ingestion{
         id: "id",
         targetDataset: "dataset_id",
@@ -127,7 +125,7 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModalTest do
       assert get_text(html, ".search-table__cell") =~ "Pretty"
     end
 
-    test "only allows one dataset to be selected", %{conn: conn} do
+    test "only allows one dataset to be selected" do
       ingestion = %Andi.InputSchemas.Ingestion{
         id: "id",
         targetDataset: "dataset_id",
@@ -157,7 +155,7 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModalTest do
       select_dataset_button = find_select_dataset_button(view)
       render_click(select_dataset_button)
 
-      html = render_submit(view, "datasets-search", %{"search-value" => "Noodles"})
+      render_submit(view, "datasets-search", %{"search-value" => "Noodles"})
 
       # Select the first dataset
       select_search_result = element(view, "[phx-value-id=1]")

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -5,7 +5,6 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
 
   alias Andi.InputSchemas.Ingestions.Transformation
   alias AndiWeb.IngestionLiveView.Transformations.TransformationForm
-  alias AndiWeb.Views.Options
 
   @endpoint AndiWeb.Endpoint
 


### PR DESCRIPTION
## Description

Removing a bunch of easy warning from Andi, such as unused imports/aliases/variables/functions.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
