### PR TITLE
Restore missing model attribute

### DIFF
--- a/apps/discovery_api/lib/discovery_api/data/mapper.ex
+++ b/apps/discovery_api/lib/discovery_api/data/mapper.ex
@@ -24,6 +24,7 @@ defmodule DiscoveryApi.Data.Mapper do
            title: biz.dataTitle,
            keywords: biz.keywords,
            modifiedDate: biz.modifiedDate,
+           fileTypes: [],
            description: biz.description,
            schema: tech.schema,
            systemName: tech.systemName,

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.3.0",
+      version: "1.3.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## Description

Restore missing model attribute that was causing UI to whitescreen. A proper deprecation ticket has been created to remove this attribute from the UI.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [x] If altering an API endpoint, was the relevant postman collection updated?
  - [x] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
