### PR TITLE
add 5 day cache to static assets

### DIFF
--- a/apps/andi/lib/andi_web/endpoint.ex
+++ b/apps/andi/lib/andi_web/endpoint.ex
@@ -11,6 +11,7 @@ defmodule AndiWeb.Endpoint do
     at: "/",
     from: :andi,
     gzip: false,
+    cache_control_for_etags: "public, max-age=432000",
     only: ~w(css fonts images js favicon.ico robots.txt)
 
   if code_reloading? do

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.3.3",
+      version: "2.3.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## Description

- Add cache policy to Andi static assets so that they're not reloaded on every page
  - Saves a small amount of bandwidth and stops logo pop in

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
