### PR TITLE
Add ingestion_id + ingestion_start_time to stored records

### DIFF
--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -166,7 +166,9 @@ defmodule E2ETest do
       expected = [
         %{"Column" => "one", "Comment" => "", "Extra" => "", "Type" => "boolean"},
         %{"Column" => "two", "Comment" => "", "Extra" => "", "Type" => "varchar"},
-        %{"Column" => "three", "Comment" => "", "Extra" => "", "Type" => "integer"}
+        %{"Column" => "three", "Comment" => "", "Extra" => "", "Type" => "integer"},
+        %{"Column" => "_ingestion_id", "Comment" => "", "Extra" => "", "Type" => "varchar"},
+        %{"Column" => "_extraction_start_time", "Comment" => "", "Extra" => "", "Type" => "date"}
       ]
 
       eventually(

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -260,7 +260,7 @@ defmodule E2ETest do
                      "three" => 10,
                      "two" => "foobar",
                      "_extraction_start_time" => get_current_yyyy_mm_dd,
-                     "_ingestion_id" => ingestion.id
+                     "_ingestion_id" => ingestion.id,
                      "os_partition" => get_current_yyyy_mm
                    }
                  ] ==

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -235,7 +235,7 @@ defmodule E2ETest do
     end
 
     @tag timeout: :infinity, capture_log: true
-    test "persists in PrestoDB", %{dataset: ds} do
+    test "persists in PrestoDB", %{dataset: ds, ingestion: ingestion} do
       topic = "#{Application.get_env(:forklift, :input_topic_prefix)}-#{ds.id}"
       table = ds.technical.systemName
 
@@ -259,6 +259,8 @@ defmodule E2ETest do
                      "one" => true,
                      "three" => 10,
                      "two" => "foobar",
+                     "_extraction_start_time" => get_current_yyyy_mm_dd,
+                     "_ingestion_id" => ingestion.id
                      "os_partition" => get_current_yyyy_mm
                    }
                  ] ==
@@ -324,7 +326,7 @@ defmodule E2ETest do
     end
 
     @tag timeout: :infinity, capture_log: true
-    test "persists in PrestoDB", %{streaming_dataset: ds} do
+    test "persists in PrestoDB", %{streaming_dataset: ds, streaming_ingestion: ingestion} do
       topic = "#{Application.get_env(:forklift, :input_topic_prefix)}-#{ds.id}"
       table = ds.technical.systemName
 
@@ -347,6 +349,8 @@ defmodule E2ETest do
                    "one" => true,
                    "three" => 10,
                    "two" => "foobar",
+                   "_extraction_start_time" => get_current_yyyy_mm_dd,
+                   "_ingestion_id" => ingestion.id,
                    "os_partition" => get_current_yyyy_mm
                  } in query(
                    "select * from #{table}",
@@ -465,6 +469,13 @@ defmodule E2ETest do
     month = DateTime.utc_now().month |> Integer.to_string() |> String.pad_leading(2, "0")
     year = DateTime.utc_now().year |> Integer.to_string()
     "#{year}_#{month}"
+  end
+
+  defp get_current_yyyy_mm_dd() do
+    day = DateTime.utc_now().day |> Integer.to_string() |> String.pad_leading(2, "0")
+    month = DateTime.utc_now().month |> Integer.to_string() |> String.pad_leading(2, "0")
+    year = DateTime.utc_now().year |> Integer.to_string()
+    "#{year}-#{month}-#{day}"
   end
 
   defp prestige_session(),

--- a/apps/forklift/lib/forklift/data_writer.ex
+++ b/apps/forklift/lib/forklift/data_writer.ex
@@ -33,8 +33,9 @@ defmodule Forklift.DataWriter do
   @doc """
   Ensures a table exists using `:table_writer` from Forklift's application environment.
   """
-  def init(args) do
-    table_writer().init(args)
+  def init(table: table, schema: dataset_schema) do
+    schema_with_ingestion_metadata = dataset_schema |> add_ingestion_metadata_to_schema()
+    table_writer().init(table: table, schema: schema_with_ingestion_metadata)
   end
 
   @impl Pipeline.Writer
@@ -118,23 +119,41 @@ defmodule Forklift.DataWriter do
     end
   end
 
-  defp write_to_table(data, %{technical: metadata}) do
+  defp write_to_table(data, %{technical: technical}) do
     with write_start <- Data.Timing.current_time(),
          :ok <-
-           table_writer().write(data, table: metadata.systemName, schema: metadata.schema, bucket: s3_writer_bucket()),
+           table_writer().write(data,
+             table: technical.systemName,
+             schema: add_ingestion_metadata_to_schema(technical.schema),
+             bucket: s3_writer_bucket()
+           ),
          write_end <- Data.Timing.current_time(),
-         write_timing <- Data.Timing.new(@instance_name, "presto_insert_time", write_start, write_end) do
+         write_timing <-
+           Data.Timing.new(@instance_name, "presto_insert_time", write_start, write_end) do
       {:ok, write_timing}
     end
+  end
+
+  defp add_ingestion_metadata_to_schema(schema) do
+    ingestion_metadata_schema = [
+      %{name: "ingestion_id", type: "string"},
+      %{name: "ingestion_start", type: "date", format: "{ISO:Extended:Z}"}
+    ]
+
+    schema ++ ingestion_metadata_schema
   end
 
   def write_to_topic(data) do
     writer_args = [instance: @instance_name, producer_name: producer_name()]
 
     data
-    |> Enum.map(fn datum -> {datum._metadata.kafka_key, Forklift.Util.remove_from_metadata(datum, :kafka_key)} end)
+    |> Enum.map(fn datum ->
+      {datum._metadata.kafka_key, Forklift.Util.remove_from_metadata(datum, :kafka_key)}
+    end)
     |> Enum.map(fn {key, datum} -> {key, Jason.encode!(datum)} end)
-    |> Forklift.Util.chunk_by_byte_size(max_outgoing_bytes(), fn {key, value} -> byte_size(key) + byte_size(value) end)
+    |> Forklift.Util.chunk_by_byte_size(max_outgoing_bytes(), fn {key, value} ->
+      byte_size(key) + byte_size(value)
+    end)
     |> Enum.each(fn msg_chunk -> topic_writer().write(msg_chunk, writer_args) end)
   end
 

--- a/apps/forklift/lib/forklift/data_writer.ex
+++ b/apps/forklift/lib/forklift/data_writer.ex
@@ -134,10 +134,10 @@ defmodule Forklift.DataWriter do
     end
   end
 
-  defp add_ingestion_metadata_to_schema(schema) do
+  def add_ingestion_metadata_to_schema(schema) do
     ingestion_metadata_schema = [
-      %{name: "ingestion_id", type: "string"},
-      %{name: "ingestion_start", type: "date", format: "{ISO:Extended:Z}"}
+      %{name: "_ingestion_id", type: "string"},
+      %{name: "_extraction_start_time", type: "date", format: "{ISO:Extended:Z}"}
     ]
 
     schema ++ ingestion_metadata_schema

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.18.0",
+      version: "0.18.1",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/integration/forklift/jobs/data_migration_test.exs
+++ b/apps/forklift/test/integration/forklift/jobs/data_migration_test.exs
@@ -62,7 +62,7 @@ defmodule Forklift.Jobs.DataMigrationTest do
     eventually(fn -> assert table_exists?(dataset.technical.systemName) end, 100, 1_000)
     eventually(fn -> assert table_exists?(dataset.technical.systemName <> "__json") end, 100, 1_000)
 
-    "insert into #{dataset.technical.systemName} values (1, 'Bob', cast(now() as date), 1.5, true)"
+    "insert into #{dataset.technical.systemName} values (1, 'Bob', cast(now() as date), 1.5, true, '1234-abc-zyx', cast(now() as date))"
     |> PrestigeHelper.execute_query()
 
     expected_records = 10

--- a/apps/forklift/test/integration/test_helper.exs
+++ b/apps/forklift/test/integration/test_helper.exs
@@ -19,6 +19,7 @@ defmodule Helper do
   alias Pipeline.Writer.TableWriter.Statement
   alias Pipeline.Writer.S3Writer
   alias Forklift.Datasets
+  alias Forklift.DataWriter
   require ExUnit.Assertions
 
   @instance_name Forklift.instance_name()
@@ -59,7 +60,7 @@ defmodule Helper do
     S3Writer.write(data,
       bucket: s3_writer_bucket(),
       table: dataset.technical.systemName,
-      schema: dataset.technical.schema
+      schema: DataWriter.add_ingestion_metadata_to_schema(dataset.technical.schema)
     )
   end
 
@@ -68,7 +69,9 @@ defmodule Helper do
   end
 
   defp insert_record(table, partition) do
-    "insert into #{table} values (1, 'Bob', cast(now() as date), 1.5, true, '#{partition}')"
+    "insert into #{table} values (1, 'Bob', cast(now() as date), 1.5, true, '1234-abc-zyx', cast(now() as date), '#{
+      partition
+    }')"
     |> PrestigeHelper.execute_query()
   end
 
@@ -78,7 +81,9 @@ defmodule Helper do
       "my_string" => "Bob",
       "my_date" => Timex.format!(DateTime.utc_now(), "{ISO:Extended:Z}"),
       "my_float" => 1.5,
-      "my_boolean" => "true"
+      "my_boolean" => "true",
+      "_ingestion_id" => "1234-abc-zyx",
+      "_extraction_start_time" => Timex.format!(DateTime.utc_now(), "{ISO:Extended:Z}")
     }
   end
 

--- a/apps/forklift/test/unit/forklift/data_writer_test.exs
+++ b/apps/forklift/test/unit/forklift/data_writer_test.exs
@@ -9,6 +9,7 @@ defmodule Forklift.DataWriterTest do
 
   getter(:elsa_brokers, generic: true)
   getter(:input_topic_prefix, generic: true)
+  getter(:profiling_enabled, generic: false)
 
   setup :set_mox_global
   setup :verify_on_exit!
@@ -34,5 +35,33 @@ defmodule Forklift.DataWriterTest do
     end)
 
     assert :ok == DataWriter.delete(expected_dataset)
+  end
+
+  test "should add ingestion_time and ingestion_id to the dataset schema" do
+    expected_dataset =
+      TDG.create_dataset(%{
+        technical: %{systemName: "some_system_name"}
+      })
+
+    stub(MockTable, :write, fn _data, params ->
+      schema = params |> Keyword.fetch!(:schema) |> IO.inspect(label: "schema from data_writer")
+
+      schema_with_ingestion_metadata =
+        expected_dataset.technical.schema ++
+          [
+            %{name: "ingestion_id", type: "string"},
+            %{name: "ingestion_start", type: "date", format: "{ISO:Extended:Z}"}
+          ]
+
+      assert schema == schema_with_ingestion_metadata
+      :ok
+    end)
+
+    assert :ok ==
+             DataWriter.write([fake_data_to_write()], dataset: expected_dataset)
+  end
+
+  defp fake_data_to_write() do
+    %{_metadata: %{forklift_start_time: DateTime.utc_now()}}
   end
 end

--- a/apps/forklift/test/unit/forklift/data_writer_test.exs
+++ b/apps/forklift/test/unit/forklift/data_writer_test.exs
@@ -9,7 +9,6 @@ defmodule Forklift.DataWriterTest do
 
   getter(:elsa_brokers, generic: true)
   getter(:input_topic_prefix, generic: true)
-  getter(:profiling_enabled, generic: false)
 
   setup :set_mox_global
   setup :verify_on_exit!
@@ -43,25 +42,22 @@ defmodule Forklift.DataWriterTest do
         technical: %{systemName: "some_system_name"}
       })
 
+    fake_data = TDG.create_data(%{})
+
     stub(MockTable, :write, fn _data, params ->
-      schema = params |> Keyword.fetch!(:schema) |> IO.inspect(label: "schema from data_writer")
+      schema = params |> Keyword.fetch!(:schema)
 
       schema_with_ingestion_metadata =
         expected_dataset.technical.schema ++
           [
-            %{name: "ingestion_id", type: "string"},
-            %{name: "ingestion_start", type: "date", format: "{ISO:Extended:Z}"}
+            %{name: "_ingestion_id", type: "string"},
+            %{name: "_extraction_start_time", type: "date", format: "{ISO:Extended:Z}"}
           ]
 
       assert schema == schema_with_ingestion_metadata
       :ok
     end)
 
-    assert :ok ==
-             DataWriter.write([fake_data_to_write()], dataset: expected_dataset)
-  end
-
-  defp fake_data_to_write() do
-    %{_metadata: %{forklift_start_time: DateTime.utc_now()}}
+    DataWriter.write([fake_data], dataset: expected_dataset)
   end
 end

--- a/apps/forklift/test/unit/integration/event/event_handling_test.exs
+++ b/apps/forklift/test/unit/integration/event/event_handling_test.exs
@@ -28,7 +28,7 @@ defmodule Forklift.Event.EventHandlingTest do
 
       dataset = TDG.create_dataset(%{})
       table_name = dataset.technical.systemName
-      schema = dataset.technical.schema
+      schema = dataset.technical.schema |> Forklift.DataWriter.add_ingestion_metadata_to_schema()
 
       Brook.Test.send(@instance_name, dataset_update(), :author, dataset)
       assert_receive table: ^table_name, schema: ^schema

--- a/apps/forklift/test/unit/integration/message_handling_test.exs
+++ b/apps/forklift/test/unit/integration/message_handling_test.exs
@@ -72,13 +72,13 @@ defmodule Forklift.Integration.MessageHandlingTest do
     end
 
     test "sends 'dataset:write_complete event' with timestamp after writing records" do
-      expect(MockTable, :write, fn [%{payload: "foobar"}, %{payload: "foobaz"}], _ -> :ok end)
+      expect(MockTable, :write, fn [%{payload: %{"foo" => "bar"}}, %{payload: %{"foz" => "baz"}}], _ -> :ok end)
       expect(MockTopic, :write, fn _, _ -> :ok end)
 
       dataset = TDG.create_dataset(%{})
 
-      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobar"})
-      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobaz"})
+      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foo" => "bar"}})
+      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foz" => "baz"}})
 
       message1 = %Elsa.Message{key: "one", value: Jason.encode!(datum1)}
       message2 = %Elsa.Message{key: "two", value: Jason.encode!(datum2)}
@@ -106,8 +106,8 @@ defmodule Forklift.Integration.MessageHandlingTest do
 
       dataset = TDG.create_dataset(%{})
 
-      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobar"})
-      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobaz"})
+      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foo" => "bar"}})
+      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foz" => "baz"}})
 
       message1 = %Elsa.Message{key: "one", value: Jason.encode!(datum1)}
       message2 = %Elsa.Message{key: "two", value: Jason.encode!(datum2)}
@@ -128,8 +128,8 @@ defmodule Forklift.Integration.MessageHandlingTest do
 
       dataset = TDG.create_dataset(%{})
 
-      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobar"})
-      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobaz"})
+      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foo" => "bar"}})
+      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foz" => "baz"}})
 
       message1 = %Elsa.Message{key: "one", value: Jason.encode!(datum1)}
       message2 = %Elsa.Message{key: "two", value: Jason.encode!(datum2)}
@@ -161,13 +161,13 @@ defmodule Forklift.Integration.MessageHandlingTest do
   describe "on receiving end-of-data message" do
     test "shuts down dataset reader" do
       Application.put_env(:forklift, :profiling_enabled, false)
-      expect(MockTable, :write, fn [%{payload: "foobar"}, %{payload: "foobaz"}], _ -> :ok end)
+      expect(MockTable, :write, fn [%{payload: %{"foo" => "bar"}}, %{payload: %{"foz" => "baz"}}], _ -> :ok end)
       expect(MockTopic, :write, fn _, _ -> :ok end)
 
       dataset = TDG.create_dataset(%{})
 
-      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobar"})
-      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: "foobaz"})
+      datum1 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foo" => "bar"}})
+      datum2 = TDG.create_data(%{dataset_id: dataset.id, payload: %{"foz" => "baz"}})
 
       message1 = %Elsa.Message{key: "one", value: Jason.encode!(datum1)}
       message2 = %Elsa.Message{key: "two", value: Jason.encode!(datum2)}


### PR DESCRIPTION
## [Ticket Link #692](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/692)

## Description

- Create json and orc tables with `_extraction_start_time` and `_ingestion_id` columns
  - Populate those columns with the ingestion metadata present in `SmartCity.Data` messages

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
