### PR TITLE
store _extract_start_time as timestamp, NOT date

### DIFF
--- a/apps/e2e/mix.exs
+++ b/apps/e2e/mix.exs
@@ -4,7 +4,7 @@ defmodule E2E.MixProject do
   def project do
     [
       app: :e2e,
-      version: "0.1.9",
+      version: "0.1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -168,7 +168,12 @@ defmodule E2ETest do
         %{"Column" => "two", "Comment" => "", "Extra" => "", "Type" => "varchar"},
         %{"Column" => "three", "Comment" => "", "Extra" => "", "Type" => "integer"},
         %{"Column" => "_ingestion_id", "Comment" => "", "Extra" => "", "Type" => "varchar"},
-        %{"Column" => "_extraction_start_time", "Comment" => "", "Extra" => "", "Type" => "date"}
+        %{
+          "Column" => "_extraction_start_time",
+          "Comment" => "",
+          "Extra" => "",
+          "Type" => "timestamp(3)"
+        }
       ]
 
       eventually(

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -257,15 +257,17 @@ defmodule E2ETest do
           assert [
                    %{
                      "one" => true,
-                     "three" => 10,
                      "two" => "foobar",
-                     "_extraction_start_time" => get_current_yyyy_mm_dd,
+                     "three" => 10,
                      "_ingestion_id" => ingestion.id,
-                     "os_partition" => get_current_yyyy_mm
+                     "os_partition" => get_current_yyyy_mm,
+                     "_extraction_start_time" => get_current_yyyy_mm_dd
                    }
                  ] ==
                    query(
-                     "select * from #{table}",
+                     "select one, two, three, _ingestion_id, os_partition, date_format(_extraction_start_time, '%Y_%m_%d') as _extraction_start_time from #{
+                       table
+                     }",
                      true
                    )
         end,
@@ -347,13 +349,15 @@ defmodule E2ETest do
 
           assert %{
                    "one" => true,
-                   "three" => 10,
                    "two" => "foobar",
-                   "_extraction_start_time" => get_current_yyyy_mm_dd,
+                   "three" => 10,
                    "_ingestion_id" => ingestion.id,
-                   "os_partition" => get_current_yyyy_mm
+                   "os_partition" => get_current_yyyy_mm,
+                   "_extraction_start_time" => get_current_yyyy_mm_dd
                  } in query(
-                   "select * from #{table}",
+                   "select one, two, three, _ingestion_id, os_partition, date_format(_extraction_start_time, '%Y_%m_%d') as _extraction_start_time from #{
+                     table
+                   }",
                    true
                  )
         end,
@@ -475,7 +479,7 @@ defmodule E2ETest do
     day = DateTime.utc_now().day |> Integer.to_string() |> String.pad_leading(2, "0")
     month = DateTime.utc_now().month |> Integer.to_string() |> String.pad_leading(2, "0")
     year = DateTime.utc_now().year |> Integer.to_string()
-    "#{year}-#{month}-#{day}"
+    "#{year}_#{month}_#{day}"
   end
 
   defp prestige_session(),

--- a/apps/forklift/lib/forklift/data_writer.ex
+++ b/apps/forklift/lib/forklift/data_writer.ex
@@ -138,7 +138,7 @@ defmodule Forklift.DataWriter do
   def add_ingestion_metadata_to_schema(schema) do
     ingestion_metadata_schema = [
       %{name: "_ingestion_id", type: "string"},
-      %{name: "_extraction_start_time", type: "date", format: "{ISO:Extended:Z}"}
+      %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"}
     ]
 
     schema ++ ingestion_metadata_schema

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.18.1",
+      version: "0.18.2",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/unit/forklift/data_writer_test.exs
+++ b/apps/forklift/test/unit/forklift/data_writer_test.exs
@@ -51,7 +51,7 @@ defmodule Forklift.DataWriterTest do
         expected_dataset.technical.schema ++
           [
             %{name: "_ingestion_id", type: "string"},
-            %{name: "_extraction_start_time", type: "date", format: "{ISO:Extended:Z}"}
+            %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"}
           ]
 
       assert schema == schema_with_ingestion_metadata


### PR DESCRIPTION
## Description

A bug fix for 692

- Change _extract_start_time that we'll use as an ID to be a `timestamp`. Not just `date`.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
