### PR TITLE
Partition json table by _ingestion_id

### DIFF
--- a/apps/e2e/mix.exs
+++ b/apps/e2e/mix.exs
@@ -4,7 +4,7 @@ defmodule E2E.MixProject do
   def project do
     [
       app: :e2e,
-      version: "0.1.10",
+      version: "0.1.11",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -173,7 +173,12 @@ defmodule E2ETest do
           "Extra" => "",
           "Type" => "timestamp(3)"
         },
-        %{"Column" => "_ingestion_id", "Comment" => "", "Extra" => "", "Type" => "varchar"}
+        %{
+          "Column" => "_ingestion_id",
+          "Comment" => "",
+          "Extra" => "partition key",
+          "Type" => "varchar"
+        }
       ]
 
       eventually(

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -167,13 +167,13 @@ defmodule E2ETest do
         %{"Column" => "one", "Comment" => "", "Extra" => "", "Type" => "boolean"},
         %{"Column" => "two", "Comment" => "", "Extra" => "", "Type" => "varchar"},
         %{"Column" => "three", "Comment" => "", "Extra" => "", "Type" => "integer"},
-        %{"Column" => "_ingestion_id", "Comment" => "", "Extra" => "", "Type" => "varchar"},
         %{
           "Column" => "_extraction_start_time",
           "Comment" => "",
           "Extra" => "",
           "Type" => "timestamp(3)"
-        }
+        },
+        %{"Column" => "_ingestion_id", "Comment" => "", "Extra" => "", "Type" => "varchar"}
       ]
 
       eventually(

--- a/apps/forklift/lib/forklift/data_writer.ex
+++ b/apps/forklift/lib/forklift/data_writer.ex
@@ -33,9 +33,9 @@ defmodule Forklift.DataWriter do
   @doc """
   Ensures a table exists using `:table_writer` from Forklift's application environment.
   """
-  def init(table: table, schema: dataset_schema) do
+  def init(table: table, schema: dataset_schema, partitions: partitions) do
     schema_with_ingestion_metadata = dataset_schema |> add_ingestion_metadata_to_schema()
-    table_writer().init(table: table, schema: schema_with_ingestion_metadata)
+    table_writer().init(table: table, schema: schema_with_ingestion_metadata, partitions: partitions)
   end
 
   @impl Pipeline.Writer
@@ -50,16 +50,17 @@ defmodule Forklift.DataWriter do
   """
   def write(data, opts) do
     dataset = Keyword.fetch!(opts, :dataset)
+    ingestion_id = Keyword.fetch!(opts, :ingestion_id)
 
     case ingest_status(data) do
       {:ok, batch_data} ->
         Enum.reverse(batch_data)
-        |> do_write(dataset)
+        |> do_write(dataset, ingestion_id)
 
       {:final, batch_data} ->
         results =
           Enum.reverse(batch_data)
-          |> do_write(dataset)
+          |> do_write(dataset, ingestion_id)
 
         Brook.Event.send(@instance_name, data_ingest_end(), :forklift, dataset)
 
@@ -106,12 +107,12 @@ defmodule Forklift.DataWriter do
     {:cont, {:ok, [message | acc]}}
   end
 
-  defp do_write(data, dataset) do
+  defp do_write(data, dataset, ingestion_id) do
     started_data = Enum.map(data, &add_start_time/1)
     ingestion_info_data = Enum.map(started_data, &add_ingestion_info/1)
 
     retry with: exponential_backoff(100) |> cap(retry_max_wait()) |> Stream.take(retry_count()) do
-      write_to_table(ingestion_info_data, dataset)
+      write_to_table(ingestion_info_data, dataset, ingestion_id)
     after
       {:ok, write_timing} -> add_total_time(data, ingestion_info_data, write_timing)
     else
@@ -120,13 +121,15 @@ defmodule Forklift.DataWriter do
     end
   end
 
-  defp write_to_table(data, %{technical: technical}) do
+  defp write_to_table(data, %{technical: technical}, ingestion_id) do
     with write_start <- Data.Timing.current_time(),
          :ok <-
            table_writer().write(data,
              table: technical.systemName,
              schema: add_ingestion_metadata_to_schema(technical.schema),
-             bucket: s3_writer_bucket()
+             bucket: s3_writer_bucket(),
+             partition_key: "_ingestion_id",
+             partition_value: ingestion_id
            ),
          write_end <- Data.Timing.current_time(),
          write_timing <-
@@ -137,8 +140,8 @@ defmodule Forklift.DataWriter do
 
   def add_ingestion_metadata_to_schema(schema) do
     ingestion_metadata_schema = [
-      %{name: "_ingestion_id", type: "string"},
-      %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"}
+      %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"},
+      %{name: "_ingestion_id", type: "string"}
     ]
 
     schema ++ ingestion_metadata_schema
@@ -167,8 +170,8 @@ defmodule Forklift.DataWriter do
 
     ingestion_info_payload =
       Map.merge(payload, %{
-        "_ingestion_id" => data.ingestion_id,
-        "_extraction_start_time" => data.extraction_start_time
+        "_extraction_start_time" => data.extraction_start_time,
+        "_ingestion_id" => data.ingestion_id
       })
 
     data |> Map.merge(%{payload: ingestion_info_payload})
@@ -180,7 +183,7 @@ defmodule Forklift.DataWriter do
         Enum.map(started_data, &Data.add_timing(&1, write_timing))
         |> Enum.map(&add_timing/1)
 
-      false ->
+      _ ->
         data
     end
   end

--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -48,7 +48,7 @@ defmodule Forklift.Event.EventHandler do
 
     Forklift.Datasets.update(dataset)
 
-    [table: dataset.technical.systemName, schema: dataset.technical.schema]
+    [table: dataset.technical.systemName, schema: dataset.technical.schema, partitions: ["_ingestion_id"]]
     |> Forklift.DataWriter.init()
 
     :discard

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.18.2",
+      version: "0.18.3",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/integration/forklift/jobs/data_migration_test.exs
+++ b/apps/forklift/test/integration/forklift/jobs/data_migration_test.exs
@@ -62,8 +62,9 @@ defmodule Forklift.Jobs.DataMigrationTest do
     eventually(fn -> assert table_exists?(dataset.technical.systemName) end, 100, 1_000)
     eventually(fn -> assert table_exists?(dataset.technical.systemName <> "__json") end, 100, 1_000)
 
-    "insert into #{dataset.technical.systemName} values (1, 'Bob', cast(now() as date), 1.5, true, '1234-abc-zyx', cast(now() as date))"
-    |> PrestigeHelper.execute_query()
+    {:ok, _} =
+      "insert into #{dataset.technical.systemName} values (1, 'Bob', cast(now() as date), 1.5, true, cast(now() as date), '1234-abc-zyx')"
+      |> PrestigeHelper.execute_query()
 
     expected_records = 10
     write_records(dataset, expected_records)

--- a/apps/forklift/test/integration/test_helper.exs
+++ b/apps/forklift/test/integration/test_helper.exs
@@ -69,10 +69,11 @@ defmodule Helper do
   end
 
   defp insert_record(table, partition) do
-    "insert into #{table} values (1, 'Bob', cast(now() as date), 1.5, true, '1234-abc-zyx', cast(now() as date), '#{
-      partition
-    }')"
-    |> PrestigeHelper.execute_query()
+    {:ok, _} =
+      "insert into #{table} values (1, 'Bob', cast(now() as date), 1.5, true, cast(now() as date), '1234-abc-zyx', '#{
+        partition
+      }')"
+      |> PrestigeHelper.execute_query()
   end
 
   def payload() do

--- a/apps/forklift/test/integration/test_helper.exs
+++ b/apps/forklift/test/integration/test_helper.exs
@@ -60,7 +60,9 @@ defmodule Helper do
     S3Writer.write(data,
       bucket: s3_writer_bucket(),
       table: dataset.technical.systemName,
-      schema: DataWriter.add_ingestion_metadata_to_schema(dataset.technical.schema)
+      schema: DataWriter.add_ingestion_metadata_to_schema(dataset.technical.schema),
+      partition_key: "_ingestion_id",
+      partition_value: "1234-abcd"
     )
   end
 

--- a/apps/forklift/test/unit/forklift/data_writer_test.exs
+++ b/apps/forklift/test/unit/forklift/data_writer_test.exs
@@ -50,14 +50,14 @@ defmodule Forklift.DataWriterTest do
       schema_with_ingestion_metadata =
         expected_dataset.technical.schema ++
           [
-            %{name: "_ingestion_id", type: "string"},
-            %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"}
+            %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"},
+            %{name: "_ingestion_id", type: "string"}
           ]
 
       assert schema == schema_with_ingestion_metadata
       :ok
     end)
 
-    DataWriter.write([fake_data], dataset: expected_dataset)
+    DataWriter.write([fake_data], dataset: expected_dataset, ingestion_id: "1234-abcd")
   end
 end

--- a/apps/forklift/test/unit/forklift/event/event_handling_test.exs
+++ b/apps/forklift/test/unit/forklift/event/event_handling_test.exs
@@ -31,7 +31,7 @@ defmodule Forklift.Event.EventHandlingTest do
       schema = dataset.technical.schema |> Forklift.DataWriter.add_ingestion_metadata_to_schema()
 
       Brook.Test.send(@instance_name, dataset_update(), :author, dataset)
-      assert_receive table: ^table_name, schema: ^schema
+      assert_receive table: ^table_name, schema: ^schema, partitions: ["_ingestion_id"]
     end
 
     test "does not create table for non-ingestible dataset" do

--- a/apps/forklift/test/unit/forklift/init_server_test.exs
+++ b/apps/forklift/test/unit/forklift/init_server_test.exs
@@ -1,4 +1,4 @@
-defmodule Forklift.Integration.InitServerTest do
+defmodule Forklift.InitServerTest do
   use ExUnit.Case
   use Placebo
 

--- a/apps/forklift/test/unit/forklift/message_handler_test.exs
+++ b/apps/forklift/test/unit/forklift/message_handler_test.exs
@@ -6,6 +6,13 @@ defmodule Forklift.MessageHandlerTest do
   alias Forklift.MessageHandler
   import SmartCity.TestHelper, only: [eventually: 1]
 
+  @instance_name Forklift.instance_name()
+
+  setup do
+    Brook.Test.register(@instance_name)
+    :ok
+  end
+
   @moduletag capture_log: true
   test "malformed messages are sent to dead letter queue" do
     malformed_kafka_message =
@@ -20,7 +27,6 @@ defmodule Forklift.MessageHandlerTest do
 
     dataset = TDG.create_dataset(%{id: "ds1", technical: %{systemName: "system__name", schema: []}})
 
-    expect Forklift.DataWriter.write(any(), dataset: dataset), return: []
     allow Elsa.produce(any(), any(), any()), return: :ok
 
     MessageHandler.handle_messages([malformed_kafka_message], %{dataset: dataset})

--- a/apps/forklift/test/unit/forklift/message_handling_test.exs
+++ b/apps/forklift/test/unit/forklift/message_handling_test.exs
@@ -1,4 +1,4 @@
-defmodule Forklift.Integration.MessageHandlingTest do
+defmodule Forklift.MessageHandlingTest do
   use ExUnit.Case
   use Placebo
 
@@ -72,7 +72,7 @@ defmodule Forklift.Integration.MessageHandlingTest do
     end
 
     test "sends 'dataset:write_complete event' with timestamp after writing records" do
-      expect(MockTable, :write, fn [%{payload: %{"foo" => "bar"}}, %{payload: %{"foz" => "baz"}}], _ -> :ok end)
+      expect(MockTable, :write, 2, fn _, _ -> :ok end)
       expect(MockTopic, :write, fn _, _ -> :ok end)
 
       dataset = TDG.create_dataset(%{})
@@ -161,7 +161,7 @@ defmodule Forklift.Integration.MessageHandlingTest do
   describe "on receiving end-of-data message" do
     test "shuts down dataset reader" do
       Application.put_env(:forklift, :profiling_enabled, false)
-      expect(MockTable, :write, fn [%{payload: %{"foo" => "bar"}}, %{payload: %{"foz" => "baz"}}], _ -> :ok end)
+      expect(MockTable, :write, 3, fn _, _ -> :ok end)
       expect(MockTopic, :write, fn _, _ -> :ok end)
 
       dataset = TDG.create_dataset(%{})

--- a/apps/pipeline/lib/pipeline/writer/s3_writer.ex
+++ b/apps/pipeline/lib/pipeline/writer/s3_writer.ex
@@ -16,7 +16,8 @@ defmodule Pipeline.Writer.S3Writer do
   @type schema() :: [map()]
 
   @impl Pipeline.Writer
-  @spec init(table: String.t(), schema: schema(), bucket: String.t()) :: :ok | {:error, term()}
+  @spec init(table: String.t(), schema: schema(), bucket: String.t(), partitions: [String.t()]) ::
+          :ok | {:error, term()}
   @doc """
   Ensures PrestoDB tables exist for JSON and ORC formats.
   """
@@ -159,7 +160,8 @@ defmodule Pipeline.Writer.S3Writer do
     %{
       table: table_name(format, options),
       schema: options[:schema],
-      format: format
+      format: format,
+      partitions: options[:partitions]
     }
   end
 

--- a/apps/pipeline/lib/pipeline/writer/s3_writer.ex
+++ b/apps/pipeline/lib/pipeline/writer/s3_writer.ex
@@ -52,7 +52,7 @@ defmodule Pipeline.Writer.S3Writer do
     case table_exists?(json_config) do
       true ->
         if is_partitioned_write(options) do
-          get_partition_folder(options) |> IO.inspect(label: "get_partition_folder(options)")
+          get_partition_folder(options)
           upload_content(content, json_config.schema, json_config.table, bucket, get_partition_folder(options))
           PrestigeHelper.execute_query(Statement.sync_partition_metadata(json_config.table))
           :ok

--- a/apps/pipeline/lib/pipeline/writer/s3_writer.ex
+++ b/apps/pipeline/lib/pipeline/writer/s3_writer.ex
@@ -51,7 +51,14 @@ defmodule Pipeline.Writer.S3Writer do
 
     case table_exists?(json_config) do
       true ->
-        upload_content(content, json_config.schema, json_config.table, bucket)
+        if is_partitioned_write(options) do
+          get_partition_folder(options) |> IO.inspect(label: "get_partition_folder(options)")
+          upload_content(content, json_config.schema, json_config.table, bucket, get_partition_folder(options))
+          PrestigeHelper.execute_query(Statement.sync_partition_metadata(json_config.table))
+          :ok
+        else
+          upload_content(content, json_config.schema, json_config.table, bucket)
+        end
 
       {:error, %{name: "TABLE_NOT_FOUND", type: "USER_ERROR"}} ->
         case init(options) do
@@ -64,17 +71,15 @@ defmodule Pipeline.Writer.S3Writer do
     end
   end
 
+  defp upload_content(content, schema, table, bucket, partition_folder) do
+    source_file_path = write_content_to_temp(content, schema, table)
+    destination_file_path = generate_unique_s3_file_path(table, partition_folder)
+    upload_to_kdp_s3_folder(bucket, source_file_path, destination_file_path)
+  end
+
   defp upload_content(content, schema, table, bucket) do
-    source_file_path =
-      content
-      |> Enum.map(&Map.get(&1, :payload))
-      |> Enum.map(&S3SafeJson.build(&1, schema))
-      |> Enum.map(&Jason.encode!/1)
-      |> Enum.join("\n")
-      |> write_to_temporary_file(table)
-
+    source_file_path = write_content_to_temp(content, schema, table)
     destination_file_path = generate_unique_s3_file_path(table)
-
     upload_to_kdp_s3_folder(bucket, source_file_path, destination_file_path)
   end
 
@@ -118,6 +123,11 @@ defmodule Pipeline.Writer.S3Writer do
     File.write!(temporary_file_path, file_contents, [:compressed])
 
     temporary_file_path
+  end
+
+  defp generate_unique_s3_file_path(table_name, partition_folder) do
+    time = DateTime.utc_now() |> DateTime.to_unix() |> to_string()
+    "hive-s3/#{table_name}/#{partition_folder}/#{time}-#{System.unique_integer()}.gz"
   end
 
   defp generate_unique_s3_file_path(table_name) do
@@ -197,5 +207,24 @@ defmodule Pipeline.Writer.S3Writer do
 
     table_name
     |> StatementUtils.drop_table()
+  end
+
+  defp get_partition_folder(options) do
+    partition_key = Keyword.fetch!(options, :partition_key)
+    partition_value = Keyword.fetch!(options, :partition_value)
+    "#{partition_key}=#{partition_value}"
+  end
+
+  defp is_partitioned_write(options) do
+    Keyword.has_key?(options, :partition_key) && Keyword.has_key?(options, :partition_value)
+  end
+
+  defp write_content_to_temp(content, schema, table) do
+    content
+    |> Enum.map(&Map.get(&1, :payload))
+    |> Enum.map(&S3SafeJson.build(&1, schema))
+    |> Enum.map(&Jason.encode!/1)
+    |> Enum.join("\n")
+    |> write_to_temporary_file(table)
   end
 end

--- a/apps/pipeline/lib/pipeline/writer/table_writer/helper/prestige_helper.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/helper/prestige_helper.ex
@@ -26,8 +26,14 @@ defmodule Pipeline.Writer.TableWriter.Helper.PrestigeHelper do
     |> Prestige.new_session()
   end
 
-  def drop_table(table) do
-    %{table: table}
+  def drop_table(%{"Table" => table_name}) do
+    %{table: table_name}
+    |> Statement.drop()
+    |> execute_query()
+  end
+
+  def drop_table(table_name) do
+    %{table: table_name}
     |> Statement.drop()
     |> execute_query()
   end

--- a/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
@@ -14,6 +14,16 @@ defmodule Pipeline.Writer.TableWriter.Statement do
     {:ok, "create table #{name} as (#{select})"}
   end
 
+  def create(%{table: name, schema: schema, format: format, partitions: partitions}) do
+    {:ok, Create.compose(name, schema, format, partitions)}
+  rescue
+    e in FieldTypeError ->
+      {:error, e.message}
+
+    e ->
+      {:error, "Unable to parse schema: #{inspect(e)}"}
+  end
+
   def create(%{table: name, schema: schema, format: format}) do
     {:ok, Create.compose(name, schema, format)}
   rescue

--- a/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
@@ -66,6 +66,10 @@ defmodule Pipeline.Writer.TableWriter.Statement do
     "select * from #{table_one} union all select * from #{table_two}"
   end
 
+  def sync_partition_metadata(table_name) do
+    "CALL system.sync_partition_metadata('default', '#{table_name}', 'ADD')"
+  end
+
   def create_new_table_with_existing_table(%{new_table_name: new_table_name, table_name: table_name}) do
     %{table: "#{new_table_name}", as: "select * from #{table_name}"}
     |> create()

--- a/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
@@ -14,8 +14,8 @@ defmodule Pipeline.Writer.TableWriter.Statement do
     {:ok, "create table #{name} as (#{select})"}
   end
 
-  def create(%{table: name, schema: schema, format: format, partitions: partitions}) do
-    {:ok, Create.compose(name, schema, format, partitions)}
+  def create(%{table: name, schema: schema, format: format, partitions: nil}) do
+    {:ok, Create.compose(name, schema, format)}
   rescue
     e in FieldTypeError ->
       {:error, e.message}
@@ -24,8 +24,8 @@ defmodule Pipeline.Writer.TableWriter.Statement do
       {:error, "Unable to parse schema: #{inspect(e)}"}
   end
 
-  def create(%{table: name, schema: schema, format: format}) do
-    {:ok, Create.compose(name, schema, format)}
+  def create(%{table: name, schema: schema, format: format, partitions: partitions}) do
+    {:ok, Create.compose(name, schema, format, partitions)}
   rescue
     e in FieldTypeError ->
       {:error, e.message}

--- a/apps/pipeline/lib/pipeline/writer/table_writer/statement/create.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/statement/create.ex
@@ -23,6 +23,15 @@ defmodule Pipeline.Writer.TableWriter.Statement.Create do
     "CREATE TABLE IF NOT EXISTS #{name} (#{translate_columns(schema)})  WITH (format = '#{format}')"
   end
 
+  def compose(name, schema, format, partitions) do
+    create_statement = compose(name, schema)
+    quoted_partitions = partitions |> Enum.map(fn p -> "'#{p}'" end)
+    partition = "partitioned_by = ARRAY[" <> (quoted_partitions |> Enum.join(", ")) <> "]"
+    format = "format = '#{format}'"
+
+    "#{create_statement} WITH (#{partition}, #{format})"
+  end
+
   defp translate_columns(cols) do
     cols
     |> Enum.map(&translate_column/1)

--- a/apps/pipeline/mix.exs
+++ b/apps/pipeline/mix.exs
@@ -4,7 +4,7 @@ defmodule Pipeline.MixProject do
   def project do
     [
       app: :pipeline,
-      version: "0.1.8",
+      version: "0.1.9",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/pipeline/test/integration/test_helper.exs
+++ b/apps/pipeline/test/integration/test_helper.exs
@@ -1,5 +1,6 @@
 defmodule Pipeline.TestHandler do
   use Elsa.Consumer.MessageHandler
+  alias Pipeline.Writer.TableWriter.Helper.PrestigeHelper
 
   def init(_ \\ []) do
     {:ok, []}
@@ -8,6 +9,11 @@ defmodule Pipeline.TestHandler do
   def handle_messages(messages, state) do
     Registry.put_meta(Pipeline.TestRegistry, :messages, messages)
     {:ack, state}
+  end
+
+  def drop_all_tables() do
+    {:ok, result} = PrestigeHelper.execute_query("show tables")
+    result |> Prestige.Result.as_maps() |> Enum.each(&PrestigeHelper.drop_table/1)
   end
 end
 

--- a/apps/pipeline/test/unit/pipeline/writer/table_writer/statement_test.exs
+++ b/apps/pipeline/test/unit/pipeline/writer/table_writer/statement_test.exs
@@ -58,7 +58,7 @@ defmodule Pipeline.Writer.TableWriter.StatementTest do
     end
 
     @tag capture_log: true
-    test "handles a single partition parameters" do
+    test "handles a single column in the partitions parameter" do
       schema = [
         %{name: "street", type: "string"},
         %{name: "first_name", type: "string"}
@@ -72,7 +72,7 @@ defmodule Pipeline.Writer.TableWriter.StatementTest do
     end
 
     @tag capture_log: true
-    test "handles multiple partition parameters" do
+    test "handles multiple columns in the partition parameter" do
       schema = [
         %{name: "street", type: "string"},
         %{name: "first_name", type: "string"},

--- a/apps/pipeline/test/unit/pipeline/writer/table_writer/statement_test.exs
+++ b/apps/pipeline/test/unit/pipeline/writer/table_writer/statement_test.exs
@@ -58,6 +58,40 @@ defmodule Pipeline.Writer.TableWriter.StatementTest do
     end
 
     @tag capture_log: true
+    test "handles a single partition parameters" do
+      schema = [
+        %{name: "street", type: "string"},
+        %{name: "first_name", type: "string"}
+      ]
+
+      expected =
+        ~s|CREATE TABLE IF NOT EXISTS table_name ("street" varchar, "first_name" varchar) WITH (partitioned_by = ARRAY['first_name'], format = 'JSON')|
+
+      assert {:ok, ^expected} =
+               Statement.create(%{table: "table_name", schema: schema, format: "JSON", partitions: ["first_name"]})
+    end
+
+    @tag capture_log: true
+    test "handles multiple partition parameters" do
+      schema = [
+        %{name: "street", type: "string"},
+        %{name: "first_name", type: "string"},
+        %{name: "last_name", type: "string"}
+      ]
+
+      expected =
+        ~s|CREATE TABLE IF NOT EXISTS table_name ("street" varchar, "first_name" varchar, "last_name" varchar) WITH (partitioned_by = ARRAY['first_name', 'last_name'], format = 'JSON')|
+
+      assert {:ok, ^expected} =
+               Statement.create(%{
+                 table: "table_name",
+                 schema: schema,
+                 format: "JSON",
+                 partitions: ["first_name", "last_name"]
+               })
+    end
+
+    @tag capture_log: true
     test "handles array of maps" do
       schema = [
         %{


### PR DESCRIPTION
## [Ticket Link #792](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/792)

## Description

- Ensure that `_ingestion_id` is after `_extract_start_time` in schema to allow for partitioning
- Partitions the json table by _ingestion_id
  - Updates s3Writer to support partition_value and partition_key options
- Move tests from `unit/integration` to `unit` to avoid confusion

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
