### PR TITLE
750 dynamic fields part 2

### DIFF
--- a/apps/alchemist/test/unit/alchemist/broadway_test.exs
+++ b/apps/alchemist/test/unit/alchemist/broadway_test.exs
@@ -13,166 +13,235 @@ defmodule Alchemist.BroadwayTest do
   @producer :ds1_producer
   @current_time "2019-07-17T14:45:06.123456Z"
 
-  setup do
-    allow Elsa.produce(any(), any(), any(), any()), return: :ok
-    allow SmartCity.Data.Timing.current_time(), return: @current_time, meck_options: [:passthrough]
+  describe "with valid transformations" do
+    setup do
+      allow Elsa.produce(any(), any(), any(), any()), return: :ok
+      allow SmartCity.Data.Timing.current_time(), return: @current_time, meck_options: [:passthrough]
 
-    transform1 =
-      TDG.create_transformation(%{
-        type: "regex_extract",
-        parameters: %{
-          "sourceField" => "phone",
-          "targetField" => "area_code",
-          "regex" => "\\((\\d{3})\\)"
-        }
-      })
+      transform1 =
+        TDG.create_transformation(%{
+          type: "regex_extract",
+          parameters: %{
+            "sourceField" => "phone",
+            "targetField" => "area_code",
+            "regex" => "\\((\\d{3})\\)"
+          }
+        })
 
-    transform2 =
-      TDG.create_transformation(%{
-        type: "regex_extract",
-        parameters: %{
-          "sourceField" => "first_name",
-          "targetField" => "first_letter",
-          "regex" => "^(\\w)"
-        }
-      })
+      transform2 =
+        TDG.create_transformation(%{
+          type: "regex_extract",
+          parameters: %{
+            "sourceField" => "first_name",
+            "targetField" => "first_letter",
+            "regex" => "^(\\w)"
+          }
+        })
 
-    ingestion =
-      TDG.create_ingestion(%{
-        id: @ingestion_id,
-        targetDataset: @dataset_id,
-        transformations: [transform1, transform2]
-      })
+      ingestion =
+        TDG.create_ingestion(%{
+          id: @ingestion_id,
+          targetDataset: @dataset_id,
+          transformations: [transform1, transform2]
+        })
 
-    {:ok, broadway} =
-      Alchemist.Broadway.start_link(
-        # ingestion is destructured in handle message as the th~ird argument
-        #   it serves as context for an incoming SmartCity.data message
-        ingestion: ingestion,
-        output: [
-          topic: :output_topic,
-          connection: @producer
-        ],
-        input: [
-          topics: [@topic]
-        ]
-      )
+      {:ok, broadway} =
+        Alchemist.Broadway.start_link(
+          # ingestion is destructured in handle message as the th~ird argument
+          #   it serves as context for an incoming SmartCity.data message
+          ingestion: ingestion,
+          output: [
+            topic: :output_topic,
+            connection: @producer
+          ],
+          input: [
+            topics: [@topic]
+          ]
+        )
 
-    on_exit(fn ->
-      ref = Process.monitor(broadway)
-      Process.exit(broadway, :normal)
-      assert_receive {:DOWN, ^ref, _, _, _}, 2_000
-    end)
+      on_exit(fn ->
+        ref = Process.monitor(broadway)
+        Process.exit(broadway, :normal)
+        assert_receive {:DOWN, ^ref, _, _, _}, 2_000
+      end)
 
-    [broadway: broadway]
+      [broadway: broadway]
+    end
+
+    test "given valid transformation ingestion data, should call Regex Extract, pulling out the relevant data", %{
+      broadway: broadway
+    } do
+      data =
+        TDG.create_data(
+          dataset_id: @dataset_id,
+          payload: %{
+            "phone" => "(555) 8675309",
+            "first_name" => "Nicole"
+          }
+        )
+
+      kafka_message = %{value: Jason.encode!(data)}
+
+      Broadway.test_batch(broadway, [kafka_message])
+
+      assert_receive {:ack, _ref, messages, _}, 5_000
+
+      assert 1 == length(messages)
+
+      payload =
+        messages
+        |> Enum.map(fn message -> Data.new(message.data.value) end)
+        |> Enum.map(fn {:ok, data} -> data end)
+        |> Enum.map(fn data -> data.payload end)
+        |> List.first()
+
+      assert Map.get(payload, "phone") == "(555) 8675309"
+      assert Map.get(payload, "area_code") == "555"
+      assert Map.get(payload, "first_name") == "Nicole"
+      assert Map.get(payload, "first_letter") == "N"
+    end
+
+    test "should return empty timing when profiling status is not true", %{broadway: broadway} do
+      Application.put_env(:alchemist, :profiling_enabled, false)
+      data = TDG.create_data(dataset_id: @dataset_id, payload: %{"name" => "johnny", "age" => 21})
+      kafka_message = %{value: Jason.encode!(data)}
+
+      Broadway.test_batch(broadway, [kafka_message])
+
+      assert_receive {:ack, _ref, messages, _}, 5_000
+
+      timing =
+        messages
+        |> Enum.map(fn message -> Data.new(message.data.value) end)
+        |> Enum.map(fn {:ok, data} -> data.operational.timing end)
+        |> List.flatten()
+        |> Enum.filter(fn timing -> timing.app == "alchemist" end)
+
+      assert timing == []
+    end
+
+    test "should send the messages to the output kafka topic", %{broadway: broadway} do
+      data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
+      data2 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(123) 456-7890", "first_name" => "carl"})
+      kafka_messages = [%{value: Jason.encode!(data1)}, %{value: Jason.encode!(data2)}]
+
+      Broadway.test_batch(broadway, kafka_messages)
+
+      assert_receive {:ack, _ref, messages, _}, 5_000
+      assert 2 == length(messages)
+
+      captured_messages = capture(Elsa.produce(:"#{@dataset_id}_producer", :output_topic, any(), partition: 0), 3)
+
+      assert 2 = length(captured_messages)
+    end
+
+    test "should dead letter messages that don't match the SmartCity.Message struct", %{broadway: broadway} do
+      badData = %{bad_field: "junk"}
+      kafka_messages = [%{value: Jason.encode!(badData)}]
+      Broadway.test_batch(broadway, kafka_messages)
+
+      assert_receive {:ack, _ref, _, [message]}, 5_000
+      assert {:failed, "Invalid data message: %{\"bad_field\" => \"junk\"}"} == message.status
+
+      eventually(fn ->
+        {:ok, dead_message} = DeadLetter.Carrier.Test.receive()
+        refute dead_message == :empty
+
+        assert dead_message.app == "Alchemist"
+        assert dead_message.dataset_id == @dataset_id
+        assert dead_message.original_message == Jason.encode!(badData)
+        assert dead_message.reason == "Invalid data message: %{\"bad_field\" => \"junk\"}"
+      end)
+    end
+
+    test "should dead letter messages that fail to be transformed", %{broadway: broadway} do
+      data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"name" => "johnny", "age" => 21})
+
+      kafka_messages = [%{value: Jason.encode!(data1)}]
+
+      Broadway.test_batch(broadway, kafka_messages)
+
+      assert_receive {:ack, _ref, _, failed_messages}, 5_000
+      assert 1 == length(failed_messages)
+
+      eventually(fn ->
+        {:ok, dead_message} = DeadLetter.Carrier.Test.receive()
+        refute dead_message == :empty
+
+        assert dead_message.app == "Alchemist"
+        assert dead_message.dataset_id == "ds1"
+        assert dead_message.original_message == Jason.encode!(data1)
+      end)
+    end
   end
 
-  test "given valid transformation ingestion data, should call Regex Extract, pulling out the relevant data", %{
-    broadway: broadway
-  } do
-    data =
-      TDG.create_data(
-        dataset_id: @dataset_id,
-        payload: %{
-          "phone" => "(555) 8675309",
-          "first_name" => "Nicole"
-        }
-      )
+  describe "with invalid transformation" do
+    setup do
+      allow Elsa.produce(any(), any(), any(), any()), return: :ok
+      allow SmartCity.Data.Timing.current_time(), return: @current_time, meck_options: [:passthrough]
 
-    kafka_message = %{value: Jason.encode!(data)}
+      transform =
+        TDG.create_transformation(%{
+          type: "regex_extract",
+          parameters: %{
+            :sourceField => "phone",
+            :targetField => "area_code",
+            :regex => "^\((\d{3})"
+          }
+        })
 
-    Broadway.test_batch(broadway, [kafka_message])
+      ingestion =
+        TDG.create_ingestion(%{
+          id: @ingestion_id,
+          targetDataset: @dataset_id,
+          transformations: [transform]
+        })
 
-    assert_receive {:ack, _ref, messages, _}, 5_000
+      {:ok, broadway} =
+        Alchemist.Broadway.start_link(
+          # ingestion is destructured in handle message as the th~ird argument
+          #   it serves as context for an incoming SmartCity.data message
+          ingestion: ingestion,
+          output: [
+            topic: :output_topic,
+            connection: @producer
+          ],
+          input: [
+            topics: [@topic]
+          ]
+        )
 
-    assert 1 == length(messages)
+      on_exit(fn ->
+        ref = Process.monitor(broadway)
+        Process.exit(broadway, :normal)
+        assert_receive {:DOWN, ^ref, _, _, _}, 2_000
+      end)
 
-    payload =
-      messages
-      |> Enum.map(fn message -> Data.new(message.data.value) end)
-      |> Enum.map(fn {:ok, data} -> data end)
-      |> Enum.map(fn data -> data.payload end)
-      |> List.first()
+      [broadway: broadway]
+    end
 
-    assert Map.get(payload, "phone") == "(555) 8675309"
-    assert Map.get(payload, "area_code") == "555"
-    assert Map.get(payload, "first_name") == "Nicole"
-    assert Map.get(payload, "first_letter") == "N"
-  end
+    test "should dead letter messages", %{broadway: broadway} do
+      data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
 
-  test "should return empty timing when profiling status is not true", %{broadway: broadway} do
-    Application.put_env(:alchemist, :profiling_enabled, false)
-    data = TDG.create_data(dataset_id: @dataset_id, payload: %{"name" => "johnny", "age" => 21})
-    kafka_message = %{value: Jason.encode!(data)}
+      kafka_messages = [%{value: Jason.encode!(data1)}]
 
-    Broadway.test_batch(broadway, [kafka_message])
+      Broadway.test_batch(broadway, kafka_messages)
 
-    assert_receive {:ack, _ref, messages, _}, 5_000
+      assert_receive {:ack, _ref, _, failed_messages}, 5_000
+      assert 1 == length(failed_messages)
 
-    timing =
-      messages
-      |> Enum.map(fn message -> Data.new(message.data.value) end)
-      |> Enum.map(fn {:ok, data} -> data.operational.timing end)
-      |> List.flatten()
-      |> Enum.filter(fn timing -> timing.app == "alchemist" end)
+      eventually(fn ->
+        {:ok, dead_message} = DeadLetter.Carrier.Test.receive()
+        refute dead_message == :empty
 
-    assert timing == []
-  end
-
-  test "should send the messages to the output kafka topic", %{broadway: broadway} do
-    data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
-    data2 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(123) 456-7890", "first_name" => "carl"})
-    kafka_messages = [%{value: Jason.encode!(data1)}, %{value: Jason.encode!(data2)}]
-
-    Broadway.test_batch(broadway, kafka_messages)
-
-    assert_receive {:ack, _ref, messages, _}, 5_000
-    assert 2 == length(messages)
-
-    captured_messages = capture(Elsa.produce(:"#{@dataset_id}_producer", :output_topic, any(), partition: 0), 3)
-
-    assert 2 = length(captured_messages)
-  end
-
-  test "should dead letter messages that don't match the SmartCity.Message struct", %{broadway: broadway} do
-    badData = %{bad_field: "junk"}
-    kafka_messages = [%{value: Jason.encode!(badData)}]
-    Broadway.test_batch(broadway, kafka_messages)
-
-    assert_receive {:ack, _ref, _, [message]}, 5_000
-    assert {:failed, "Invalid data message: %{\"bad_field\" => \"junk\"}"} == message.status
-
-    eventually(fn ->
-      {:ok, dead_message} = DeadLetter.Carrier.Test.receive()
-      refute dead_message == :empty
-
-      assert dead_message.app == "Alchemist"
-      assert dead_message.dataset_id == @dataset_id
-      assert dead_message.original_message == Jason.encode!(badData)
-      assert dead_message.reason == "Invalid data message: %{\"bad_field\" => \"junk\"}"
-    end)
-  end
-
-  test "should dead letter messages that fail to be transformed", %{broadway: broadway} do
-    data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"name" => "johnny", "age" => 21})
-
-    kafka_messages = [%{value: Jason.encode!(data1)}]
-
-    Broadway.test_batch(broadway, kafka_messages)
-
-    assert_receive {:ack, _ref, _, failed_messages}, 5_000
-    assert 1 == length(failed_messages)
-
-    eventually(fn ->
-      {:ok, dead_message} = DeadLetter.Carrier.Test.receive()
-      refute dead_message == :empty
-
-      assert dead_message.app == "Alchemist"
-      assert dead_message.dataset_id == "ds1"
-      assert dead_message.original_message == Jason.encode!(data1)
-    end)
+        assert dead_message.app == "Alchemist"
+        assert dead_message.dataset_id == "ds1"
+        assert dead_message.original_message == Jason.encode!(data1)
+      end)
+    end
   end
 end
+
 
 defmodule Fake.Producer do
   use GenStage

--- a/apps/alchemist/test/unit/alchemist/broadway_test.exs
+++ b/apps/alchemist/test/unit/alchemist/broadway_test.exs
@@ -121,7 +121,9 @@ defmodule Alchemist.BroadwayTest do
     end
 
     test "should send the messages to the output kafka topic", %{broadway: broadway} do
-      data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
+      data1 =
+        TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
+
       data2 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(123) 456-7890", "first_name" => "carl"})
       kafka_messages = [%{value: Jason.encode!(data1)}, %{value: Jason.encode!(data2)}]
 
@@ -221,7 +223,8 @@ defmodule Alchemist.BroadwayTest do
     end
 
     test "should dead letter messages", %{broadway: broadway} do
-      data1 = TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
+      data1 =
+        TDG.create_data(dataset_id: @dataset_id, payload: %{"phone" => "(555) 555-5555", "first_name" => "johnny"})
 
       kafka_messages = [%{value: Jason.encode!(data1)}]
 
@@ -241,7 +244,6 @@ defmodule Alchemist.BroadwayTest do
     end
   end
 end
-
 
 defmodule Fake.Producer do
   use GenStage

--- a/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
+++ b/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
@@ -71,9 +71,8 @@ defmodule Andi.InputSchemas.Ingestions.Transformation do
       {:ok, _} -> changeset
       {:error, reason} when is_binary(reason) -> changeset
       {:error, reasons} ->
-        Enum.reduce(Map.keys(reasons), changeset, fn key, changeset ->
-          error_message = Map.get(reasons, key)
-          add_error(changeset, :parameters, error_message, field: key)
+        Enum.reduce(reasons, changeset, fn {key, value}, changeset ->
+          add_error(changeset, key, value)
         end)
     end
   end

--- a/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
+++ b/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
@@ -72,7 +72,8 @@ defmodule Andi.InputSchemas.Ingestions.Transformation do
       {:error, reason} when is_binary(reason) -> changeset
       {:error, reasons} ->
         Enum.reduce(reasons, changeset, fn {key, value}, changeset ->
-          add_error(changeset, key, value)
+          atom_key = String.to_atom(key)
+          add_error(changeset, atom_key, value)
         end)
     end
   end

--- a/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
+++ b/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
@@ -68,8 +68,12 @@ defmodule Andi.InputSchemas.Ingestions.Transformation do
     converted_parameters = convert_parameters_from_atom_to_string(parameters)
 
     case Transformers.OperationBuilder.validate(type, converted_parameters) do
-      {:ok, _} -> changeset
-      {:error, reason} when is_binary(reason) -> changeset
+      {:ok, _} ->
+        changeset
+
+      {:error, reason} when is_binary(reason) ->
+        changeset
+
       {:error, reasons} ->
         Enum.reduce(reasons, changeset, fn {key, value}, changeset ->
           atom_key = String.to_atom(key)

--- a/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
+++ b/apps/andi/lib/andi/input_schemas/ingestions/transformation.ex
@@ -65,14 +65,16 @@ defmodule Andi.InputSchemas.Ingestions.Transformation do
   defp validate_type(changeset), do: changeset
 
   defp validate_parameters(%{changes: %{type: type, parameters: parameters}} = changeset) do
-    transformation = %{
-      type: type,
-      parameters: convert_parameters_from_atom_to_string(parameters)
-    }
+    converted_parameters = convert_parameters_from_atom_to_string(parameters)
 
-    case Transformers.validate([transformation]) do
-      [{:ok, _}] -> changeset
-      [{:error, reason}] -> add_error(changeset, :parameters, reason)
+    case Transformers.OperationBuilder.validate(type, converted_parameters) do
+      {:ok, _} -> changeset
+      {:error, reason} when is_binary(reason) -> changeset
+      {:error, reasons} ->
+        Enum.reduce(Map.keys(reasons), changeset, fn key, changeset ->
+          error_message = Map.get(reasons, key)
+          add_error(changeset, :parameters, error_message, field: key)
+        end)
     end
   end
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
@@ -6,12 +6,13 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
 
   def build_input(%{field_type: "string"} = field, assigns, form) do
     name = String.to_atom(field.field_name)
+    value = get_in(form.source.changes, [:parameters, name])
 
     ~L"""
     <div class="transformation-field">
       <%= label(form, name, field.field_label, class: "transformation-field-label label label--required") %>
-      <%= text_input(form, name, class: "input transformation-form-fields", phx_debounce: "1000") %>
-      <%= ErrorHelpers.error_tag_with_label(form.source, field.field_name, field.field_label, bind_to_input: false) %>
+      <%= text_input(form, name, value: value, class: "input transformation-form-fields", phx_debounce: "1000") %>
+      <%= ErrorHelpers.error_tag_with_label(form.source, name, field.field_label, bind_to_input: false) %>
     </div>
     """
   end

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
@@ -5,25 +5,14 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
   alias AndiWeb.ErrorHelpers
 
   def build_input(%{field_type: "string"} = field, assigns, form) do
-    transformation_id = get_transformation_id(assigns)
-    field_id = build_field_id(transformation_id, field.field_name)
-    name = "form_data[parameters][#{field.field_name}]"
+    name = String.to_atom(field.field_name)
 
     ~L"""
     <div class="transformation-field">
-      <%= label(form, field_id, field.field_label, class: "transformation-field-label label label--required") %>
-      <%= text_input(form, field_id, name: name, class: "input transformation-form-fields", phx_debounce: "1000") %>
+      <%= label(form, name, field.field_label, class: "transformation-field-label label label--required") %>
+      <%= text_input(form, name, class: "input transformation-form-fields", phx_debounce: "1000") %>
       <%= ErrorHelpers.error_tag_with_label(form.source, field.field_name, field.field_label, bind_to_input: false) %>
     </div>
     """
-  end
-
-  defp get_transformation_id(assigns) do
-    assigns.transformation_changeset.changes.id
-  end
-
-  defp build_field_id(transformation_id, field_name) do
-    field_id_content = "transformation-#{transformation_id}-#{field_name}"
-    String.to_atom(field_id_content)
   end
 end

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
@@ -2,14 +2,18 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
   import Phoenix.HTML.Form
   import Phoenix.LiveView.Helpers
 
+  alias AndiWeb.ErrorHelpers
+
   def build_input(%{field_type: "string"} = field, assigns, form) do
     transformation_id = get_transformation_id(assigns)
     field_id = build_field_id(transformation_id, field.field_name)
+    name = "form_data[parameters][#{field.field_name}]"
 
     ~L"""
     <div class="transformation-field">
       <%= label(form, field_id, field.field_label, class: "transformation-field-label label label--required") %>
-      <%= text_input(form, field_id, name: field.field_name, class: "input transformation-form-fields", phx_debounce: "1000") %>
+      <%= text_input(form, field_id, name: name, class: "input transformation-form-fields", phx_debounce: "1000") %>
+      <%= ErrorHelpers.error_tag_with_label(form.source, field.field_name, field.field_label, bind_to_input: false) %>
     </div>
     """
   end

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -19,11 +19,13 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
   def mount(_params, %{"transformation_changeset" => transformation_changeset}, socket) do
     AndiWeb.Endpoint.subscribe("form-save")
 
+    transformation_type = Map.get(transformation_changeset.changes, :type)
+
     {:ok,
      assign(socket,
        transformation_changeset: transformation_changeset,
        visibility: "collapsed",
-       transformation_type: ""
+       transformation_type: transformation_type
      )}
   end
 

--- a/apps/andi/lib/andi_web/views/error_helpers.ex
+++ b/apps/andi/lib/andi_web/views/error_helpers.ex
@@ -10,7 +10,6 @@ defmodule AndiWeb.ErrorHelpers do
   alias AndiWeb.InputSchemas.SubmissionMetadataFormSchema
   alias AndiWeb.Views.DisplayNames
 
-
   @doc """
   Generates tag for inlined form input errors.
   """
@@ -39,6 +38,7 @@ defmodule AndiWeb.ErrorHelpers do
 
   def error_tag_with_label(form, field, label, options \\ [])
   def error_tag_with_label(form, _, _, _) when not is_map(form), do: []
+
   def error_tag_with_label(form, field, label, options) do
     form.errors
     |> Map.new()
@@ -50,9 +50,12 @@ defmodule AndiWeb.ErrorHelpers do
 
   defp generate_error_tag_with_label(error, field, form, label, options) do
     %{data: %form_type{}} = form
-    translated = error
+
+    translated =
+      error
       |> interpret_error_with_label(field, form_type, label)
       |> translate_error()
+
     content_tag(:span, translated,
       class: "error-msg",
       id: "#{field}-error-msg",
@@ -130,7 +133,8 @@ defmodule AndiWeb.ErrorHelpers do
 
   defp interpret_error_message(_message, field, _), do: default_error_message(field)
 
-  defp interpret_error_with_label({_message, opts}, _field, form_type, label), do: {interpret_error_message_with_label(label, form_type), opts}
+  defp interpret_error_with_label({_message, opts}, _field, form_type, label),
+    do: {interpret_error_message_with_label(label, form_type), opts}
 
   defp interpret_error_message_with_label(label, Transformation) do
     "Please enter a valid #{String.downcase(label)}"

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.3.3",
+      version: "2.3.5",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi/input_schemas/ingestions/transformation_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/ingestions/transformation_test.exs
@@ -32,7 +32,7 @@ defmodule Andi.InputSchemas.Ingestions.TransformationTest do
 
     changeset = Transformation.changeset(changes)
 
-    assert changeset.errors == [{:parameters, {"Missing or empty field", [field: "separator"]}}]
+    assert changeset.errors == [{"separator", {"Missing or empty field", []}}]
     assert not changeset.valid?
   end
 

--- a/apps/andi/test/unit/andi/input_schemas/ingestions/transformation_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/ingestions/transformation_test.exs
@@ -32,7 +32,7 @@ defmodule Andi.InputSchemas.Ingestions.TransformationTest do
 
     changeset = Transformation.changeset(changes)
 
-    assert changeset.errors == [{:parameters, {"Transformation not valid.", []}}]
+    assert changeset.errors == [{:parameters, {"Missing or empty field", [field: "separator"]}}]
     assert not changeset.valid?
   end
 

--- a/apps/andi/test/unit/andi/input_schemas/ingestions/transformation_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/ingestions/transformation_test.exs
@@ -20,7 +20,7 @@ defmodule Andi.InputSchemas.Ingestions.TransformationTest do
     assert changeset.valid?
   end
 
-  test "fails for an invalid transformation" do
+  test "fails for an invalid transformation with atom key" do
     changes = %{
       type: "concatenation",
       name: "name",
@@ -32,7 +32,7 @@ defmodule Andi.InputSchemas.Ingestions.TransformationTest do
 
     changeset = Transformation.changeset(changes)
 
-    assert changeset.errors == [{"separator", {"Missing or empty field", []}}]
+    assert changeset.errors == [{:separator, {"Missing field", []}}]
     assert not changeset.valid?
   end
 

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -100,18 +100,31 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       assert element(view, "##{field_id}") |> has_element?()
     end
 
-    @tag :skip
     test "shows error message if field missing" do
-      transformation_changeset = Transformation.changeset_for_draft(%{})
+      transformation_changeset = Transformation.changeset_for_draft(%{type: "remove"})
       assert {:ok, view, html} = render_transformation_form(transformation_changeset)
 
-      select_type("remove", view)
       form_update = %{
         "parameters" => %{"sourceField" => ""}
       }
-      element(view, ".transformation-item") |> render_change(form_update) |> IO.inspect()
+
+      element(view, ".transformation-item") |> render_change(form_update)
 
       assert element(view, "#sourceField-error-msg", "Please enter a valid field to remove") |> has_element?()
+    end
+
+    test "shows parameter field value on load" do
+      parameter_value = "something"
+      transformation_changeset = Transformation.changeset_for_draft(%{type: "remove", parameters: %{sourceField: parameter_value}})
+
+      assert {:ok, view, html} = render_transformation_form(transformation_changeset)
+
+      field_id = build_field_id("sourceField")
+      {:ok, document} = Floki.parse_document(html)
+      
+      assert parameter_value == document
+      |> Floki.attribute("##{field_id}", "value")
+      |> Enum.join()
     end
   end
 

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -83,7 +83,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
 
       select_type("remove", view)
 
-      field_id = build_field_id(transformation_changeset.changes.id, "sourceField")
+      field_id = build_field_id("sourceField")
       assert has_element?(view, ".transformation-field")
       assert element(view, "label[for=#{field_id}]", "Field to Remove") |> has_element?()
       assert element(view, "##{field_id}") |> has_element?()
@@ -113,7 +113,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
     element(view, "#form_data_type") |> render_click(click_value)
   end
 
-  defp build_field_id(transformation_id, field_name) do
-    "form_data_transformation-#{transformation_id}-#{field_name}"
+  defp build_field_id(field_name) do
+    "form_data_#{field_name}"
   end
 end

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -121,10 +121,11 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
 
       field_id = build_field_id("sourceField")
       {:ok, document} = Floki.parse_document(html)
-      
-      assert parameter_value == document
-      |> Floki.attribute("##{field_id}", "value")
-      |> Enum.join()
+
+      assert parameter_value ==
+               document
+               |> Floki.attribute("##{field_id}", "value")
+               |> Enum.join()
     end
   end
 

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -88,6 +88,20 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       assert element(view, "label[for=#{field_id}]", "Field to Remove") |> has_element?()
       assert element(view, "##{field_id}") |> has_element?()
     end
+
+    @tag :skip
+    test "shows error message if field missing" do
+      transformation_changeset = Transformation.changeset_for_draft(%{})
+      assert {:ok, view, html} = render_transformation_form(transformation_changeset)
+
+      select_type("remove", view)
+      form_update = %{
+        "parameters" => %{"sourceField" => ""}
+      }
+      element(view, ".transformation-item") |> render_change(form_update) |> IO.inspect()
+
+      assert element(view, "#sourceField-error-msg", "Please enter a valid field to remove") |> has_element?()
+    end
   end
 
   defp render_transformation_form(transformation_changeset) do

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -89,6 +89,17 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       assert element(view, "##{field_id}") |> has_element?()
     end
 
+    test "if type is selected show fields on load" do
+      transformation_changeset = Transformation.changeset_for_draft(%{type: "remove"})
+
+      assert {:ok, view, html} = render_transformation_form(transformation_changeset)
+
+      field_id = build_field_id("sourceField")
+      assert has_element?(view, ".transformation-field")
+      assert element(view, "label[for=#{field_id}]", "Field to Remove") |> has_element?()
+      assert element(view, "##{field_id}") |> has_element?()
+    end
+
     @tag :skip
     test "shows error message if field missing" do
       transformation_changeset = Transformation.changeset_for_draft(%{})

--- a/apps/transformers/lib/conversion_functions.ex
+++ b/apps/transformers/lib/conversion_functions.ex
@@ -1,0 +1,13 @@
+defmodule Transformers.ConversionFunctions do
+  def pick(source_type, target_type) do
+    case {source_type, target_type} do
+      {"float", "integer"} -> {:ok, fn value -> Float.round(value) end}
+      {"float", "string"} -> {:ok, fn value -> to_string(value) end}
+      {"integer", "float"} -> {:ok, fn value -> value / 1 end}
+      {"integer", "string"} -> {:ok, fn value -> to_string(value) end}
+      {"string", "integer"} -> {:ok, fn value -> String.to_integer(value) end}
+      {"string", "float"} -> {:ok, fn value -> String.to_float(value) end}
+      _ -> {:error, "Conversion from #{source_type} to #{target_type} is not supported"}
+    end
+  end
+end

--- a/apps/transformers/lib/field_fetcher.ex
+++ b/apps/transformers/lib/field_fetcher.ex
@@ -1,4 +1,13 @@
 defmodule Transformers.FieldFetcher do
+
+  def fetch_value_or_error(parameters, field) do
+    result = fetch_parameter_new(parameters, field)
+    case result do
+      {:ok, value} -> {:ok, value}
+      {:error, reason} -> {:error, %{field => reason}}
+    end
+  end
+
   def fetch_parameter(params, field_name) do
     fetch_or_error(params, field_name, "Missing transformation parameter: #{field_name}")
   end

--- a/apps/transformers/lib/field_fetcher.ex
+++ b/apps/transformers/lib/field_fetcher.ex
@@ -13,12 +13,7 @@ defmodule Transformers.FieldFetcher do
   end
 
   def fetch_parameter_new(params, field_name) do
-    error_msg = "Missing or empty field"
-    fetch_result = fetch_or_error(params, field_name, error_msg)
-    case fetch_result do
-      {:ok, field} -> non_empty_field_or_error(field, error_msg)
-      {:error, reason} -> {:error, reason}
-    end
+    fetch_or_error(params, field_name, "Missing or empty field")
   end
 
   def fetch_value(payload, field_name) do
@@ -29,14 +24,6 @@ defmodule Transformers.FieldFetcher do
     case Map.fetch(map, field_name) do
       {:ok, field} -> {:ok, field}
       :error -> {:error, error_msg}
-    end
-  end
-
-  defp non_empty_field_or_error(field, error_msg) do
-    if field == "" do
-      {:error, error_msg}
-    else
-      {:ok, field}
     end
   end
 end

--- a/apps/transformers/lib/field_fetcher.ex
+++ b/apps/transformers/lib/field_fetcher.ex
@@ -3,6 +3,10 @@ defmodule Transformers.FieldFetcher do
     fetch_or_error(params, field_name, "Missing transformation parameter: #{field_name}")
   end
 
+  def fetch_parameter_new(params, field_name) do
+    fetch_or_error(params, field_name, "Missing or empty field")
+  end
+
   def fetch_value(payload, field_name) do
     fetch_or_error(payload, field_name, "Missing field in payload: #{field_name}")
   end

--- a/apps/transformers/lib/field_fetcher.ex
+++ b/apps/transformers/lib/field_fetcher.ex
@@ -13,7 +13,12 @@ defmodule Transformers.FieldFetcher do
   end
 
   def fetch_parameter_new(params, field_name) do
-    fetch_or_error(params, field_name, "Missing or empty field")
+    error_msg = "Missing or empty field"
+    fetch_result = fetch_or_error(params, field_name, error_msg)
+    case fetch_result do
+      {:ok, field} -> non_empty_field_or_error(field, error_msg)
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   def fetch_value(payload, field_name) do
@@ -24,6 +29,14 @@ defmodule Transformers.FieldFetcher do
     case Map.fetch(map, field_name) do
       {:ok, field} -> {:ok, field}
       :error -> {:error, error_msg}
+    end
+  end
+
+  defp non_empty_field_or_error(field, error_msg) do
+    if field == "" do
+      {:error, error_msg}
+    else
+      {:ok, field}
     end
   end
 end

--- a/apps/transformers/lib/field_fetcher.ex
+++ b/apps/transformers/lib/field_fetcher.ex
@@ -1,7 +1,7 @@
 defmodule Transformers.FieldFetcher do
-
   def fetch_value_or_error(parameters, field) do
     result = fetch_parameter_new(parameters, field)
+
     case result do
       {:ok, value} -> {:ok, value}
       {:error, reason} -> {:error, %{field => reason}}

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -40,7 +40,7 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("concatenation", parameters) do
-    Transformers.Concatenation.validate_new(parameters)
+    Transformers.Concatenation.validate(parameters)
   end
 
   def validate("datetime", parameters) do

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -44,7 +44,7 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("datetime", parameters) do
-    Transformers.DateTime.validate_new(parameters)
+    Transformers.DateTime.validate(parameters)
   end
 
   def validate("remove", parameters) do

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -28,7 +28,7 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("regex_extract", parameters) do
-    Transformers.RegexExtract.validate_new(parameters)
+    Transformers.RegexExtract.validate(parameters)
   end
 
   def validate("regex_replace", parameters) do

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -48,7 +48,7 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("remove", parameters) do
-    Transformers.Remove.validate_new(parameters)
+    Transformers.Remove.validate(parameters)
   end
 
   def validate(unsupported, _) do

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -36,7 +36,7 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("conversion", parameters) do
-    Transformers.TypeConversion.validate_new(parameters)
+    Transformers.TypeConversion.validate(parameters)
   end
 
   def validate("concatenation", parameters) do

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -28,27 +28,27 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("regex_extract", parameters) do
-    Transformers.RegexExtract.validate(parameters)
+    Transformers.RegexExtract.validate_new(parameters)
   end
 
   def validate("regex_replace", parameters) do
-    Transformers.RegexReplace.validate(parameters)
+    Transformers.RegexReplace.validate_new(parameters)
   end
 
   def validate("conversion", parameters) do
-    Transformers.TypeConversion.validate(parameters)
+    Transformers.TypeConversion.validate_new(parameters)
   end
 
   def validate("concatenation", parameters) do
-    Transformers.Concatenation.validate(parameters)
+    Transformers.Concatenation.validate_new(parameters)
   end
 
   def validate("datetime", parameters) do
-    Transformers.DateTime.validate(parameters)
+    Transformers.DateTime.validate_new(parameters)
   end
 
   def validate("remove", parameters) do
-    Transformers.Remove.validate(parameters)
+    Transformers.Remove.validate_new(parameters)
   end
 
   def validate(unsupported, _) do

--- a/apps/transformers/lib/operation_builder.ex
+++ b/apps/transformers/lib/operation_builder.ex
@@ -32,7 +32,7 @@ defmodule Transformers.OperationBuilder do
   end
 
   def validate("regex_replace", parameters) do
-    Transformers.RegexReplace.validate_new(parameters)
+    Transformers.RegexReplace.validate(parameters)
   end
 
   def validate("conversion", parameters) do

--- a/apps/transformers/lib/transform_actions.ex
+++ b/apps/transformers/lib/transform_actions.ex
@@ -18,7 +18,7 @@ defmodule Transformers do
            {:ok, parameters} <- Map.fetch(transformation, :parameters) do
         case Transformers.OperationBuilder.validate(type, parameters) do
           {:ok, _} -> {:ok, "Transformation valid."}
-          {:error, _} -> {:error, "Transformation not valid."}
+          {:error, reasons} -> {:error, reasons}
         end
       else
         :error -> {:error, "Map provided is not a valid transformation"}

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -5,6 +5,10 @@ defmodule Transformers.Concatenation do
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidationStatus
 
+  @source_fields "sourceFields"
+  @target_field "targetField"
+  @separator "separator"
+
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_fields, separator, target_field]} <- validate(parameters),
@@ -20,10 +24,10 @@ defmodule Transformers.Concatenation do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, "sourceFields")
-      |> NotBlank.check(parameters, "targetField")
-      |> IsPresent.check(parameters, "separator")
-      |> ValidationStatus.ordered_values_or_errors(["sourceFields", "separator", "targetField"])
+      |> NotBlank.check(parameters, @source_fields)
+      |> NotBlank.check(parameters, @target_field)
+      |> IsPresent.check(parameters, @separator)
+      |> ValidationStatus.ordered_values_or_errors([@source_fields, @separator, @target_field])
   end
 
   def fetch_values(payload, field_names) when is_list(field_names) do
@@ -31,7 +35,7 @@ defmodule Transformers.Concatenation do
     |> all_values_if_present_else_error()
   end
 
-  def fetch_values(_, _), do: {:error, "Expected list but received single value: sourceFields"}
+  def fetch_values(_, _), do: {:error, "Expected list but received single value: #{@source_fields}"}
 
   def find_values_or_errors(payload, field_names) do
     Enum.reduce(field_names, %{values: [], errors: []}, fn field_name, accumulator ->

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -24,10 +24,10 @@ defmodule Transformers.Concatenation do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, @source_fields)
-      |> NotBlank.check(parameters, @target_field)
-      |> IsPresent.check(parameters, @separator)
-      |> ValidationStatus.ordered_values_or_errors([@source_fields, @separator, @target_field])
+    |> NotBlank.check(parameters, @source_fields)
+    |> NotBlank.check(parameters, @target_field)
+    |> IsPresent.check(parameters, @separator)
+    |> ValidationStatus.ordered_values_or_errors([@source_fields, @separator, @target_field])
   end
 
   def fetch_values(payload, field_names) when is_list(field_names) do
@@ -35,7 +35,8 @@ defmodule Transformers.Concatenation do
     |> all_values_if_present_else_error()
   end
 
-  def fetch_values(_, _), do: {:error, "Expected list but received single value: #{@source_fields}"}
+  def fetch_values(_, _),
+    do: {:error, "Expected list but received single value: #{@source_fields}"}
 
   def find_values_or_errors(payload, field_names) do
     Enum.reduce(field_names, %{values: [], errors: []}, fn field_name, accumulator ->

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -1,14 +1,13 @@
 defmodule Transformers.Concatenation do
   @behaviour Transformation
 
-  alias Transformers.FieldFetcher
   alias Transformers.Validations.IsPresent
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidationStatus
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, [source_fields, separator, target_field]} <- validate_new(parameters),
+    with {:ok, [source_fields, separator, target_field]} <- validate(parameters),
          {:ok, values} <- fetch_values(payload, source_fields),
          :ok <- can_convert_to_string?(values) do
       joined_string = Enum.join(values, separator)
@@ -20,16 +19,6 @@ defmodule Transformers.Concatenation do
   end
 
   def validate(parameters) do
-    with {:ok, source_fields} <- FieldFetcher.fetch_parameter(parameters, "sourceFields"),
-         {:ok, separator} <- FieldFetcher.fetch_parameter(parameters, "separator"),
-         {:ok, target_field} <- FieldFetcher.fetch_parameter(parameters, "targetField") do
-      {:ok, [source_fields, separator, target_field]}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def validate_new(parameters) do
     %ValidationStatus{}
       |> NotBlank.check(parameters, "sourceFields")
       |> NotBlank.check(parameters, "targetField")

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -5,7 +5,7 @@ defmodule Transformers.Concatenation do
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, [source_fields, separator, target_field]} <- validate(parameters),
+    with {:ok, [source_fields, separator, target_field]} <- validate_new(parameters),
          {:ok, values} <- fetch_values(payload, source_fields),
          :ok <- can_convert_to_string?(values) do
       joined_string = Enum.join(values, separator)

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -23,22 +23,7 @@ defmodule Transformers.Concatenation do
       |> NotBlank.check(parameters, "sourceFields")
       |> NotBlank.check(parameters, "targetField")
       |> IsPresent.check(parameters, "separator")
-      |> ordered_values_or_errors()
-  end
-
-  defp ordered_values_or_errors(status) do
-    if ValidationStatus.any_errors?(status) do
-      {:error, status.errors}
-    else
-      ok_with_ordered_values(status)
-    end
-  end
-
-  defp ok_with_ordered_values(status) do
-    source_fields = ValidationStatus.get_value(status, "sourceFields")
-    separator = ValidationStatus.get_value(status, "separator")
-    target_field = ValidationStatus.get_value(status, "targetField")
-    {:ok, [source_fields, separator, target_field]}
+      |> ValidationStatus.ordered_values_or_errors(["sourceFields", "separator", "targetField"])
   end
 
   def fetch_values(payload, field_names) when is_list(field_names) do

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -32,8 +32,8 @@ defmodule Transformers.Concatenation do
   def validate_new(parameters) do
     %ValidationStatus{}
       |> NotBlank.check(parameters, "sourceFields")
-      |> IsPresent.check(parameters, "separator")
       |> NotBlank.check(parameters, "targetField")
+      |> IsPresent.check(parameters, "separator")
       |> ordered_values_or_errors()
   end
 

--- a/apps/transformers/lib/transformations/date_time.ex
+++ b/apps/transformers/lib/transformations/date_time.ex
@@ -6,6 +6,11 @@ defmodule Transformers.DateTime do
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidationStatus
 
+  @source_field "sourceField"
+  @source_format "sourceFormat"
+  @target_field "targetField"
+  @target_format "targetFormat"
+
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_field, source_format, target_field, target_format]} <-
@@ -26,13 +31,13 @@ defmodule Transformers.DateTime do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, "sourceField")
-      |> NotBlank.check(parameters, "sourceFormat")
-      |> NotBlank.check(parameters, "targetField")
-      |> NotBlank.check(parameters, "targetFormat")
-      |> DateTimeFormat.check(parameters, "sourceFormat")
-      |> DateTimeFormat.check(parameters, "targetFormat")
-      |> ValidationStatus.ordered_values_or_errors(["sourceField", "sourceFormat", "targetField", "targetFormat"])
+      |> NotBlank.check(parameters, @source_field)
+      |> NotBlank.check(parameters, @source_format)
+      |> NotBlank.check(parameters, @target_field)
+      |> NotBlank.check(parameters, @target_format)
+      |> DateTimeFormat.check(parameters, @source_format)
+      |> DateTimeFormat.check(parameters, @target_format)
+      |> ValidationStatus.ordered_values_or_errors([@source_field, @source_format, @target_field, @target_format])
   end
 
   defp string_to_datetime(date_string, date_format, source_field) do

--- a/apps/transformers/lib/transformations/date_time.ex
+++ b/apps/transformers/lib/transformations/date_time.ex
@@ -32,23 +32,7 @@ defmodule Transformers.DateTime do
       |> NotBlank.check(parameters, "targetFormat")
       |> DateTimeFormat.check(parameters, "sourceFormat")
       |> DateTimeFormat.check(parameters, "targetFormat")
-      |> ordered_values_or_errors()
-  end
-
-  defp ordered_values_or_errors(status) do
-    if ValidationStatus.any_errors?(status) do
-      {:error, status.errors}
-    else
-      ok_with_ordered_values(status)
-    end
-  end
-
-  defp ok_with_ordered_values(status) do
-    source_field = ValidationStatus.get_value(status, "sourceField")
-    source_format = ValidationStatus.get_value(status, "sourceFormat")
-    target_field = ValidationStatus.get_value(status, "targetField")
-    target_format = ValidationStatus.get_value(status, "targetFormat")
-    {:ok, [source_field, source_format, target_field, target_format]}
+      |> ValidationStatus.ordered_values_or_errors(["sourceField", "sourceFormat", "targetField", "targetFormat"])
   end
 
   defp string_to_datetime(date_string, date_format, source_field) do

--- a/apps/transformers/lib/transformations/date_time.ex
+++ b/apps/transformers/lib/transformations/date_time.ex
@@ -6,7 +6,7 @@ defmodule Transformers.DateTime do
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_field, source_format, target_field, target_format]} <-
-           validate(parameters),
+           validate_new(parameters),
          {:ok, payload_source_value} <- FieldFetcher.fetch_value(payload, source_field),
          {:ok, source_datetime} <-
            string_to_datetime(payload_source_value, source_format, source_field),

--- a/apps/transformers/lib/transformations/date_time.ex
+++ b/apps/transformers/lib/transformations/date_time.ex
@@ -9,7 +9,7 @@ defmodule Transformers.DateTime do
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_field, source_format, target_field, target_format]} <-
-           validate_new(parameters),
+           validate(parameters),
          {:ok, payload_source_value} <- FieldFetcher.fetch_value(payload, source_field),
          {:ok, source_datetime} <-
            string_to_datetime(payload_source_value, source_format, source_field),
@@ -25,19 +25,6 @@ defmodule Transformers.DateTime do
   end
 
   def validate(parameters) do
-    with {:ok, source_field} <- FieldFetcher.fetch_parameter(parameters, "sourceField"),
-         {:ok, source_format} <- FieldFetcher.fetch_parameter(parameters, "sourceFormat"),
-         {:ok, target_field} <- FieldFetcher.fetch_parameter(parameters, "targetField"),
-         {:ok, target_format} <- FieldFetcher.fetch_parameter(parameters, "targetFormat"),
-         :ok <- validate_datetime_format(source_format),
-         :ok <- validate_datetime_format(target_format) do
-      {:ok, [source_field, source_format, target_field, target_format]}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def validate_new(parameters) do
     %ValidationStatus{}
       |> NotBlank.check(parameters, "sourceField")
       |> NotBlank.check(parameters, "sourceFormat")
@@ -73,15 +60,6 @@ defmodule Transformers.DateTime do
          "Unable to parse datetime from \"#{source_field}\" in format \"#{date_format}\": #{
            timexReason
          }"}
-    end
-  end
-
-  defp validate_datetime_format(format) do
-    with :ok <- Timex.Format.DateTime.Formatter.validate(format) do
-      :ok
-    else
-      {:error, reason} ->
-        {:error, "DateTime format \"#{format}\" is invalid: #{reason}"}
     end
   end
 

--- a/apps/transformers/lib/transformations/date_time.ex
+++ b/apps/transformers/lib/transformations/date_time.ex
@@ -31,13 +31,18 @@ defmodule Transformers.DateTime do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, @source_field)
-      |> NotBlank.check(parameters, @source_format)
-      |> NotBlank.check(parameters, @target_field)
-      |> NotBlank.check(parameters, @target_format)
-      |> DateTimeFormat.check(parameters, @source_format)
-      |> DateTimeFormat.check(parameters, @target_format)
-      |> ValidationStatus.ordered_values_or_errors([@source_field, @source_format, @target_field, @target_format])
+    |> NotBlank.check(parameters, @source_field)
+    |> NotBlank.check(parameters, @source_format)
+    |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check(parameters, @target_format)
+    |> DateTimeFormat.check(parameters, @source_format)
+    |> DateTimeFormat.check(parameters, @target_format)
+    |> ValidationStatus.ordered_values_or_errors([
+      @source_field,
+      @source_format,
+      @target_field,
+      @target_format
+    ])
   end
 
   defp string_to_datetime(date_string, date_format, source_field) do

--- a/apps/transformers/lib/transformations/regex_extract.ex
+++ b/apps/transformers/lib/transformations/regex_extract.ex
@@ -31,11 +31,10 @@ defmodule Transformers.RegexExtract do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, @source_field)
-      |> NotBlank.check(parameters, @target_field)
-      |> NotBlank.check(parameters, @regex)
-      |> ValidRegex.check(parameters, @regex)
-      |> ValidationStatus.ordered_values_or_errors([@source_field, @target_field, @regex])
+    |> NotBlank.check(parameters, @source_field)
+    |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check(parameters, @regex)
+    |> ValidRegex.check(parameters, @regex)
+    |> ValidationStatus.ordered_values_or_errors([@source_field, @target_field, @regex])
   end
-
 end

--- a/apps/transformers/lib/transformations/regex_extract.ex
+++ b/apps/transformers/lib/transformations/regex_extract.ex
@@ -6,6 +6,10 @@ defmodule Transformers.RegexExtract do
   alias Transformers.Validations.ValidRegex
   alias Transformers.Validations.ValidationStatus
 
+  @source_field "sourceField"
+  @target_field "targetField"
+  @regex "regex"
+
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_field, target_field, regex]} <- validate(parameters),
@@ -27,11 +31,11 @@ defmodule Transformers.RegexExtract do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, "sourceField")
-      |> NotBlank.check(parameters, "regex")
-      |> NotBlank.check(parameters, "targetField")
-      |> ValidRegex.check(parameters, "regex")
-      |> ValidationStatus.ordered_values_or_errors(["sourceField", "targetField", "regex"])
+      |> NotBlank.check(parameters, @source_field)
+      |> NotBlank.check(parameters, @target_field)
+      |> NotBlank.check(parameters, @regex)
+      |> ValidRegex.check(parameters, @regex)
+      |> ValidationStatus.ordered_values_or_errors([@source_field, @target_field, @regex])
   end
 
 end

--- a/apps/transformers/lib/transformations/regex_extract.ex
+++ b/apps/transformers/lib/transformations/regex_extract.ex
@@ -6,7 +6,7 @@ defmodule Transformers.RegexExtract do
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, [source_field, target_field, regex]} <- validate(parameters),
+    with {:ok, [source_field, target_field, regex]} <- validate_new(parameters),
          {:ok, value} <- FieldFetcher.fetch_value(payload, source_field) do
       case Regex.run(regex, value, capture: :all_but_first) do
         nil ->

--- a/apps/transformers/lib/transformations/regex_extract.ex
+++ b/apps/transformers/lib/transformations/regex_extract.ex
@@ -2,11 +2,13 @@ defmodule Transformers.RegexExtract do
   @behaviour Transformation
 
   alias Transformers.FieldFetcher
-  alias Transformers.RegexUtils
+  alias Transformers.Validations.NotBlank
+  alias Transformers.Validations.ValidRegex
+  alias Transformers.Validations.ValidationStatus
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, [source_field, target_field, regex]} <- validate_new(parameters),
+    with {:ok, [source_field, target_field, regex]} <- validate(parameters),
          {:ok, value} <- FieldFetcher.fetch_value(payload, source_field) do
       case Regex.run(regex, value, capture: :all_but_first) do
         nil ->
@@ -24,69 +26,12 @@ defmodule Transformers.RegexExtract do
   end
 
   def validate(parameters) do
-    with {:ok, source_field} <- FieldFetcher.fetch_parameter(parameters, "sourceField"),
-         {:ok, regex_pattern} <- FieldFetcher.fetch_parameter(parameters, "regex"),
-         {:ok, target_field} <- FieldFetcher.fetch_parameter(parameters, "targetField"),
-         {:ok, regex} <- RegexUtils.regex_compile(regex_pattern) do
-      {:ok, [source_field, target_field, regex]}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def validate_new(parameters) do
-    reverse_fields_for_easier_list_updates_while_preserving_order()
-      |> validate_fields(parameters)
-      |> validate_regex(parameters)
-      |> ordered_values_or_errors()
-  end
-
-  defp validate_regex(accumulator, parameters) do
-    with {:ok, regex_pattern} <- FieldFetcher.fetch_parameter_new(parameters, "regex"),
-         {:ok, regex} <- RegexUtils.regex_compile(regex_pattern) do
-      Map.update(accumulator, :values, %{}, fn values -> Map.put(values, "regex", regex) end)
-    else
-      {:error, reason} -> Map.update(accumulator, :errors, %{}, fn errors -> Map.put(errors, "regex", reason) end)
-    end
-  end
-
-  defp reverse_fields_for_easier_list_updates_while_preserving_order do
-    ["sourceField", "targetField", "regex"] |> Enum.reverse()
-  end
-
-  defp validate_fields(required_fields, parameters) do
-    Enum.reduce(required_fields, %{values: %{}, errors: %{}}, fn required_field, accumulator ->
-      update_with_value_or_error(required_field, accumulator, parameters)
-    end)
-  end
-
-  defp update_with_value_or_error(required_field, accumulator, parameters) do
-    result = FieldFetcher.fetch_value_or_error(parameters, required_field)
-    case result do
-      {:ok, value} -> update_with_value(accumulator, required_field, value)
-      {:error, reason} -> update_with_error(accumulator, reason)
-    end
-  end
-
-  defp update_with_value(accumulator, field, value) do
-    Map.update(accumulator, :values, %{}, fn values -> Map.put(values, field, value) end)
-  end
-
-  defp update_with_error(accumulator, error_reason) do
-    Map.update(accumulator, :errors, %{}, fn errors -> Map.merge(errors, error_reason) end)
-  end
-
-  defp ordered_values_or_errors(accumulated) do
-    errors = Map.get(accumulated, :errors)
-    if length(Map.keys(errors)) > 0 do
-      {:error, errors}
-    else
-      values = Map.get(accumulated, :values)
-      source_field = Map.get(values, "sourceField")
-      target_field = Map.get(values, "targetField")
-      regex = Map.get(values, "regex")
-      {:ok, [source_field, target_field, regex]}
-    end
+    %ValidationStatus{}
+      |> NotBlank.check(parameters, "sourceField")
+      |> NotBlank.check(parameters, "regex")
+      |> NotBlank.check(parameters, "targetField")
+      |> ValidRegex.check(parameters, "regex")
+      |> ValidationStatus.ordered_values_or_errors(["sourceField", "targetField", "regex"])
   end
 
 end

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -6,12 +6,16 @@ defmodule Transformers.RegexReplace do
   alias Transformers.Validations.ValidRegex
   alias Transformers.Validations.ValidationStatus
 
+  @source_field "sourceField"
+  @replacement "replacement"
+  @regex "regex"
+
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_field, replacement, regex]} <- validate(parameters),
          {:ok, value} <- FieldFetcher.fetch_value(payload, source_field),
          :ok <- abort_if_not_string(value, source_field),
-         :ok <- abort_if_not_string(replacement, "replacement") do
+         :ok <- abort_if_not_string(replacement, @replacement) do
       transformed_value = Regex.replace(regex, value, replacement)
       transformed_payload = Map.put(payload, source_field, transformed_value)
       {:ok, transformed_payload}
@@ -22,11 +26,11 @@ defmodule Transformers.RegexReplace do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, "sourceField")
-      |> NotBlank.check(parameters, "replacement")
-      |> NotBlank.check(parameters, "regex")
-      |> ValidRegex.check(parameters, "regex")
-      |> ValidationStatus.ordered_values_or_errors(["sourceField", "replacement", "regex"])
+      |> NotBlank.check(parameters, @source_field)
+      |> NotBlank.check(parameters, @replacement)
+      |> NotBlank.check(parameters, @regex)
+      |> ValidRegex.check(parameters, @regex)
+      |> ValidationStatus.ordered_values_or_errors([@source_field, @replacement, @regex])
   end
 
   defp abort_if_not_string(value, field_name) do

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -2,14 +2,13 @@ defmodule Transformers.RegexReplace do
   @behaviour Transformation
 
   alias Transformers.FieldFetcher
-  alias Transformers.RegexUtils
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidRegex
   alias Transformers.Validations.ValidationStatus
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, [source_field, replacement, regex]} <- validate_new(parameters),
+    with {:ok, [source_field, replacement, regex]} <- validate(parameters),
          {:ok, value} <- FieldFetcher.fetch_value(payload, source_field),
          :ok <- abort_if_not_string(value, source_field),
          :ok <- abort_if_not_string(replacement, "replacement") do
@@ -22,17 +21,6 @@ defmodule Transformers.RegexReplace do
   end
 
   def validate(parameters) do
-    with {:ok, source_field} <- FieldFetcher.fetch_parameter(parameters, "sourceField"),
-         {:ok, regex_pattern} <- FieldFetcher.fetch_parameter(parameters, "regex"),
-         {:ok, replacement} <- FieldFetcher.fetch_parameter(parameters, "replacement"),
-         {:ok, regex} <- RegexUtils.regex_compile(regex_pattern) do
-      {:ok, [source_field, replacement, regex]}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def validate_new(parameters) do
     %ValidationStatus{}
       |> NotBlank.check(parameters, "sourceField")
       |> NotBlank.check(parameters, "replacement")

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -26,11 +26,11 @@ defmodule Transformers.RegexReplace do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, @source_field)
-      |> NotBlank.check(parameters, @replacement)
-      |> NotBlank.check(parameters, @regex)
-      |> ValidRegex.check(parameters, @regex)
-      |> ValidationStatus.ordered_values_or_errors([@source_field, @replacement, @regex])
+    |> NotBlank.check(parameters, @source_field)
+    |> NotBlank.check(parameters, @replacement)
+    |> NotBlank.check(parameters, @regex)
+    |> ValidRegex.check(parameters, @regex)
+    |> ValidationStatus.ordered_values_or_errors([@source_field, @replacement, @regex])
   end
 
   defp abort_if_not_string(value, field_name) do

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -3,6 +3,9 @@ defmodule Transformers.RegexReplace do
 
   alias Transformers.FieldFetcher
   alias Transformers.RegexUtils
+  alias Transformers.Validations.NotBlank
+  alias Transformers.Validations.ValidRegex
+  alias Transformers.Validations.ValidationStatus
 
   @impl Transformation
   def transform(payload, parameters) do
@@ -30,58 +33,12 @@ defmodule Transformers.RegexReplace do
   end
 
   def validate_new(parameters) do
-    reverse_fields_for_easier_list_updates_while_preserving_order()
-      |> validate_fields(parameters)
-      |> validate_regex(parameters)
-      |> ordered_values_or_errors()
-  end
-
-  defp validate_regex(accumulator, parameters) do
-    with {:ok, regex_pattern} <- FieldFetcher.fetch_parameter_new(parameters, "regex"),
-         {:ok, regex} <- RegexUtils.regex_compile(regex_pattern) do
-      Map.update(accumulator, :values, %{}, fn values -> Map.put(values, "regex", regex) end)
-    else
-      {:error, reason} -> Map.update(accumulator, :errors, %{}, fn errors -> Map.put(errors, "regex", reason) end)
-    end
-  end
-
-  defp reverse_fields_for_easier_list_updates_while_preserving_order do
-    ["sourceField", "replacement", "regex"] |> Enum.reverse()
-  end
-
-  defp validate_fields(required_fields, parameters) do
-    Enum.reduce(required_fields, %{values: %{}, errors: %{}}, fn required_field, accumulator ->
-      update_with_value_or_error(required_field, accumulator, parameters)
-    end)
-  end
-
-  defp update_with_value_or_error(required_field, accumulator, parameters) do
-    result = FieldFetcher.fetch_value_or_error(parameters, required_field)
-    case result do
-      {:ok, value} -> update_with_value(accumulator, required_field, value)
-      {:error, reason} -> update_with_error(accumulator, reason)
-    end
-  end
-
-  defp update_with_value(accumulator, field, value) do
-    Map.update(accumulator, :values, %{}, fn values -> Map.put(values, field, value) end)
-  end
-
-  defp update_with_error(accumulator, error_reason) do
-    Map.update(accumulator, :errors, %{}, fn errors -> Map.merge(errors, error_reason) end)
-  end
-
-  defp ordered_values_or_errors(accumulated) do
-    errors = Map.get(accumulated, :errors)
-    if length(Map.keys(errors)) > 0 do
-      {:error, errors}
-    else
-      values = Map.get(accumulated, :values)
-      source_field = Map.get(values, "sourceField")
-      target_field = Map.get(values, "replacement")
-      regex = Map.get(values, "regex")
-      {:ok, [source_field, target_field, regex]}
-    end
+    %ValidationStatus{}
+      |> NotBlank.check(parameters, "sourceField")
+      |> NotBlank.check(parameters, "replacement")
+      |> NotBlank.check(parameters, "regex")
+      |> ValidRegex.check(parameters, "regex")
+      |> ValidationStatus.ordered_values_or_errors(["sourceField", "replacement", "regex"])
   end
 
   defp abort_if_not_string(value, field_name) do

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -6,7 +6,7 @@ defmodule Transformers.RegexReplace do
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, [source_field, replacement, regex]} <- validate(parameters),
+    with {:ok, [source_field, replacement, regex]} <- validate_new(parameters),
          {:ok, value} <- FieldFetcher.fetch_value(payload, source_field),
          :ok <- abort_if_not_string(value, source_field),
          :ok <- abort_if_not_string(replacement, "replacement") do

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -29,6 +29,61 @@ defmodule Transformers.RegexReplace do
     end
   end
 
+  def validate_new(parameters) do
+    reverse_fields_for_easier_list_updates_while_preserving_order()
+      |> validate_fields(parameters)
+      |> validate_regex(parameters)
+      |> ordered_values_or_errors()
+  end
+
+  defp validate_regex(accumulator, parameters) do
+    with {:ok, regex_pattern} <- FieldFetcher.fetch_parameter_new(parameters, "regex"),
+         {:ok, regex} <- RegexUtils.regex_compile(regex_pattern) do
+      Map.update(accumulator, :values, %{}, fn values -> Map.put(values, "regex", regex) end)
+    else
+      {:error, reason} -> Map.update(accumulator, :errors, %{}, fn errors -> Map.put(errors, "regex", reason) end)
+    end
+  end
+
+  defp reverse_fields_for_easier_list_updates_while_preserving_order do
+    ["sourceField", "replacement", "regex"] |> Enum.reverse()
+  end
+
+  defp validate_fields(required_fields, parameters) do
+    Enum.reduce(required_fields, %{values: %{}, errors: %{}}, fn required_field, accumulator ->
+      update_with_value_or_error(required_field, accumulator, parameters)
+    end)
+  end
+
+  defp update_with_value_or_error(required_field, accumulator, parameters) do
+    result = FieldFetcher.fetch_value_or_error(parameters, required_field)
+    case result do
+      {:ok, value} -> update_with_value(accumulator, required_field, value)
+      {:error, reason} -> update_with_error(accumulator, reason)
+    end
+  end
+
+  defp update_with_value(accumulator, field, value) do
+    Map.update(accumulator, :values, %{}, fn values -> Map.put(values, field, value) end)
+  end
+
+  defp update_with_error(accumulator, error_reason) do
+    Map.update(accumulator, :errors, %{}, fn errors -> Map.merge(errors, error_reason) end)
+  end
+
+  defp ordered_values_or_errors(accumulated) do
+    errors = Map.get(accumulated, :errors)
+    if length(Map.keys(errors)) > 0 do
+      {:error, errors}
+    else
+      values = Map.get(accumulated, :values)
+      source_field = Map.get(values, "sourceField")
+      target_field = Map.get(values, "replacement")
+      regex = Map.get(values, "regex")
+      {:ok, [source_field, target_field, regex]}
+    end
+  end
+
   defp abort_if_not_string(value, field_name) do
     if is_binary(value) do
       :ok

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -22,6 +22,14 @@ defmodule Transformers.Remove do
     end
   end
 
+  def validate_new(parameters) do
+    result = FieldFetcher.fetch_parameter_new(parameters, "sourceField")
+    case result do
+      {:ok, sourceField} -> {:ok, sourceField}
+      {:error, reason} -> {:error, %{"sourceField" => reason}}
+    end
+  end
+
   def fields() do
     [
       %{

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -7,7 +7,7 @@ defmodule Transformers.Remove do
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, source_field} <- validate_new(parameters),
+    with {:ok, source_field} <- validate(parameters),
          {:ok, _} <- FieldFetcher.fetch_value(payload, source_field) do
       transformed_payload = Map.delete(payload, source_field)
       {:ok, transformed_payload}
@@ -17,14 +17,6 @@ defmodule Transformers.Remove do
   end
 
   def validate(parameters) do
-    with {:ok, source_field} <- FieldFetcher.fetch_parameter(parameters, "sourceField") do
-      {:ok, source_field}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def validate_new(parameters) do
     result = %ValidationStatus{}
       |> NotBlank.check(parameters, "sourceField")
 

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -5,7 +5,7 @@ defmodule Transformers.Remove do
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, source_field} <- validate(parameters),
+    with {:ok, source_field} <- validate_new(parameters),
          {:ok, _} <- FieldFetcher.fetch_value(payload, source_field) do
       transformed_payload = Map.delete(payload, source_field)
       {:ok, transformed_payload}

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -2,6 +2,8 @@ defmodule Transformers.Remove do
   @behaviour Transformation
 
   alias Transformers.FieldFetcher
+  alias Transformers.Validations.NotBlank
+  alias Transformers.Validations.ValidationStatus
 
   @impl Transformation
   def transform(payload, parameters) do
@@ -23,7 +25,19 @@ defmodule Transformers.Remove do
   end
 
   def validate_new(parameters) do
-    FieldFetcher.fetch_value_or_error(parameters, "sourceField")
+    result = %ValidationStatus{}
+      |> NotBlank.check(parameters, "sourceField")
+
+    if ValidationStatus.any_errors?(result) do
+      {:error, result.errors}
+    else
+      ok_with_ordered_values(result)
+    end
+  end
+
+  defp ok_with_ordered_values(status) do
+    source_field = ValidationStatus.get_value(status, "sourceField")
+    {:ok, source_field}
   end
 
   def fields() do

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -20,8 +20,8 @@ defmodule Transformers.Remove do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, @source_field)
-      |> ValidationStatus.ordered_values_or_errors([@source_field])
+    |> NotBlank.check(parameters, @source_field)
+    |> ValidationStatus.ordered_values_or_errors([@source_field])
   end
 
   def fields() do

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -23,11 +23,7 @@ defmodule Transformers.Remove do
   end
 
   def validate_new(parameters) do
-    result = FieldFetcher.fetch_parameter_new(parameters, "sourceField")
-    case result do
-      {:ok, sourceField} -> {:ok, sourceField}
-      {:error, reason} -> {:error, %{"sourceField" => reason}}
-    end
+    FieldFetcher.fetch_value_or_error(parameters, "sourceField")
   end
 
   def fields() do

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -5,6 +5,8 @@ defmodule Transformers.Remove do
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidationStatus
 
+  @source_field "sourceField"
+
   @impl Transformation
   def transform(payload, parameters) do
     with {:ok, [source_field]} <- validate(parameters),
@@ -18,14 +20,14 @@ defmodule Transformers.Remove do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, "sourceField")
-      |> ValidationStatus.ordered_values_or_errors(["sourceField"])
+      |> NotBlank.check(parameters, @source_field)
+      |> ValidationStatus.ordered_values_or_errors([@source_field])
   end
 
   def fields() do
     [
       %{
-        field_name: "sourceField",
+        field_name: @source_field,
         field_type: "string",
         field_label: "Field to Remove",
         options: nil

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -7,7 +7,7 @@ defmodule Transformers.Remove do
 
   @impl Transformation
   def transform(payload, parameters) do
-    with {:ok, source_field} <- validate(parameters),
+    with {:ok, [source_field]} <- validate(parameters),
          {:ok, _} <- FieldFetcher.fetch_value(payload, source_field) do
       transformed_payload = Map.delete(payload, source_field)
       {:ok, transformed_payload}
@@ -17,19 +17,9 @@ defmodule Transformers.Remove do
   end
 
   def validate(parameters) do
-    result = %ValidationStatus{}
+    %ValidationStatus{}
       |> NotBlank.check(parameters, "sourceField")
-
-    if ValidationStatus.any_errors?(result) do
-      {:error, result.errors}
-    else
-      ok_with_ordered_values(result)
-    end
-  end
-
-  defp ok_with_ordered_values(status) do
-    source_field = ValidationStatus.get_value(status, "sourceField")
-    {:ok, source_field}
+      |> ValidationStatus.ordered_values_or_errors(["sourceField"])
   end
 
   def fields() do

--- a/apps/transformers/lib/transformations/type_conversion.ex
+++ b/apps/transformers/lib/transformations/type_conversion.ex
@@ -26,11 +26,16 @@ defmodule Transformers.TypeConversion do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, @field)
-      |> NotBlank.check(parameters, @source_type)
-      |> NotBlank.check(parameters, @target_type)
-      |> ValidTypeConversion.check(parameters, @source_type, @target_type, @conversion_function)
-      |> ValidationStatus.ordered_values_or_errors([@field, @source_type, @target_type, @conversion_function])
+    |> NotBlank.check(parameters, @field)
+    |> NotBlank.check(parameters, @source_type)
+    |> NotBlank.check(parameters, @target_type)
+    |> ValidTypeConversion.check(parameters, @source_type, @target_type, @conversion_function)
+    |> ValidationStatus.ordered_values_or_errors([
+      @field,
+      @source_type,
+      @target_type,
+      @conversion_function
+    ])
   end
 
   defp abort_if_missing_value(payload, field, value) do

--- a/apps/transformers/lib/transformations/type_conversion.ex
+++ b/apps/transformers/lib/transformations/type_conversion.ex
@@ -2,10 +2,13 @@ defmodule Transformers.TypeConversion do
   @behaviour Transformation
 
   alias Transformers.FieldFetcher
+  alias Transformers.Validations.NotBlank
+  alias Transformers.Validations.ValidTypeConversion
+  alias Transformers.Validations.ValidationStatus
 
   @impl Transformation
   def transform(payload, params) do
-    with {:ok, [field, source_type, target_type, conversion_function]} <- validate_new(params),
+    with {:ok, [field, source_type, target_type, conversion_function]} <- validate(params),
          {:ok, value} <- FieldFetcher.fetch_value(payload, field),
          :ok <- abort_if_missing_value(payload, field, value),
          :ok <- check_field_is_of_sourcetype(field, value, source_type) do
@@ -16,92 +19,13 @@ defmodule Transformers.TypeConversion do
     end
   end
 
-  def validate(params) do
-    with {:ok, field} <- FieldFetcher.fetch_parameter(params, "field"),
-         {:ok, source_type} <- FieldFetcher.fetch_parameter(params, "sourceType"),
-         {:ok, target_type} <- FieldFetcher.fetch_parameter(params, "targetType"),
-         {:ok, conversion_function} <- pick_conversion(source_type, target_type) do
-      {:ok, [field, source_type, target_type, conversion_function]}
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def validate_new(parameters) do
-    required_fields()
-      |> validate_fields(parameters)
-      |> validate_conversion(parameters)
-      |> ordered_values_or_errors()
-  end
-
-  defp validate_conversion(accumulator, parameters) do
-    prior_error_source_type = get_in(accumulator, [:errors, "sourceType"])
-    prior_error_target_type = get_in(accumulator, [:errors, "targetType"])
-
-    if prior_error_source_type != nil || prior_error_target_type != nil do
-      accumulator
-    else
-      with {:ok, source_type} <- FieldFetcher.fetch_parameter(parameters, "sourceType"),
-           {:ok, target_type} <- FieldFetcher.fetch_parameter(parameters, "targetType"),
-           {:ok, conversion_function} <- pick_conversion(source_type, target_type) do
-        Map.update(accumulator, :values, %{}, fn values -> Map.put(values, "conversionFunction", conversion_function) end)
-      else
-        {:error, reason} -> Map.update(accumulator, :errors, %{}, fn errors -> Map.put(errors, "sourceType", reason) end)
-          |> Map.update(:errors, %{}, fn errors -> Map.put(errors, "targetType", reason) end)
-      end
-    end
-  end
-
-  defp required_fields() do
-    ["field", "sourceType", "targetType"]
-  end
-
-  defp validate_fields(required_fields, parameters) do
-    Enum.reduce(required_fields, %{values: %{}, errors: %{}}, fn required_field, accumulator ->
-      update_with_value_or_error(required_field, accumulator, parameters)
-    end)
-  end
-
-  defp update_with_value_or_error(required_field, accumulator, parameters) do
-    result = FieldFetcher.fetch_value_or_error(parameters, required_field)
-    case result do
-      {:ok, value} -> update_with_value(accumulator, required_field, value)
-      {:error, reason} -> update_with_error(accumulator, reason)
-    end
-  end
-
-  defp update_with_value(accumulator, field, value) do
-    Map.update(accumulator, :values, %{}, fn values -> Map.put(values, field, value) end)
-  end
-
-  defp update_with_error(accumulator, error_reason) do
-    Map.update(accumulator, :errors, %{}, fn errors -> Map.merge(errors, error_reason) end)
-  end
-
-  defp ordered_values_or_errors(accumulated) do
-    errors = Map.get(accumulated, :errors)
-    if length(Map.keys(errors)) > 0 do
-      {:error, errors}
-    else
-      values = Map.get(accumulated, :values)
-      field = Map.get(values, "field")
-      sourceType = Map.get(values, "sourceType")
-      targetType = Map.get(values, "targetType")
-      conversion_function = Map.get(values, "conversionFunction")
-      {:ok, [field, sourceType, targetType, conversion_function]}
-    end
-  end
-
-  defp pick_conversion(source_type, target_type) do
-    case {source_type, target_type} do
-      {"float", "integer"} -> {:ok, fn value -> Float.round(value) end}
-      {"float", "string"} -> {:ok, fn value -> to_string(value) end}
-      {"integer", "float"} -> {:ok, fn value -> value / 1 end}
-      {"integer", "string"} -> {:ok, fn value -> to_string(value) end}
-      {"string", "integer"} -> {:ok, fn value -> String.to_integer(value) end}
-      {"string", "float"} -> {:ok, fn value -> String.to_float(value) end}
-      _ -> {:error, "Conversion from #{source_type} to #{target_type} is not supported"}
-    end
+  def validate(parameters) do
+    %ValidationStatus{}
+      |> NotBlank.check(parameters, "field")
+      |> NotBlank.check(parameters, "sourceType")
+      |> NotBlank.check(parameters, "targetType")
+      |> ValidTypeConversion.check(parameters, "sourceType", "targetType", "conversionFunction")
+      |> ValidationStatus.ordered_values_or_errors(["field", "sourceType", "targetType", "conversionFunction"])
   end
 
   defp abort_if_missing_value(payload, field, value) do

--- a/apps/transformers/lib/transformations/type_conversion.ex
+++ b/apps/transformers/lib/transformations/type_conversion.ex
@@ -5,7 +5,7 @@ defmodule Transformers.TypeConversion do
 
   @impl Transformation
   def transform(payload, params) do
-    with {:ok, [field, source_type, target_type, conversion_function]} <- validate(params),
+    with {:ok, [field, source_type, target_type, conversion_function]} <- validate_new(params),
          {:ok, value} <- FieldFetcher.fetch_value(payload, field),
          :ok <- abort_if_missing_value(payload, field, value),
          :ok <- check_field_is_of_sourcetype(field, value, source_type) do

--- a/apps/transformers/lib/transformations/type_conversion.ex
+++ b/apps/transformers/lib/transformations/type_conversion.ex
@@ -27,6 +27,71 @@ defmodule Transformers.TypeConversion do
     end
   end
 
+  def validate_new(parameters) do
+    required_fields()
+      |> validate_fields(parameters)
+      |> validate_conversion(parameters)
+      |> ordered_values_or_errors()
+  end
+
+  defp validate_conversion(accumulator, parameters) do
+    prior_error_source_type = get_in(accumulator, [:errors, "sourceType"])
+    prior_error_target_type = get_in(accumulator, [:errors, "targetType"])
+
+    if prior_error_source_type != nil || prior_error_target_type != nil do
+      accumulator
+    else
+      with {:ok, source_type} <- FieldFetcher.fetch_parameter(parameters, "sourceType"),
+           {:ok, target_type} <- FieldFetcher.fetch_parameter(parameters, "targetType"),
+           {:ok, conversion_function} <- pick_conversion(source_type, target_type) do
+        Map.update(accumulator, :values, %{}, fn values -> Map.put(values, "conversionFunction", conversion_function) end)
+      else
+        {:error, reason} -> Map.update(accumulator, :errors, %{}, fn errors -> Map.put(errors, "sourceType", reason) end)
+          |> Map.update(:errors, %{}, fn errors -> Map.put(errors, "targetType", reason) end)
+      end
+    end
+  end
+
+  defp required_fields() do
+    ["field", "sourceType", "targetType"]
+  end
+
+  defp validate_fields(required_fields, parameters) do
+    Enum.reduce(required_fields, %{values: %{}, errors: %{}}, fn required_field, accumulator ->
+      update_with_value_or_error(required_field, accumulator, parameters)
+    end)
+  end
+
+  defp update_with_value_or_error(required_field, accumulator, parameters) do
+    result = FieldFetcher.fetch_value_or_error(parameters, required_field)
+    case result do
+      {:ok, value} -> update_with_value(accumulator, required_field, value)
+      {:error, reason} -> update_with_error(accumulator, reason)
+    end
+  end
+
+  defp update_with_value(accumulator, field, value) do
+    Map.update(accumulator, :values, %{}, fn values -> Map.put(values, field, value) end)
+  end
+
+  defp update_with_error(accumulator, error_reason) do
+    Map.update(accumulator, :errors, %{}, fn errors -> Map.merge(errors, error_reason) end)
+  end
+
+  defp ordered_values_or_errors(accumulated) do
+    errors = Map.get(accumulated, :errors)
+    if length(Map.keys(errors)) > 0 do
+      {:error, errors}
+    else
+      values = Map.get(accumulated, :values)
+      field = Map.get(values, "field")
+      sourceType = Map.get(values, "sourceType")
+      targetType = Map.get(values, "targetType")
+      conversion_function = Map.get(values, "conversionFunction")
+      {:ok, [field, sourceType, targetType, conversion_function]}
+    end
+  end
+
   defp pick_conversion(source_type, target_type) do
     case {source_type, target_type} do
       {"float", "integer"} -> {:ok, fn value -> Float.round(value) end}

--- a/apps/transformers/lib/transformations/type_conversion.ex
+++ b/apps/transformers/lib/transformations/type_conversion.ex
@@ -6,6 +6,11 @@ defmodule Transformers.TypeConversion do
   alias Transformers.Validations.ValidTypeConversion
   alias Transformers.Validations.ValidationStatus
 
+  @field "field"
+  @source_type "sourceType"
+  @target_type "targetType"
+  @conversion_function "conversionFunction"
+
   @impl Transformation
   def transform(payload, params) do
     with {:ok, [field, source_type, target_type, conversion_function]} <- validate(params),
@@ -21,11 +26,11 @@ defmodule Transformers.TypeConversion do
 
   def validate(parameters) do
     %ValidationStatus{}
-      |> NotBlank.check(parameters, "field")
-      |> NotBlank.check(parameters, "sourceType")
-      |> NotBlank.check(parameters, "targetType")
-      |> ValidTypeConversion.check(parameters, "sourceType", "targetType", "conversionFunction")
-      |> ValidationStatus.ordered_values_or_errors(["field", "sourceType", "targetType", "conversionFunction"])
+      |> NotBlank.check(parameters, @field)
+      |> NotBlank.check(parameters, @source_type)
+      |> NotBlank.check(parameters, @target_type)
+      |> ValidTypeConversion.check(parameters, @source_type, @target_type, @conversion_function)
+      |> ValidationStatus.ordered_values_or_errors([@field, @source_type, @target_type, @conversion_function])
   end
 
   defp abort_if_missing_value(payload, field, value) do

--- a/apps/transformers/lib/validations/datetime_format.ex
+++ b/apps/transformers/lib/validations/datetime_format.ex
@@ -1,0 +1,31 @@
+defmodule Transformers.Validations.DateTimeFormat do
+
+  alias Transformers.Validations.ValidationStatus
+
+  def check(status, parameters, field) do
+    value = Map.get(parameters, field)
+
+    if value == nil do
+      add_missing_field_error(status, field)
+    else
+      check_if_valid(status, field, value)
+    end
+  end
+
+  defp add_missing_field_error(status, field) do
+    ValidationStatus.add_error(status, field, "No datetime format provided")
+  end
+
+  defp check_if_valid(status, field, value) do
+    result = Timex.Format.DateTime.Formatter.validate(value)
+    case result do
+      :ok -> ValidationStatus.update_value(status, field, value)
+      {:error, reason} -> add_error(status, field, value, reason)
+    end
+  end
+
+  defp add_error(status, field, value, reason) do
+    message = "DateTime format \"#{value}\" is invalid: #{reason}"
+    ValidationStatus.add_error(status, field, message)
+  end
+end

--- a/apps/transformers/lib/validations/datetime_format.ex
+++ b/apps/transformers/lib/validations/datetime_format.ex
@@ -1,5 +1,4 @@
 defmodule Transformers.Validations.DateTimeFormat do
-
   alias Transformers.Validations.ValidationStatus
 
   def check(status, parameters, field) do
@@ -18,6 +17,7 @@ defmodule Transformers.Validations.DateTimeFormat do
 
   defp check_if_valid(status, field, value) do
     result = Timex.Format.DateTime.Formatter.validate(value)
+
     case result do
       :ok -> ValidationStatus.update_value(status, field, value)
       {:error, reason} -> add_error(status, field, value, reason)

--- a/apps/transformers/lib/validations/is_present.ex
+++ b/apps/transformers/lib/validations/is_present.ex
@@ -1,5 +1,4 @@
 defmodule Transformers.Validations.IsPresent do
-
   alias Transformers.Validations.ValidationStatus
 
   def check(status, parameters, field) do
@@ -10,5 +9,4 @@ defmodule Transformers.Validations.IsPresent do
       _ -> ValidationStatus.update_value(status, field, value)
     end
   end
-
 end

--- a/apps/transformers/lib/validations/is_present.ex
+++ b/apps/transformers/lib/validations/is_present.ex
@@ -1,0 +1,14 @@
+defmodule Transformers.Validations.IsPresent do
+
+  alias Transformers.Validations.ValidationStatus
+
+  def check(status, parameters, field) do
+    value = Map.get(parameters, field)
+
+    case value do
+      nil -> ValidationStatus.add_error(status, field, "Missing field")
+      _ -> ValidationStatus.update_value(status, field, value)
+    end
+  end
+
+end

--- a/apps/transformers/lib/validations/not_blank.ex
+++ b/apps/transformers/lib/validations/not_blank.ex
@@ -13,6 +13,15 @@ defmodule Transformers.Validations.NotBlank do
   defp check_if_blank(status, parameters, field) do
     value = Map.get(parameters, field)
 
+    case value do
+      nil -> ValidationStatus.add_error(status, field, "Missing or empty field")
+      value when is_binary(value) -> check_if_blank_string(status, field, value)
+      value when is_list(value) -> check_if_blank_list(status, field, value)
+      _ -> status
+    end
+  end
+
+  defp check_if_blank_string(status, field, value) do
     if is_blank?(value) do
       ValidationStatus.add_error(status, field, "Missing or empty field")
     else
@@ -21,13 +30,25 @@ defmodule Transformers.Validations.NotBlank do
   end
 
   defp is_blank?(field) do
-    field == nil || String.trim(field)
+    String.trim(field)
       |> String.length()
       |> is_zero?()
   end
 
   defp is_zero?(length) do
     length == 0
+  end
+
+  defp check_if_blank_list(status, field, value) do
+    if is_empty_list?(value) do
+      ValidationStatus.add_error(status, field, "Missing or empty field")
+    else
+      ValidationStatus.update_value(status, field, value)
+    end
+  end
+
+  defp is_empty_list?(list) do
+    length(list) == 0
   end
 
 end

--- a/apps/transformers/lib/validations/not_blank.ex
+++ b/apps/transformers/lib/validations/not_blank.ex
@@ -16,7 +16,7 @@ defmodule Transformers.Validations.NotBlank do
       nil -> ValidationStatus.add_error(status, field, "Missing or empty field")
       value when is_binary(value) -> check_if_blank_string(status, field, value)
       value when is_list(value) -> check_if_blank_list(status, field, value)
-      _ -> add_unsupported_type_error(status, field, value)
+      _ -> add_unsupported_type_error(status, field)
     end
   end
 
@@ -50,7 +50,7 @@ defmodule Transformers.Validations.NotBlank do
     length(list) == 0
   end
 
-  defp add_unsupported_type_error(status, field, value) do
+  defp add_unsupported_type_error(status, field) do
     ValidationStatus.add_error(status, field, "Not a string or list")
   end
 end

--- a/apps/transformers/lib/validations/not_blank.ex
+++ b/apps/transformers/lib/validations/not_blank.ex
@@ -1,5 +1,4 @@
 defmodule Transformers.Validations.NotBlank do
-
   alias Transformers.Validations.ValidationStatus
 
   def check(status, parameters, field) do
@@ -31,8 +30,8 @@ defmodule Transformers.Validations.NotBlank do
 
   defp is_blank?(field) do
     String.trim(field)
-      |> String.length()
-      |> is_zero?()
+    |> String.length()
+    |> is_zero?()
   end
 
   defp is_zero?(length) do

--- a/apps/transformers/lib/validations/not_blank.ex
+++ b/apps/transformers/lib/validations/not_blank.ex
@@ -1,0 +1,33 @@
+defmodule Transformers.Validations.NotBlank do
+
+  alias Transformers.Validations.ValidationStatus
+
+  def check(status, parameters, field) do
+    if ValidationStatus.has_error?(status, field) do
+      status
+    else
+      check_if_blank(status, parameters, field)
+    end
+  end
+
+  defp check_if_blank(status, parameters, field) do
+    value = Map.get(parameters, field)
+
+    if is_blank?(value) do
+      ValidationStatus.add_error(status, field, "Missing or empty field")
+    else
+      ValidationStatus.update_value(status, field, value)
+    end
+  end
+
+  defp is_blank?(field) do
+    field == nil || String.trim(field)
+      |> String.length()
+      |> is_zero?()
+  end
+
+  defp is_zero?(length) do
+    length == 0
+  end
+
+end

--- a/apps/transformers/lib/validations/not_blank.ex
+++ b/apps/transformers/lib/validations/not_blank.ex
@@ -17,7 +17,7 @@ defmodule Transformers.Validations.NotBlank do
       nil -> ValidationStatus.add_error(status, field, "Missing or empty field")
       value when is_binary(value) -> check_if_blank_string(status, field, value)
       value when is_list(value) -> check_if_blank_list(status, field, value)
-      _ -> status
+      _ -> add_unsupported_type_error(status, field, value)
     end
   end
 
@@ -51,4 +51,7 @@ defmodule Transformers.Validations.NotBlank do
     length(list) == 0
   end
 
+  defp add_unsupported_type_error(status, field, value) do
+    ValidationStatus.add_error(status, field, "Not a string or list")
+  end
 end

--- a/apps/transformers/lib/validations/valid_regex.ex
+++ b/apps/transformers/lib/validations/valid_regex.ex
@@ -1,0 +1,28 @@
+defmodule Transformers.Validations.ValidRegex do
+
+  alias Transformers.RegexUtils
+  alias Transformers.Validations.ValidationStatus
+
+  def check(status, parameters, field) do
+    value = Map.get(parameters, field)
+
+    if value == nil do
+      add_missing_value_error(status, field)
+    else
+      attempt_validation(status, field, value)
+    end
+  end
+
+  defp add_missing_value_error(status, field) do
+    ValidationStatus.add_error(status, field, "No regular expression provided")
+  end
+
+  defp attempt_validation(status, field, value) do
+    result = RegexUtils.regex_compile(value)
+
+    case result do
+      {:ok, compiled} -> ValidationStatus.update_value(status, field, compiled)
+      {:error, reason} -> ValidationStatus.add_error(status, field, reason)
+    end
+  end
+end

--- a/apps/transformers/lib/validations/valid_regex.ex
+++ b/apps/transformers/lib/validations/valid_regex.ex
@@ -1,5 +1,4 @@
 defmodule Transformers.Validations.ValidRegex do
-
   alias Transformers.RegexUtils
   alias Transformers.Validations.ValidationStatus
 

--- a/apps/transformers/lib/validations/valid_type_conversion.ex
+++ b/apps/transformers/lib/validations/valid_type_conversion.ex
@@ -1,5 +1,4 @@
 defmodule Transformers.Validations.ValidTypeConversion do
-
   alias Transformers.ConversionFunctions
   alias Transformers.Validations.ValidationStatus
 
@@ -19,8 +18,11 @@ defmodule Transformers.Validations.ValidTypeConversion do
 
   defp attempt_validation(status, parameters, source, target, function_field) do
     case pick_conversion(parameters) do
-      {:ok, conversion_function} -> add_function_to_designated_field(status, function_field, conversion_function)
-      {:error, reason} -> add_error_to_source_and_target(status, source, target, reason)
+      {:ok, conversion_function} ->
+        add_function_to_designated_field(status, function_field, conversion_function)
+
+      {:error, reason} ->
+        add_error_to_source_and_target(status, source, target, reason)
     end
   end
 
@@ -36,7 +38,6 @@ defmodule Transformers.Validations.ValidTypeConversion do
 
   defp add_error_to_source_and_target(status, source, target, reason) do
     ValidationStatus.add_error(status, source, reason)
-      |> ValidationStatus.add_error(target, reason)
+    |> ValidationStatus.add_error(target, reason)
   end
-
 end

--- a/apps/transformers/lib/validations/valid_type_conversion.ex
+++ b/apps/transformers/lib/validations/valid_type_conversion.ex
@@ -1,0 +1,41 @@
+defmodule Transformers.Validations.ValidTypeConversion do
+
+  alias Transformers.ConversionFunctions
+  alias Transformers.Validations.ValidationStatus
+
+  def check(status, parameters, source, target, function_field) do
+    if prior_errors_on_source_or_target?(status, source, target) do
+      status
+    else
+      attempt_validation(status, parameters, source, target, function_field)
+    end
+  end
+
+  defp prior_errors_on_source_or_target?(status, source, target) do
+    prior_source_type_error? = ValidationStatus.has_error?(status, source)
+    prior_target_type_error? = ValidationStatus.has_error?(status, target)
+    prior_source_type_error? || prior_target_type_error?
+  end
+
+  defp attempt_validation(status, parameters, source, target, function_field) do
+    source_type = Map.get(parameters, source)
+    target_type = Map.get(parameters, target)
+
+    result = ConversionFunctions.pick(source_type, target_type)
+
+    case result do
+      {:ok, conversion_function} -> add_function_to_designated_field(status, function_field, conversion_function)
+      {:error, reason} -> add_error_to_source_and_target(status, source, target, reason)
+    end
+  end
+
+  defp add_function_to_designated_field(status, function_field, conversion_function) do
+    ValidationStatus.update_value(status, function_field, conversion_function)
+  end
+
+  defp add_error_to_source_and_target(status, source, target, reason) do
+    ValidationStatus.add_error(status, source, reason)
+      |> ValidationStatus.add_error(target, reason)
+  end
+
+end

--- a/apps/transformers/lib/validations/valid_type_conversion.ex
+++ b/apps/transformers/lib/validations/valid_type_conversion.ex
@@ -17,7 +17,7 @@ defmodule Transformers.Validations.ValidTypeConversion do
   end
 
   defp attempt_validation(status, parameters, source, target, function_field) do
-    case pick_conversion(parameters) do
+    case pick_conversion(parameters, source, target) do
       {:ok, conversion_function} ->
         add_function_to_designated_field(status, function_field, conversion_function)
 
@@ -26,10 +26,10 @@ defmodule Transformers.Validations.ValidTypeConversion do
     end
   end
 
-  defp pick_conversion(parameters) do
+  defp pick_conversion(parameters, source, target) do
     source_type = Map.get(parameters, source)
     target_type = Map.get(parameters, target)
-    result = ConversionFunctions.pick(source_type, target_type)
+    ConversionFunctions.pick(source_type, target_type)
   end
 
   defp add_function_to_designated_field(status, function_field, conversion_function) do

--- a/apps/transformers/lib/validations/valid_type_conversion.ex
+++ b/apps/transformers/lib/validations/valid_type_conversion.ex
@@ -18,15 +18,16 @@ defmodule Transformers.Validations.ValidTypeConversion do
   end
 
   defp attempt_validation(status, parameters, source, target, function_field) do
-    source_type = Map.get(parameters, source)
-    target_type = Map.get(parameters, target)
-
-    result = ConversionFunctions.pick(source_type, target_type)
-
-    case result do
+    case pick_conversion(parameters) do
       {:ok, conversion_function} -> add_function_to_designated_field(status, function_field, conversion_function)
       {:error, reason} -> add_error_to_source_and_target(status, source, target, reason)
     end
+  end
+
+  defp pick_conversion(parameters) do
+    source_type = Map.get(parameters, source)
+    target_type = Map.get(parameters, target)
+    result = ConversionFunctions.pick(source_type, target_type)
   end
 
   defp add_function_to_designated_field(status, function_field, conversion_function) do

--- a/apps/transformers/lib/validations/validation_status.ex
+++ b/apps/transformers/lib/validations/validation_status.ex
@@ -29,4 +29,13 @@ defmodule Transformers.Validations.ValidationStatus do
   defp greater_than_zero?(length) do
     length > 0
   end
+
+  def ordered_values_or_errors(status, field_order) do
+    if any_errors?(status) do
+      {:error, status.errors}
+    else
+      ordered = Enum.map(field_order, fn field -> get_value(status, field) end)
+      {:ok, ordered}
+    end
+  end
 end

--- a/apps/transformers/lib/validations/validation_status.ex
+++ b/apps/transformers/lib/validations/validation_status.ex
@@ -1,5 +1,4 @@
 defmodule Transformers.Validations.ValidationStatus do
-
   defstruct values: %{}, errors: %{}
 
   def update_value(status, field, value) do

--- a/apps/transformers/lib/validations/validation_status.ex
+++ b/apps/transformers/lib/validations/validation_status.ex
@@ -18,6 +18,10 @@ defmodule Transformers.Validations.ValidationStatus do
     Map.get(status, :errors) |> Map.get(field)
   end
 
+  def has_error?(status, field) do
+    Map.get(status, :errors) |> Map.has_key?(field)
+  end
+
   def any_errors?(status) do
     Map.get(status, :errors) |> Map.keys() |> length() |> greater_than_zero?()
   end

--- a/apps/transformers/lib/validations/validation_status.ex
+++ b/apps/transformers/lib/validations/validation_status.ex
@@ -1,0 +1,28 @@
+defmodule Transformers.Validations.ValidationStatus do
+
+  defstruct values: %{}, errors: %{}
+
+  def update_value(status, field, value) do
+    Map.update(status, :values, %{}, fn values -> Map.put(values, field, value) end)
+  end
+
+  def add_error(status, field, error) do
+    Map.update(status, :errors, %{}, fn errors -> Map.put_new(errors, field, error) end)
+  end
+
+  def get_value(status, field) do
+    Map.get(status, :values) |> Map.get(field)
+  end
+
+  def get_error(status, field) do
+    Map.get(status, :errors) |> Map.get(field)
+  end
+
+  def any_errors?(status) do
+    Map.get(status, :errors) |> Map.keys() |> length() |> greater_than_zero?()
+  end
+
+  defp greater_than_zero?(length) do
+    length > 0
+  end
+end

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "0.3.8",
+      version: "1.0.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/test_helper.exs
+++ b/apps/transformers/test/unit/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Code.require_file("test/unit/validations/never_supported_type.exs")

--- a/apps/transformers/test/unit/test_helper.exs
+++ b/apps/transformers/test/unit/test_helper.exs
@@ -1,2 +1,1 @@
 ExUnit.start()
-Code.require_file("test/unit/validations/never_supported_type.exs")

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -202,4 +202,47 @@ defmodule Transformers.ConcatenationTest do
       where(parameter: ["sourceFields", "separator", "targetField"])
     end
   end
+
+  describe "validate_new/1" do
+    test "returns :ok if all parameters are present" do
+      parameters = %{
+        "sourceFields" => ["other", "name"],
+        "separator" => ".",
+        "targetField" => "name"
+      }
+
+      {:ok, [source_fields, separator, target_field]} = Concatenation.validate_new(parameters)
+
+      assert source_fields == parameters["sourceFields"]
+      assert separator == parameters["separator"]
+      assert target_field == parameters["targetField"]
+    end
+
+    data_test "when missing parameter #{parameter} return error" do
+      parameters =
+        %{
+          "sourceFields" => ["name", "last_name"],
+          "separator" => ".",
+          "targetField" => "full_name"
+        }
+        |> Map.delete(parameter)
+
+      {:error, reason} = Concatenation.validate_new(parameters)
+
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
+
+      where(parameter: ["sourceFields", "separator", "targetField"])
+    end
+
+    test "when all parameters missing return errors for all" do
+      {:error, reason} = Concatenation.validate_new(%{})
+
+      assert reason == %{
+        "sourceFields" => "Missing or empty field",
+        "separator" => "Missing or empty field",
+        "targetField" => "Missing or empty field"
+      }
+    end
+
+  end
 end

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -5,7 +5,7 @@ defmodule Transformers.ConcatenationTest do
   alias Transformers.Concatenation
 
   describe "transform/2" do
-    data_test "when missing parameter #{parameter} return error" do
+    data_test "when missing parameter #{parameter} return error #{message}" do
       payload = %{
         "string1" => "one",
         "string2" => "two"
@@ -21,9 +21,12 @@ defmodule Transformers.ConcatenationTest do
 
       {:error, reason} = Concatenation.transform(payload, parameters)
 
-      assert reason == %{"#{parameter}" => "Missing or empty field"}
+      assert reason == %{"#{parameter}" => "#{message}"}
 
-      where(parameter: ["sourceFields", "separator", "targetField"])
+      where(
+        parameter: ["sourceFields", "separator", "targetField"],
+        message: ["Missing or empty field", "Missing field", "Missing or empty field"]
+      )
     end
 
     test "error if a source field is missing" do
@@ -218,7 +221,7 @@ defmodule Transformers.ConcatenationTest do
       assert target_field == parameters["targetField"]
     end
 
-    data_test "when missing parameter #{parameter} return error" do
+    data_test "when missing parameter #{parameter} return error #{message}" do
       parameters =
         %{
           "sourceFields" => ["name", "last_name"],
@@ -229,9 +232,12 @@ defmodule Transformers.ConcatenationTest do
 
       {:error, reason} = Concatenation.validate_new(parameters)
 
-      assert reason == %{"#{parameter}" => "Missing or empty field"}
+      assert reason == %{"#{parameter}" => "#{message}"}
 
-      where(parameter: ["sourceFields", "separator", "targetField"])
+      where(
+        parameter: ["sourceFields", "separator", "targetField"],
+        message: ["Missing or empty field", "Missing field", "Missing or empty field"]
+      )
     end
 
     test "when all parameters missing return errors for all" do
@@ -239,7 +245,7 @@ defmodule Transformers.ConcatenationTest do
 
       assert reason == %{
         "sourceFields" => "Missing or empty field",
-        "separator" => "Missing or empty field",
+        "separator" => "Missing field",
         "targetField" => "Missing or empty field"
       }
     end

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -212,11 +212,10 @@ defmodule Transformers.ConcatenationTest do
       {:error, reason} = Concatenation.validate(%{})
 
       assert reason == %{
-        "sourceFields" => "Missing or empty field",
-        "separator" => "Missing field",
-        "targetField" => "Missing or empty field"
-      }
+               "sourceFields" => "Missing or empty field",
+               "separator" => "Missing field",
+               "targetField" => "Missing or empty field"
+             }
     end
-
   end
 end

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -189,7 +189,7 @@ defmodule Transformers.ConcatenationTest do
       assert target_field == parameters["targetField"]
     end
 
-    data_test "when missing parameter #{parameter} return error" do
+    data_test "when missing parameter #{parameter} return error #{message}" do
       parameters =
         %{
           "sourceFields" => ["name", "last_name"],
@@ -200,38 +200,6 @@ defmodule Transformers.ConcatenationTest do
 
       {:error, reason} = Concatenation.validate(parameters)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
-
-      where(parameter: ["sourceFields", "separator", "targetField"])
-    end
-  end
-
-  describe "validate_new/1" do
-    test "returns :ok if all parameters are present" do
-      parameters = %{
-        "sourceFields" => ["other", "name"],
-        "separator" => ".",
-        "targetField" => "name"
-      }
-
-      {:ok, [source_fields, separator, target_field]} = Concatenation.validate_new(parameters)
-
-      assert source_fields == parameters["sourceFields"]
-      assert separator == parameters["separator"]
-      assert target_field == parameters["targetField"]
-    end
-
-    data_test "when missing parameter #{parameter} return error #{message}" do
-      parameters =
-        %{
-          "sourceFields" => ["name", "last_name"],
-          "separator" => ".",
-          "targetField" => "full_name"
-        }
-        |> Map.delete(parameter)
-
-      {:error, reason} = Concatenation.validate_new(parameters)
-
       assert reason == %{"#{parameter}" => "#{message}"}
 
       where(
@@ -241,7 +209,7 @@ defmodule Transformers.ConcatenationTest do
     end
 
     test "when all parameters missing return errors for all" do
-      {:error, reason} = Concatenation.validate_new(%{})
+      {:error, reason} = Concatenation.validate(%{})
 
       assert reason == %{
         "sourceFields" => "Missing or empty field",

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -21,7 +21,7 @@ defmodule Transformers.ConcatenationTest do
 
       {:error, reason} = Concatenation.transform(payload, parameters)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
 
       where(parameter: ["sourceFields", "separator", "targetField"])
     end

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -173,7 +173,11 @@ defmodule Transformers.DateTimeTest do
 
       {:error, reason} = Transformers.DateTime.validate(params)
 
-      assert reason == %{"#{format}" => "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."}
+      assert reason == %{
+               "#{format}" =>
+                 "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."
+             }
+
       where(format: ["sourceFormat", "targetFormat"])
     end
 

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -155,7 +155,7 @@ defmodule Transformers.DateTimeTest do
 
       {:error, reason} = DateTime.validate(parameters)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
 
       where(parameter: ["sourceField", "sourceFormat", "targetField", "targetFormat"])
     end
@@ -173,61 +173,6 @@ defmodule Transformers.DateTimeTest do
 
       {:error, reason} = Transformers.DateTime.validate(params)
 
-      assert reason ==
-               "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."
-
-      where(format: ["sourceFormat", "targetFormat"])
-    end
-  end
-
-  describe "validate_new/1" do
-    test "returns :ok if all parameters are present and valid" do
-      parameters = %{
-        "sourceField" => "date1",
-        "targetField" => "date2",
-        "sourceFormat" => "{YYYY}-{0M}-{D} {h24}:{m}",
-        "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
-      }
-
-      {:ok, [source_field, source_format, target_field, target_format]} =
-        DateTime.validate_new(parameters)
-
-      assert source_field == parameters["sourceField"]
-      assert source_format == parameters["sourceFormat"]
-      assert target_field == parameters["targetField"]
-      assert target_format == parameters["targetFormat"]
-    end
-
-    data_test "when missing parameter #{parameter} return error" do
-      parameters =
-        %{
-          "sourceField" => "date1",
-          "targetField" => "date2",
-          "sourceFormat" => "{YYYY}-{0M}-{D} {h24}:{m}",
-          "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
-        }
-        |> Map.delete(parameter)
-
-      {:error, reason} = DateTime.validate_new(parameters)
-
-      assert reason == %{"#{parameter}" => "Missing or empty field"}
-
-      where(parameter: ["sourceField", "sourceFormat", "targetField", "targetFormat"])
-    end
-
-    data_test "returns error when #{format} is invalid Timex DateTime format" do
-      params =
-        %{
-          "sourceField" => "date1",
-          "targetField" => "date2",
-          "sourceFormat" => "{YYYY}-{0M}-{D} {h24}:{m}",
-          "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
-        }
-        |> Map.delete(format)
-        |> Map.put(format, "{invalid}")
-
-      {:error, reason} = Transformers.DateTime.validate_new(params)
-
       assert reason == %{"#{format}" => "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."}
       where(format: ["sourceFormat", "targetFormat"])
     end
@@ -242,7 +187,7 @@ defmodule Transformers.DateTimeTest do
         }
         |> Map.delete("sourceFormat")
 
-      {:error, reason} = DateTime.validate_new(parameters)
+      {:error, reason} = DateTime.validate(parameters)
 
       assert reason == %{"sourceFormat" => "Missing or empty field"}
     end

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -67,7 +67,7 @@ defmodule Transformers.DateTimeTest do
 
       {:error, reason} = Transformers.DateTime.transform(%{}, params)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
 
       where(parameter: ["sourceField", "sourceFormat", "targetField", "targetFormat"])
     end

--- a/apps/transformers/test/unit/transformations/regex_extract_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_extract_test.exs
@@ -75,7 +75,7 @@ defmodule Transformers.RegexExtractTest do
 
       {:error, reason} = Transformers.RegexExtract.transform(message_payload, params)
 
-      assert reason == "Invalid regular expression: missing ) at index 8"
+      assert reason == %{"regex" => "Invalid regular expression: missing ) at index 8"}
     end
 
     test "if source and target field are the same overwrite original value" do

--- a/apps/transformers/test/unit/transformations/regex_extract_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_extract_test.exs
@@ -119,51 +119,6 @@ defmodule Transformers.RegexExtractTest do
 
       {:error, reason} = RegexExtract.validate(parameters)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
-
-      where(parameter: ["sourceField", "targetField", "regex"])
-    end
-
-    test "returns error when regex is invalid" do
-      params = %{
-        "sourceField" => "source_field",
-        "targetField" => "target_field",
-        "regex" => "^\((\d{3})"
-      }
-
-      {:error, reason} = RegexExtract.validate(params)
-
-      assert reason ==
-               "Invalid regular expression: missing ) at index 8"
-    end
-  end
-
-  describe "validate_new/1" do
-    test "returns :ok if all parameters are present and valid" do
-      parameters = %{
-        "sourceField" => "phone_number",
-        "targetField" => "area_code",
-        "regex" => "^\\((\\d{3})\\)"
-      }
-
-      {:ok, [source_field, target_field, regex]} = RegexExtract.validate_new(parameters)
-
-      assert source_field == parameters["sourceField"]
-      assert target_field == parameters["targetField"]
-      assert regex == Regex.compile!(parameters["regex"])
-    end
-
-    data_test "when missing parameter #{parameter} return error" do
-      parameters =
-        %{
-          "sourceField" => "phone_number",
-          "targetField" => "area_code",
-          "regex" => "^\\((\\d{3})\\)"
-        }
-        |> Map.delete(parameter)
-
-      {:error, reason} = RegexExtract.validate_new(parameters)
-
       assert reason == %{"#{parameter}" => "Missing or empty field"}
 
       where(parameter: ["sourceField", "targetField", "regex"])
@@ -176,7 +131,7 @@ defmodule Transformers.RegexExtractTest do
         "regex" => "^\((\d{3})"
       }
 
-      {:error, reason} = RegexExtract.validate_new(params)
+      {:error, reason} = RegexExtract.validate(params)
 
       assert reason == %{"regex" => "Invalid regular expression: missing ) at index 8"}
     end

--- a/apps/transformers/test/unit/transformations/regex_extract_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_extract_test.exs
@@ -137,4 +137,48 @@ defmodule Transformers.RegexExtractTest do
                "Invalid regular expression: missing ) at index 8"
     end
   end
+
+  describe "validate_new/1" do
+    test "returns :ok if all parameters are present and valid" do
+      parameters = %{
+        "sourceField" => "phone_number",
+        "targetField" => "area_code",
+        "regex" => "^\\((\\d{3})\\)"
+      }
+
+      {:ok, [source_field, target_field, regex]} = RegexExtract.validate_new(parameters)
+
+      assert source_field == parameters["sourceField"]
+      assert target_field == parameters["targetField"]
+      assert regex == Regex.compile!(parameters["regex"])
+    end
+
+    data_test "when missing parameter #{parameter} return error" do
+      parameters =
+        %{
+          "sourceField" => "phone_number",
+          "targetField" => "area_code",
+          "regex" => "^\\((\\d{3})\\)"
+        }
+        |> Map.delete(parameter)
+
+      {:error, reason} = RegexExtract.validate_new(parameters)
+
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
+
+      where(parameter: ["sourceField", "targetField", "regex"])
+    end
+
+    test "returns error when regex is invalid" do
+      params = %{
+        "sourceField" => "source_field",
+        "targetField" => "target_field",
+        "regex" => "^\((\d{3})"
+      }
+
+      {:error, reason} = RegexExtract.validate_new(params)
+
+      assert reason == %{"regex" => "Invalid regular expression: missing ) at index 8"}
+    end
+  end
 end

--- a/apps/transformers/test/unit/transformations/regex_replace_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_replace_test.exs
@@ -162,51 +162,6 @@ defmodule Transformers.RegexReplaceTest do
 
       {:error, reason} = RegexReplace.validate(parameters)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
-
-      where(parameter: ["sourceField", "replacement", "regex"])
-    end
-
-    test "returns error when regex is invalid" do
-      parameters = %{
-        "sourceField" => "something",
-        "regex" => "(()",
-        "replacement" => "123"
-      }
-
-      {:error, reason} = RegexReplace.validate(parameters)
-
-      assert reason ==
-               "Invalid regular expression: missing ) at index 3"
-    end
-  end
-
-  describe "validate_new/1" do
-    test "returns :ok if all parameters are present and valid" do
-      parameters = %{
-        "sourceField" => "something",
-        "regex" => "a",
-        "replacement" => "123"
-      }
-
-      {:ok, [source_field, replacement, regex]} = RegexReplace.validate_new(parameters)
-
-      assert source_field == parameters["sourceField"]
-      assert replacement == parameters["replacement"]
-      assert regex == Regex.compile!(parameters["regex"])
-    end
-
-    data_test "when missing parameter #{parameter} return error" do
-      parameters =
-        %{
-          "sourceField" => "something",
-          "regex" => "a",
-          "replacement" => "123"
-        }
-        |> Map.delete(parameter)
-
-      {:error, reason} = RegexReplace.validate_new(parameters)
-
       assert reason == %{"#{parameter}" => "Missing or empty field"}
 
       where(parameter: ["sourceField", "replacement", "regex"])
@@ -219,7 +174,7 @@ defmodule Transformers.RegexReplaceTest do
         "replacement" => "123"
       }
 
-      {:error, reason} = RegexReplace.validate_new(parameters)
+      {:error, reason} = RegexReplace.validate(parameters)
 
       assert reason == %{"regex" => "Invalid regular expression: missing ) at index 3"}
     end

--- a/apps/transformers/test/unit/transformations/regex_replace_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_replace_test.exs
@@ -180,4 +180,48 @@ defmodule Transformers.RegexReplaceTest do
                "Invalid regular expression: missing ) at index 3"
     end
   end
+
+  describe "validate_new/1" do
+    test "returns :ok if all parameters are present and valid" do
+      parameters = %{
+        "sourceField" => "something",
+        "regex" => "a",
+        "replacement" => "123"
+      }
+
+      {:ok, [source_field, replacement, regex]} = RegexReplace.validate_new(parameters)
+
+      assert source_field == parameters["sourceField"]
+      assert replacement == parameters["replacement"]
+      assert regex == Regex.compile!(parameters["regex"])
+    end
+
+    data_test "when missing parameter #{parameter} return error" do
+      parameters =
+        %{
+          "sourceField" => "something",
+          "regex" => "a",
+          "replacement" => "123"
+        }
+        |> Map.delete(parameter)
+
+      {:error, reason} = RegexReplace.validate_new(parameters)
+
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
+
+      where(parameter: ["sourceField", "replacement", "regex"])
+    end
+
+    test "returns error when regex is invalid" do
+      parameters = %{
+        "sourceField" => "something",
+        "regex" => "(()",
+        "replacement" => "123"
+      }
+
+      {:error, reason} = RegexReplace.validate_new(parameters)
+
+      assert reason == %{"regex" => "Invalid regular expression: missing ) at index 3"}
+    end
+  end
 end

--- a/apps/transformers/test/unit/transformations/regex_replace_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_replace_test.exs
@@ -69,7 +69,7 @@ defmodule Transformers.RegexReplaceTest do
 
     {:error, reason} = RegexReplace.transform(payload, parameters)
 
-    assert reason == "Value of field replacement is not a string: 123"
+    assert reason == %{"replacement" => "Not a string or list"}
   end
 
   test "if source field is not a string, return error" do

--- a/apps/transformers/test/unit/transformations/regex_replace_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_replace_test.exs
@@ -19,7 +19,7 @@ defmodule Transformers.RegexReplaceTest do
 
     {:error, reason} = RegexReplace.transform(payload, parameters)
 
-    assert reason == "Missing transformation parameter: #{parameter}"
+    assert reason == %{"#{parameter}" => "Missing or empty field"}
 
     where(parameter: ["sourceField", "regex", "replacement"])
   end
@@ -53,7 +53,7 @@ defmodule Transformers.RegexReplaceTest do
 
     {:error, reason} = RegexReplace.transform(payload, parameters)
 
-    assert reason == "Invalid regular expression: missing ) at index 3"
+    assert reason == %{"regex" => "Invalid regular expression: missing ) at index 3"}
   end
 
   test "when replacement is not a string, return error" do

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -70,6 +70,30 @@ defmodule Transformers.RemoveTest do
     end
   end
 
+  describe "validate_new/1" do
+    test "returns :ok if all parameters are present" do
+      parameters = %{
+        "sourceField" => "dead_field"
+      }
+
+      {:ok, source_field} = Remove.validate_new(parameters)
+
+      assert source_field == parameters["sourceField"]
+    end
+
+    test "when missing parameter sourceField return error" do
+      parameters =
+        %{
+          "sourceField" => "dead_field"
+        }
+        |> Map.delete("sourceField")
+
+      {:error, reason} = Remove.validate_new(parameters)
+
+      assert reason == %{"sourceField" => "Missing or empty field"}
+    end
+  end
+
   describe "fields/0" do
     test "describes the fields needed for transformation" do
       expected_fields = [

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -92,6 +92,17 @@ defmodule Transformers.RemoveTest do
 
       assert reason == %{"sourceField" => "Missing or empty field"}
     end
+
+    test "when empty sourceField return error" do
+      parameters =
+        %{
+          "sourceField" => ""
+        }
+
+      {:error, reason} = Remove.validate_new(parameters)
+
+      assert reason == %{"sourceField" => "Missing or empty field"}
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -103,6 +103,17 @@ defmodule Transformers.RemoveTest do
 
       assert reason == %{"sourceField" => "Missing or empty field"}
     end
+
+    test "when whitespace sourceField return error" do
+      parameters =
+        %{
+          "sourceField" => "   "
+        }
+
+      {:error, reason} = Remove.validate_new(parameters)
+
+      assert reason == %{"sourceField" => "Missing or empty field"}
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -70,10 +70,9 @@ defmodule Transformers.RemoveTest do
     end
 
     test "when empty sourceField return error" do
-      parameters =
-        %{
-          "sourceField" => ""
-        }
+      parameters = %{
+        "sourceField" => ""
+      }
 
       {:error, reason} = Remove.validate(parameters)
 
@@ -81,10 +80,9 @@ defmodule Transformers.RemoveTest do
     end
 
     test "when whitespace sourceField return error" do
-      parameters =
-        %{
-          "sourceField" => "   "
-        }
+      parameters = %{
+        "sourceField" => "   "
+      }
 
       {:error, reason} = Remove.validate(parameters)
 

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -13,7 +13,7 @@ defmodule Transformers.RemoveTest do
 
       {:error, reason} = Remove.transform(payload, parameters)
 
-      assert reason == "Missing transformation parameter: sourceField"
+      assert reason == %{"sourceField" => "Missing or empty field"}
     end
 
     test "if source field not on payload, return error" do

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -54,7 +54,7 @@ defmodule Transformers.RemoveTest do
 
       {:ok, source_field} = Remove.validate(parameters)
 
-      assert source_field == parameters["sourceField"]
+      assert source_field == ["dead_field"]
     end
 
     test "when missing parameter sourceField return error" do

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -66,30 +66,6 @@ defmodule Transformers.RemoveTest do
 
       {:error, reason} = Remove.validate(parameters)
 
-      assert reason == "Missing transformation parameter: sourceField"
-    end
-  end
-
-  describe "validate_new/1" do
-    test "returns :ok if all parameters are present" do
-      parameters = %{
-        "sourceField" => "dead_field"
-      }
-
-      {:ok, source_field} = Remove.validate_new(parameters)
-
-      assert source_field == parameters["sourceField"]
-    end
-
-    test "when missing parameter sourceField return error" do
-      parameters =
-        %{
-          "sourceField" => "dead_field"
-        }
-        |> Map.delete("sourceField")
-
-      {:error, reason} = Remove.validate_new(parameters)
-
       assert reason == %{"sourceField" => "Missing or empty field"}
     end
 
@@ -99,7 +75,7 @@ defmodule Transformers.RemoveTest do
           "sourceField" => ""
         }
 
-      {:error, reason} = Remove.validate_new(parameters)
+      {:error, reason} = Remove.validate(parameters)
 
       assert reason == %{"sourceField" => "Missing or empty field"}
     end
@@ -110,7 +86,7 @@ defmodule Transformers.RemoveTest do
           "sourceField" => "   "
         }
 
-      {:error, reason} = Remove.validate_new(parameters)
+      {:error, reason} = Remove.validate(parameters)
 
       assert reason == %{"sourceField" => "Missing or empty field"}
     end

--- a/apps/transformers/test/unit/transformations/type_conversion_test.exs
+++ b/apps/transformers/test/unit/transformations/type_conversion_test.exs
@@ -37,7 +37,7 @@ defmodule Transformers.TypeConversionTest do
 
     result = Transformers.TypeConversion.transform(payload, parameters)
 
-    assert {:error, "Missing transformation parameter: field"} == result
+    assert {:error, %{"field" => "Missing or empty field"}} == result
   end
 
   test "if params do not contain source type return error" do
@@ -46,7 +46,7 @@ defmodule Transformers.TypeConversionTest do
 
     result = Transformers.TypeConversion.transform(payload, parameters)
 
-    assert {:error, "Missing transformation parameter: sourceType"} == result
+    assert {:error, %{"sourceType" => "Missing or empty field"}} == result
   end
 
   test "if params do not contain target type return error" do
@@ -55,7 +55,7 @@ defmodule Transformers.TypeConversionTest do
 
     result = Transformers.TypeConversion.transform(payload, parameters)
 
-    assert {:error, "Missing transformation parameter: targetType"} == result
+    assert {:error, %{"targetType" => "Missing or empty field"}} == result
   end
 
   test "if field supposed to be float but is not, return error" do
@@ -170,9 +170,12 @@ defmodule Transformers.TypeConversionTest do
     payload = %{"thing" => true}
     parameters = %{"field" => "thing", "sourceType" => "boolean", "targetType" => "string"}
 
-    result = Transformers.TypeConversion.transform(payload, parameters)
+    {:error, reason} = Transformers.TypeConversion.transform(payload, parameters)
 
-    assert {:error, "Conversion from boolean to string is not supported"} == result
+    assert reason == %{
+      "sourceType" => "Conversion from boolean to string is not supported",
+      "targetType" => "Conversion from boolean to string is not supported"
+    }
   end
 
   test "if string cannot be parsed into integer return error" do

--- a/apps/transformers/test/unit/transformations/type_conversion_test.exs
+++ b/apps/transformers/test/unit/transformations/type_conversion_test.exs
@@ -173,9 +173,9 @@ defmodule Transformers.TypeConversionTest do
     {:error, reason} = Transformers.TypeConversion.transform(payload, parameters)
 
     assert reason == %{
-      "sourceType" => "Conversion from boolean to string is not supported",
-      "targetType" => "Conversion from boolean to string is not supported"
-    }
+             "sourceType" => "Conversion from boolean to string is not supported",
+             "targetType" => "Conversion from boolean to string is not supported"
+           }
   end
 
   test "if string cannot be parsed into integer return error" do
@@ -235,9 +235,9 @@ defmodule Transformers.TypeConversionTest do
       {:error, reasons} = TypeConversion.validate(parameters)
 
       assert reasons == %{
-        "sourceType" => "Conversion from boolean to string is not supported",
-        "targetType" => "Conversion from boolean to string is not supported"
-      }
+               "sourceType" => "Conversion from boolean to string is not supported",
+               "targetType" => "Conversion from boolean to string is not supported"
+             }
     end
   end
 end

--- a/apps/transformers/test/unit/transformations/type_conversion_test.exs
+++ b/apps/transformers/test/unit/transformations/type_conversion_test.exs
@@ -224,48 +224,6 @@ defmodule Transformers.TypeConversionTest do
 
       {:error, reason} = TypeConversion.validate(parameters)
 
-      assert reason == "Missing transformation parameter: #{parameter}"
-
-      where(parameter: ["field", "sourceType", "targetType"])
-    end
-
-    test "if conversion is not supported return error" do
-      parameters = %{"field" => "thing", "sourceType" => "boolean", "targetType" => "string"}
-
-      result = TypeConversion.validate(parameters)
-
-      assert {:error, "Conversion from boolean to string is not supported"} == result
-    end
-  end
-
-  describe "validate_new/1" do
-    test "returns :ok if all parameters are present and the type conversion is valid" do
-      parameters = %{
-        "field" => "some_int",
-        "sourceType" => "integer",
-        "targetType" => "string"
-      }
-
-      {:ok, [field, source_type, target_type, conversion_function]} =
-        TypeConversion.validate_new(parameters)
-
-      assert field == parameters["field"]
-      assert source_type == parameters["sourceType"]
-      assert target_type == parameters["targetType"]
-      assert is_function(conversion_function)
-    end
-
-    data_test "when missing parameter #{parameter} return error" do
-      parameters =
-        %{
-          "field" => "some_int",
-          "sourceType" => "integer",
-          "targetType" => "string"
-        }
-        |> Map.delete(parameter)
-
-      {:error, reason} = TypeConversion.validate_new(parameters)
-
       assert reason == %{"#{parameter}" => "Missing or empty field"}
 
       where(parameter: ["field", "sourceType", "targetType"])
@@ -274,7 +232,7 @@ defmodule Transformers.TypeConversionTest do
     test "if conversion is not supported return error" do
       parameters = %{"field" => "thing", "sourceType" => "boolean", "targetType" => "string"}
 
-      {:error, reasons} = TypeConversion.validate_new(parameters)
+      {:error, reasons} = TypeConversion.validate(parameters)
 
       assert reasons == %{
         "sourceType" => "Conversion from boolean to string is not supported",

--- a/apps/transformers/test/unit/transformations/type_conversion_test.exs
+++ b/apps/transformers/test/unit/transformations/type_conversion_test.exs
@@ -234,4 +234,49 @@ defmodule Transformers.TypeConversionTest do
       assert {:error, "Conversion from boolean to string is not supported"} == result
     end
   end
+
+  describe "validate_new/1" do
+    test "returns :ok if all parameters are present and the type conversion is valid" do
+      parameters = %{
+        "field" => "some_int",
+        "sourceType" => "integer",
+        "targetType" => "string"
+      }
+
+      {:ok, [field, source_type, target_type, conversion_function]} =
+        TypeConversion.validate_new(parameters)
+
+      assert field == parameters["field"]
+      assert source_type == parameters["sourceType"]
+      assert target_type == parameters["targetType"]
+      assert is_function(conversion_function)
+    end
+
+    data_test "when missing parameter #{parameter} return error" do
+      parameters =
+        %{
+          "field" => "some_int",
+          "sourceType" => "integer",
+          "targetType" => "string"
+        }
+        |> Map.delete(parameter)
+
+      {:error, reason} = TypeConversion.validate_new(parameters)
+
+      assert reason == %{"#{parameter}" => "Missing or empty field"}
+
+      where(parameter: ["field", "sourceType", "targetType"])
+    end
+
+    test "if conversion is not supported return error" do
+      parameters = %{"field" => "thing", "sourceType" => "boolean", "targetType" => "string"}
+
+      {:error, reasons} = TypeConversion.validate_new(parameters)
+
+      assert reasons == %{
+        "sourceType" => "Conversion from boolean to string is not supported",
+        "targetType" => "Conversion from boolean to string is not supported"
+      }
+    end
+  end
 end

--- a/apps/transformers/test/unit/validate_transformations_test.exs
+++ b/apps/transformers/test/unit/validate_transformations_test.exs
@@ -67,7 +67,7 @@ defmodule Transformers.ValidateTest do
     }
 
     assert Transformers.validate([transformation1, transformation2]) ==
-             [{:ok, "Transformation valid."}, {:error, "Transformation not valid."}]
+             [{:ok, "Transformation valid."}, {:error, %{"sourceField" => "Missing or empty field"}}]
   end
 
   test "when provided an empty transformations list, an empty list is returned" do

--- a/apps/transformers/test/unit/validate_transformations_test.exs
+++ b/apps/transformers/test/unit/validate_transformations_test.exs
@@ -67,7 +67,10 @@ defmodule Transformers.ValidateTest do
     }
 
     assert Transformers.validate([transformation1, transformation2]) ==
-             [{:ok, "Transformation valid."}, {:error, %{"sourceField" => "Missing or empty field"}}]
+             [
+               {:ok, "Transformation valid."},
+               {:error, %{"sourceField" => "Missing or empty field"}}
+             ]
   end
 
   test "when provided an empty transformations list, an empty list is returned" do

--- a/apps/transformers/test/unit/validations/datetime_format_test.exs
+++ b/apps/transformers/test/unit/validations/datetime_format_test.exs
@@ -23,7 +23,9 @@ defmodule Transformers.Validations.DateTimeFormatTest do
 
     result = DateTimeFormat.check(status, parameters, key)
 
-    expected_message = "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."
+    expected_message =
+      "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."
+
     assert ValidationStatus.get_error(result, key) == expected_message
   end
 

--- a/apps/transformers/test/unit/validations/datetime_format_test.exs
+++ b/apps/transformers/test/unit/validations/datetime_format_test.exs
@@ -1,0 +1,40 @@
+defmodule Transformers.Validations.DateTimeFormatTest do
+  use ExUnit.Case
+
+  alias Transformers.Validations.DateTimeFormat
+  alias Transformers.Validations.ValidationStatus
+
+  test "adds value to status values if valid" do
+    status = %ValidationStatus{}
+    key = "format"
+    value = "{YYYY}-{0M}-{D} {h24}:{m}"
+    parameters = %{key => value}
+
+    result = DateTimeFormat.check(status, parameters, key)
+
+    assert ValidationStatus.get_value(result, key) == value
+  end
+
+  test "adds message to errors if invalid" do
+    status = %ValidationStatus{}
+    key = "format"
+    value = "{invalid}"
+    parameters = %{key => value}
+
+    result = DateTimeFormat.check(status, parameters, key)
+
+    expected_message = "DateTime format \"{invalid}\" is invalid: Expected at least one parser to succeed at line 1, column 0."
+    assert ValidationStatus.get_error(result, key) == expected_message
+  end
+
+  test "add error for missing value if nil" do
+    status = %ValidationStatus{}
+    key = "format"
+    parameters = %{key => nil}
+
+    result = DateTimeFormat.check(status, parameters, key)
+
+    expected_message = "No datetime format provided"
+    assert ValidationStatus.get_error(result, key) == expected_message
+  end
+end

--- a/apps/transformers/test/unit/validations/is_present_test.exs
+++ b/apps/transformers/test/unit/validations/is_present_test.exs
@@ -22,5 +22,4 @@ defmodule Transformers.Validations.IsPresentTest do
 
     assert result == %ValidationStatus{errors: %{"gone" => "Missing field"}}
   end
-
 end

--- a/apps/transformers/test/unit/validations/is_present_test.exs
+++ b/apps/transformers/test/unit/validations/is_present_test.exs
@@ -1,0 +1,26 @@
+defmodule Transformers.Validations.IsPresentTest do
+  use ExUnit.Case
+
+  alias Transformers.Validations.IsPresent
+  alias Transformers.Validations.ValidationStatus
+
+  test "updates values if field present" do
+    field = "yay"
+    value = " "
+    parameters = %{field => value}
+    status = %ValidationStatus{}
+
+    result = IsPresent.check(status, parameters, field)
+
+    assert result == %ValidationStatus{values: %{field => value}}
+  end
+
+  test "updates errors if field absent" do
+    status = %ValidationStatus{}
+
+    result = IsPresent.check(status, %{}, "gone")
+
+    assert result == %ValidationStatus{errors: %{"gone" => "Missing field"}}
+  end
+
+end

--- a/apps/transformers/test/unit/validations/never_supported_type.exs
+++ b/apps/transformers/test/unit/validations/never_supported_type.exs
@@ -1,3 +1,0 @@
-defmodule Transformers.Validations.NeverSupportedThing do
-  defstruct supported: false
-end

--- a/apps/transformers/test/unit/validations/never_supported_type.exs
+++ b/apps/transformers/test/unit/validations/never_supported_type.exs
@@ -1,0 +1,3 @@
+defmodule Transformers.Validations.NeverSupportedThing do
+  defstruct supported: false
+end

--- a/apps/transformers/test/unit/validations/not_blank_test.exs
+++ b/apps/transformers/test/unit/validations/not_blank_test.exs
@@ -1,0 +1,60 @@
+defmodule Transformers.Validations.NotBlankTest do
+  use ExUnit.Case
+
+  alias Transformers.Validations.NotBlank
+  alias Transformers.Validations.ValidationStatus
+
+  test "if field present return ok with value" do
+    field = "something"
+    value = "present!"
+    parameters = %{field => value}
+    status = %ValidationStatus{}
+
+    result = NotBlank.check(status, parameters, field)
+
+    assert result == %ValidationStatus{values: %{field => value}}
+  end
+
+  test "if field nil return error" do
+    field = "something"
+    value = nil
+    parameters = %{field => value}
+    status = %ValidationStatus{}
+
+    result = NotBlank.check(status, parameters, field)
+
+    assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+  end
+
+  test "if field empty string return error" do
+    field = "something"
+    value = ""
+    parameters = %{field => value}
+    status = %ValidationStatus{}
+
+    result = NotBlank.check(status, parameters, field)
+
+    assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+  end
+
+  test "if field whitespace return error" do
+    field = "something"
+    value = "    "
+    parameters = %{field => value}
+    status = %ValidationStatus{}
+
+    result = NotBlank.check(status, parameters, field)
+
+    assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+  end
+
+  test "if prior errors for field do nothing" do
+    field = "something"
+    parameters = %{field => "something"}
+    status = %ValidationStatus{errors: %{field => "Invalid field"}}
+
+    result = NotBlank.check(status, parameters, field)
+
+    assert result == status
+  end
+end

--- a/apps/transformers/test/unit/validations/not_blank_test.exs
+++ b/apps/transformers/test/unit/validations/not_blank_test.exs
@@ -1,7 +1,6 @@
 defmodule Transformers.Validations.NotBlankTest do
   use ExUnit.Case
 
-  alias Transformers.Validations.NeverSupportedThing
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidationStatus
 
@@ -96,14 +95,15 @@ defmodule Transformers.Validations.NotBlankTest do
   end
 
   describe("check/3 for unsupported type") do
-    test "do nothing" do
+    test "add error if value neither string or list" do
       field = "something"
-      parameters = %{field => %NeverSupportedThing{}}
+      value = 123
+      parameters = %{field => value}
       status = %ValidationStatus{}
 
       result = NotBlank.check(status, parameters, field)
 
-      assert result == status
+      assert result.errors == %{field => "Not a string or list"}
     end
   end
 end

--- a/apps/transformers/test/unit/validations/not_blank_test.exs
+++ b/apps/transformers/test/unit/validations/not_blank_test.exs
@@ -1,60 +1,109 @@
 defmodule Transformers.Validations.NotBlankTest do
   use ExUnit.Case
 
+  alias Transformers.Validations.NeverSupportedThing
   alias Transformers.Validations.NotBlank
   alias Transformers.Validations.ValidationStatus
 
-  test "if field present return ok with value" do
-    field = "something"
-    value = "present!"
-    parameters = %{field => value}
-    status = %ValidationStatus{}
+  describe("check/3 for binary") do
+    test "if field present return ok with value" do
+      field = "something"
+      value = "present!"
+      parameters = %{field => value}
+      status = %ValidationStatus{}
 
-    result = NotBlank.check(status, parameters, field)
+      result = NotBlank.check(status, parameters, field)
 
-    assert result == %ValidationStatus{values: %{field => value}}
+      assert result == %ValidationStatus{values: %{field => value}}
+    end
+
+    test "if field nil return error" do
+      field = "something"
+      value = nil
+      parameters = %{field => value}
+      status = %ValidationStatus{}
+
+      result = NotBlank.check(status, parameters, field)
+
+      assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+    end
+
+    test "if field empty string return error" do
+      field = "something"
+      value = ""
+      parameters = %{field => value}
+      status = %ValidationStatus{}
+
+      result = NotBlank.check(status, parameters, field)
+
+      assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+    end
+
+    test "if field whitespace return error" do
+      field = "something"
+      value = "    "
+      parameters = %{field => value}
+      status = %ValidationStatus{}
+
+      result = NotBlank.check(status, parameters, field)
+
+      assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+    end
+
+    test "if prior errors for field do nothing" do
+      field = "something"
+      parameters = %{field => "something"}
+      status = %ValidationStatus{errors: %{field => "Invalid field"}}
+
+      result = NotBlank.check(status, parameters, field)
+
+      assert result == status
+    end
   end
 
-  test "if field nil return error" do
-    field = "something"
-    value = nil
-    parameters = %{field => value}
-    status = %ValidationStatus{}
+  describe("check/3 for list") do
+    test "if field present return ok with value" do
+      field = "something"
+      value = ["one", "two", "three"]
+      parameters = %{field => value}
+      status = %ValidationStatus{}
 
-    result = NotBlank.check(status, parameters, field)
+      result = NotBlank.check(status, parameters, field)
 
-    assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+      assert result == %ValidationStatus{values: %{field => value}}
+    end
+
+    test "if field nil return error" do
+      field = "something"
+      value = nil
+      parameters = %{field => value}
+      status = %ValidationStatus{}
+
+      result = NotBlank.check(status, parameters, field)
+
+      assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
+    end
+
+    test "if prior errors for field do nothing" do
+      field = "something"
+      parameters = %{field => ["one", "two", "three"]}
+      status = %ValidationStatus{errors: %{field => "Invalid field"}}
+
+      result = NotBlank.check(status, parameters, field)
+
+      assert result == status
+    end
   end
 
-  test "if field empty string return error" do
-    field = "something"
-    value = ""
-    parameters = %{field => value}
-    status = %ValidationStatus{}
+  describe("check/3 for unsupported type") do
+    test "do nothing" do
+      field = "something"
+      parameters = %{field => %NeverSupportedThing{}}
+      status = %ValidationStatus{}
 
-    result = NotBlank.check(status, parameters, field)
+      result = NotBlank.check(status, parameters, field)
 
-    assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
-  end
-
-  test "if field whitespace return error" do
-    field = "something"
-    value = "    "
-    parameters = %{field => value}
-    status = %ValidationStatus{}
-
-    result = NotBlank.check(status, parameters, field)
-
-    assert result == %ValidationStatus{errors: %{field => "Missing or empty field"}}
-  end
-
-  test "if prior errors for field do nothing" do
-    field = "something"
-    parameters = %{field => "something"}
-    status = %ValidationStatus{errors: %{field => "Invalid field"}}
-
-    result = NotBlank.check(status, parameters, field)
-
-    assert result == status
+      assert result == status
+    end
   end
 end

--- a/apps/transformers/test/unit/validations/valid_regex_test.exs
+++ b/apps/transformers/test/unit/validations/valid_regex_test.exs
@@ -1,0 +1,38 @@
+defmodule Transformers.Validations.ValidRegexTest do
+  use ExUnit.Case
+
+  alias Transformers.Validations.ValidRegex
+  alias Transformers.Validations.ValidationStatus
+
+  test "add value if regex compiles" do
+    status = %ValidationStatus{}
+    field = "regex"
+    value = "gr[ae]y"
+    parameters = %{field => value}
+
+    result = ValidRegex.check(status, parameters, field)
+
+    assert result.values == %{"regex" => ~r/gr[ae]y/}
+  end
+
+  test "add error if regex does not compile" do
+    status = %ValidationStatus{}
+    field = "regex"
+    value = "(()"
+    parameters = %{field => value}
+
+    result = ValidRegex.check(status, parameters, field)
+
+    assert result.errors == %{"regex" => "Invalid regular expression: missing ) at index 3"}
+  end
+
+  test "add error if no value provided" do
+    status = %ValidationStatus{}
+    field = "regex"
+    parameters = %{field => nil}
+
+    result = ValidRegex.check(status, parameters, field)
+
+    assert result.errors == %{"regex" => "No regular expression provided"}
+  end
+end

--- a/apps/transformers/test/unit/validations/valid_type_conversion_test.exs
+++ b/apps/transformers/test/unit/validations/valid_type_conversion_test.exs
@@ -1,0 +1,48 @@
+defmodule Transformers.Validations.ValidTypeConversionTest do
+  use ExUnit.Case
+
+  alias Transformers.ConversionFunctions
+  alias Transformers.Validations.ValidTypeConversion
+  alias Transformers.Validations.ValidationStatus
+
+  test "if source has prior error do nothing" do
+    parameters = %{"sourceType" => "string", "targetType" => "integer"}
+
+    original = %ValidationStatus{}
+      |> ValidationStatus.add_error("sourceType", "something bad happened")
+
+    result = ValidTypeConversion.check(original, parameters, "sourceType", "targetType", "function_field")
+
+    assert result == original
+  end
+
+  test "if target has prior error do nothing" do
+    parameters = %{"sourceType" => "string", "targetType" => "integer"}
+
+    original = %ValidationStatus{}
+      |> ValidationStatus.add_error("targetType", "something bad happened")
+
+    result = ValidTypeConversion.check(original, parameters, "sourceType", "targetType", "function_field")
+
+    assert result == original
+  end
+
+  test "adds error to source and target if unsupported conversion" do
+    parameters = %{"sourceType" => "double", "targetType" => "float"}
+    result = %ValidationStatus{}
+      |> ValidTypeConversion.check(parameters, "sourceType", "targetType", "function_field")
+
+    expected_message = "Conversion from double to float is not supported"
+    assert result.errors == %{"sourceType" => expected_message, "targetType" => expected_message}
+  end
+
+  test "if conversion supported then add function to specified field" do
+    parameters = %{"origin" => "integer", "destination" => "float"}
+    result = %ValidationStatus{}
+      |> ValidTypeConversion.check(parameters, "origin", "destination", "thing_to_do")
+
+    {:ok, expected_function} = ConversionFunctions.pick("integer", "float")
+    assert ValidationStatus.get_value(result, "thing_to_do") == expected_function
+  end
+
+end

--- a/apps/transformers/test/unit/validations/valid_type_conversion_test.exs
+++ b/apps/transformers/test/unit/validations/valid_type_conversion_test.exs
@@ -8,10 +8,18 @@ defmodule Transformers.Validations.ValidTypeConversionTest do
   test "if source has prior error do nothing" do
     parameters = %{"sourceType" => "string", "targetType" => "integer"}
 
-    original = %ValidationStatus{}
+    original =
+      %ValidationStatus{}
       |> ValidationStatus.add_error("sourceType", "something bad happened")
 
-    result = ValidTypeConversion.check(original, parameters, "sourceType", "targetType", "function_field")
+    result =
+      ValidTypeConversion.check(
+        original,
+        parameters,
+        "sourceType",
+        "targetType",
+        "function_field"
+      )
 
     assert result == original
   end
@@ -19,17 +27,27 @@ defmodule Transformers.Validations.ValidTypeConversionTest do
   test "if target has prior error do nothing" do
     parameters = %{"sourceType" => "string", "targetType" => "integer"}
 
-    original = %ValidationStatus{}
+    original =
+      %ValidationStatus{}
       |> ValidationStatus.add_error("targetType", "something bad happened")
 
-    result = ValidTypeConversion.check(original, parameters, "sourceType", "targetType", "function_field")
+    result =
+      ValidTypeConversion.check(
+        original,
+        parameters,
+        "sourceType",
+        "targetType",
+        "function_field"
+      )
 
     assert result == original
   end
 
   test "adds error to source and target if unsupported conversion" do
     parameters = %{"sourceType" => "double", "targetType" => "float"}
-    result = %ValidationStatus{}
+
+    result =
+      %ValidationStatus{}
       |> ValidTypeConversion.check(parameters, "sourceType", "targetType", "function_field")
 
     expected_message = "Conversion from double to float is not supported"
@@ -38,11 +56,12 @@ defmodule Transformers.Validations.ValidTypeConversionTest do
 
   test "if conversion supported then add function to specified field" do
     parameters = %{"origin" => "integer", "destination" => "float"}
-    result = %ValidationStatus{}
+
+    result =
+      %ValidationStatus{}
       |> ValidTypeConversion.check(parameters, "origin", "destination", "thing_to_do")
 
     {:ok, expected_function} = ConversionFunctions.pick("integer", "float")
     assert ValidationStatus.get_value(result, "thing_to_do") == expected_function
   end
-
 end

--- a/apps/transformers/test/unit/validations/validation_status_test.exs
+++ b/apps/transformers/test/unit/validations/validation_status_test.exs
@@ -128,7 +128,8 @@ defmodule Transformers.Validations.ValidationStatusTest do
 
   describe("ordered_values_or_errors/2") do
     test "returns error map if any errors" do
-      {:error, result} = %ValidationStatus{}
+      {:error, result} =
+        %ValidationStatus{}
         |> ValidationStatus.add_error("alpha", "nonsense")
         |> ValidationStatus.ordered_values_or_errors(["alpha"])
 
@@ -136,7 +137,8 @@ defmodule Transformers.Validations.ValidationStatusTest do
     end
 
     test "returns values in specified order if no errors" do
-      {:ok, result} = %ValidationStatus{}
+      {:ok, result} =
+        %ValidationStatus{}
         |> ValidationStatus.update_value("three", "C")
         |> ValidationStatus.update_value("one", "A")
         |> ValidationStatus.update_value("four", "D")

--- a/apps/transformers/test/unit/validations/validation_status_test.exs
+++ b/apps/transformers/test/unit/validations/validation_status_test.exs
@@ -96,6 +96,22 @@ defmodule Transformers.Validations.ValidationStatusTest do
     end
   end
 
+  describe("has_error?/2") do
+    test "return true if field has associated error" do
+      field = "awesome"
+      error = "oh no!"
+      status = %ValidationStatus{errors: %{field => error}}
+
+      assert ValidationStatus.has_error?(status, field)
+    end
+
+    test "return false if no matching error" do
+      status = %ValidationStatus{}
+
+      refute ValidationStatus.get_error(status, "something")
+    end
+  end
+
   describe("any_errors?/1") do
     test "return true if any errors" do
       status = %ValidationStatus{errors: %{"bad" => "thing"}}

--- a/apps/transformers/test/unit/validations/validation_status_test.exs
+++ b/apps/transformers/test/unit/validations/validation_status_test.exs
@@ -126,4 +126,24 @@ defmodule Transformers.Validations.ValidationStatusTest do
     end
   end
 
+  describe("ordered_values_or_errors/2") do
+    test "returns error map if any errors" do
+      {:error, result} = %ValidationStatus{}
+        |> ValidationStatus.add_error("alpha", "nonsense")
+        |> ValidationStatus.ordered_values_or_errors(["alpha"])
+
+      assert result == %{"alpha" => "nonsense"}
+    end
+
+    test "returns values in specified order if no errors" do
+      {:ok, result} = %ValidationStatus{}
+        |> ValidationStatus.update_value("three", "C")
+        |> ValidationStatus.update_value("one", "A")
+        |> ValidationStatus.update_value("four", "D")
+        |> ValidationStatus.update_value("two", "B")
+        |> ValidationStatus.ordered_values_or_errors(["one", "two", "three", "four"])
+
+      assert result == ["A", "B", "C", "D"]
+    end
+  end
 end

--- a/apps/transformers/test/unit/validations/validation_status_test.exs
+++ b/apps/transformers/test/unit/validations/validation_status_test.exs
@@ -1,0 +1,113 @@
+defmodule Transformers.Validations.ValidationStatusTest do
+  use ExUnit.Case
+
+  alias Transformers.Validations.ValidationStatus
+
+  describe("struct") do
+    test "defaults to empty map of values" do
+      assert %ValidationStatus{}.values == %{}
+    end
+
+    test "defaults to empty map of errors" do
+      assert %ValidationStatus{}.errors == %{}
+    end
+  end
+
+  describe("update_value/3") do
+    test "adds value to provided status" do
+      status = %ValidationStatus{}
+      field = "some_key"
+      value = "some_value"
+
+      result = ValidationStatus.update_value(status, field, value)
+
+      assert result.values == %{field => value}
+    end
+
+    test "overwrites value if one already present" do
+      field = "some_key"
+      status = %ValidationStatus{values: %{field => "old_value"}}
+
+      result = ValidationStatus.update_value(status, field, "new_value")
+
+      assert result.values == %{"some_key" => "new_value"}
+    end
+  end
+
+  describe("update_error/3") do
+    test "adds error to provided status" do
+      status = %ValidationStatus{}
+      field = "some_key"
+      error = "something awful happened!"
+
+      result = ValidationStatus.add_error(status, field, error)
+
+      assert result.errors == %{field => error}
+    end
+
+    test "does not overwrite prior errors" do
+      field = "some_key"
+      original_error = "something awful happened!"
+      status = %ValidationStatus{errors: %{field => original_error}}
+
+      result = ValidationStatus.add_error(status, field, "another bad thing!")
+
+      assert result.errors == %{field => original_error}
+    end
+  end
+
+  describe("get_value/2") do
+    test "return value for field" do
+      field = "awesome"
+      value = "sauce"
+      status = %ValidationStatus{values: %{field => value}}
+
+      result = ValidationStatus.get_value(status, field)
+
+      assert result == value
+    end
+
+    test "return nil if no matching field" do
+      status = %ValidationStatus{}
+
+      result = ValidationStatus.get_value(status, "something")
+
+      assert result == nil
+    end
+  end
+
+  describe("error/2") do
+    test "return error for field" do
+      field = "awesome"
+      error = "oh no!"
+      status = %ValidationStatus{errors: %{field => error}}
+
+      result = ValidationStatus.get_error(status, field)
+
+      assert result == error
+    end
+
+    test "return nil if no matching error" do
+      status = %ValidationStatus{}
+
+      result = ValidationStatus.get_error(status, "something")
+
+      assert result == nil
+    end
+  end
+
+  describe("any_errors?/1") do
+    test "return true if any errors" do
+      status = %ValidationStatus{errors: %{"bad" => "thing"}}
+
+      assert ValidationStatus.any_errors?(status)
+    end
+
+    test "return false if no errors" do
+      status = %ValidationStatus{}
+
+      refute ValidationStatus.any_errors?(status)
+    end
+  end
+
+end


### PR DESCRIPTION
## [Ticket Link #750](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/750)

## Description

Andi now validates dynamically created fields for a transformation.

This required extensive changes to the transformers library in order to get all errors for a particular transformation, and to show errors individually by field. The validation function for each transformation now creates an accumulator object which updates with either the field values or errors, and returns either those errors as a map or an ordered list of values for use in the transform function.

Also added a test to alchemist to make sure incorrect transformations would dead letter appropriately.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
