### PR TITLE
Update runtime.exs

### DIFF
--- a/apps/andi/runtime.exs
+++ b/apps/andi/runtime.exs
@@ -87,7 +87,7 @@ config :andi, Andi.Repo,
 postgres_verify_sni = Regex.match?(~r/^true$/i, System.get_env("POSTGRES_VERIFY_SNI"))
 
 if postgres_verify_sni do
-  config :discovery_api, DiscoveryApi.Repo,
+  config :andi, Andi.Repo,
     ssl_opts: [
       verify: :verify_peer,
       server_name_indication: String.to_charlist(System.get_env("POSTGRES_HOST", "")),


### PR DESCRIPTION
This was a miss in the runtime.exs. Looks like this change was probably never working correctly.

## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- High level overview of changes
- ...

## Reminders:

- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
