### PR TITLE
Remove never cadence on ingestions because it doesn't make sense anymore

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
@@ -88,10 +88,6 @@ defmodule AndiWeb.IngestionLiveView.FinalizeForm do
                     <%= radio_button(f, :cadence, "once")%>
                   </div>
                   <div class="finalize-form__schedule-option">
-                  <%= label(f, :cadence, "Never", class: "finalize-form__schedule-option-label") %>
-                  <%= radio_button(f, :cadence, "never") %>
-                  </div>
-                  <div class="finalize-form__schedule-option">
                     <%= label(f, :cadence, "Repeat", class: "finalize-form__schedule-option-label") %>
                     <%= radio_button(f, :cadence, @crontab) %>
                   </div>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.3.6",
+      version: "2.3.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/finalize_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/finalize_form_test.exs
@@ -50,27 +50,6 @@ defmodule AndiWeb.IngestionLiveView.FinalizeFormTest do
     end
   end
 
-  describe "never ingestion" do
-    setup %{conn: conn} do
-      ingestion = create_ingestion_with_cadence("never")
-      assert {:ok, view, html} = live(conn, @url_path <> ingestion.id)
-
-      [
-        view: view,
-        html: html
-      ]
-    end
-
-    test "shows the Never ingestion button selected", %{html: html} do
-      refute Enum.empty?(get_attributes(html, "#form_data_cadence_never", "checked"))
-    end
-
-    test "does not show cron scheduler", %{html: html} do
-      assert Enum.empty?(find_elements(html, ".finalize-form__scheduler--visible"))
-      refute Enum.empty?(find_elements(html, ".finalize-form__scheduler--hidden"))
-    end
-  end
-
   describe "repeat ingestion" do
     setup %{conn: conn} do
       ingestion = create_ingestion_with_cadence("0 * * * * *")


### PR DESCRIPTION
## Description

In reviewing the user manual, it became apparent that the never option for ingestion cadence isn't relevant anymore. This is a quick fix to remove it from the UI.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
