### PR TITLE
Fix pattern matching order for create statements in pipeline

### DIFF
--- a/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
@@ -10,12 +10,8 @@ defmodule Pipeline.Writer.TableWriter.Statement do
     defexception message: "Encountered an unsupported field type"
   end
 
-  def create(%{table: name, as: select}) do
-    {:ok, "create table #{name} as (#{select})"}
-  end
-
-  def create(%{table: name, schema: schema, format: format, partitions: nil}) do
-    {:ok, Create.compose(name, schema, format)}
+  def create(%{table: name, schema: schema, format: format, partitions: partitions}) do
+    {:ok, Create.compose(name, schema, format, partitions)}
   rescue
     e in FieldTypeError ->
       {:error, e.message}
@@ -24,8 +20,8 @@ defmodule Pipeline.Writer.TableWriter.Statement do
       {:error, "Unable to parse schema: #{inspect(e)}"}
   end
 
-  def create(%{table: name, schema: schema, format: format, partitions: partitions}) do
-    {:ok, Create.compose(name, schema, format, partitions)}
+  def create(%{table: name, schema: schema, format: format}) do
+    {:ok, Create.compose(name, schema, format)}
   rescue
     e in FieldTypeError ->
       {:error, e.message}
@@ -42,6 +38,10 @@ defmodule Pipeline.Writer.TableWriter.Statement do
 
     e ->
       {:error, "Unable to parse schema: #{inspect(e)}"}
+  end
+
+  def create(%{table: name, as: select}) do
+    {:ok, "create table #{name} as (#{select})"}
   end
 
   def insert(config, content) do

--- a/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
+++ b/apps/pipeline/lib/pipeline/writer/table_writer/statement.ex
@@ -11,17 +11,13 @@ defmodule Pipeline.Writer.TableWriter.Statement do
   end
 
   def create(%{table: name, schema: schema, format: format, partitions: partitions}) do
-    {:ok, Create.compose(name, schema, format, partitions)}
-  rescue
-    e in FieldTypeError ->
-      {:error, e.message}
+    case partitions do
+      nil ->
+        {:ok, Create.compose(name, schema, format)}
 
-    e ->
-      {:error, "Unable to parse schema: #{inspect(e)}"}
-  end
-
-  def create(%{table: name, schema: schema, format: format}) do
-    {:ok, Create.compose(name, schema, format)}
+      _ ->
+        {:ok, Create.compose(name, schema, format, partitions)}
+    end
   rescue
     e in FieldTypeError ->
       {:error, e.message}

--- a/apps/pipeline/mix.exs
+++ b/apps/pipeline/mix.exs
@@ -4,7 +4,7 @@ defmodule Pipeline.MixProject do
   def project do
     [
       app: :pipeline,
-      version: "0.1.10",
+      version: "0.1.11",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## Description

Utilize Create.compose correctly based on statement.create parameters

- Corrects incorrect hydra order introduced in [792](https://github.com/UrbanOS-Public/smartcitiesdata/pull/1446/files#diff-feb0ad2c453b0c1ff1d7707f000b30a45099ed891279e63f5c2198533c9bfda9)

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
