### PR TITLE
Push to quay after publish so that there can be security scanning

### DIFF
--- a/.github/workflows/alchemist.yml
+++ b/.github/workflows/alchemist.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/andi.yml
+++ b/.github/workflows/andi.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/discovery_api.yml
+++ b/.github/workflows/discovery_api.yml
@@ -58,3 +58,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/discovery_streams.yml
+++ b/.github/workflows/discovery_streams.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/forklift.yml
+++ b/.github/workflows/forklift.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/raptor.yml
+++ b/.github/workflows/raptor.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/valkyrie.yml
+++ b/.github/workflows/valkyrie.yml
@@ -52,3 +52,10 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish to Quay
+        run: |
+          bash scripts/gh-action-quay.sh ${GITHUB_WORKFLOW} development
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/scripts/gh-action-quay.sh
+++ b/scripts/gh-action-quay.sh
@@ -1,0 +1,10 @@
+set -e
+
+app="${1}"
+version="${2}"
+
+echo "Logging into Quay..."
+echo "${QUAY_PASSWORD}" | docker login -u "${QUAY_USERNAME}" --password-stdin quay.io
+
+docker tag smartcitiesdata/$app:$version quay.io/urbanos/$app:$version
+docker push quay.io/urbanos/$app:$version


### PR DESCRIPTION
## Description

Automate pushing the development build to quay from the main branch after a publish is successful. New workflow variables have already been set in organization secrets.

## Reminders:

~- [ ] If changing elixir code in an "app", did you update the relevant version~
      ~in `mix.exs`?~
~- [ ] If altering an API endpoint, was the relevant postman collection updated?~
~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~
