### PR TITLE
Partition json by extraction time as well as existing ingestion_id

### DIFF
--- a/apps/e2e/mix.exs
+++ b/apps/e2e/mix.exs
@@ -4,7 +4,7 @@ defmodule E2E.MixProject do
   def project do
     [
       app: :e2e,
-      version: "0.1.12",
+      version: "0.1.13",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -170,8 +170,8 @@ defmodule E2ETest do
         %{
           "Column" => "_extraction_start_time",
           "Comment" => "",
-          "Extra" => "",
-          "Type" => "timestamp(3)"
+          "Extra" => "partition key",
+          "Type" => "bigint"
         },
         %{
           "Column" => "_ingestion_id",
@@ -275,7 +275,7 @@ defmodule E2ETest do
                    }
                  ] ==
                    query(
-                     "select one, two, three, _ingestion_id, os_partition, date_format(_extraction_start_time, '%Y_%m_%d') as _extraction_start_time from #{
+                     "select one, two, three, _ingestion_id, os_partition, date_format(from_unixtime(_extraction_start_time), '%Y_%m_%d') as _extraction_start_time from #{
                        table
                      }",
                      true
@@ -365,7 +365,7 @@ defmodule E2ETest do
                    "os_partition" => get_current_yyyy_mm,
                    "_extraction_start_time" => get_current_yyyy_mm_dd
                  } in query(
-                   "select one, two, three, _ingestion_id, os_partition, date_format(_extraction_start_time, '%Y_%m_%d') as _extraction_start_time from #{
+                   "select one, two, three, _ingestion_id, os_partition, date_format(from_unixtime(_extraction_start_time), '%Y_%m_%d') as _extraction_start_time from #{
                      table
                    }",
                    true

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -170,7 +170,7 @@ defmodule E2ETest do
         %{
           "Column" => "_extraction_start_time",
           "Comment" => "",
-          "Extra" => "partition key",
+          "Extra" => "",
           "Type" => "bigint"
         },
         %{

--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -48,7 +48,12 @@ defmodule Forklift.Event.EventHandler do
 
     Forklift.Datasets.update(dataset)
 
-    [table: dataset.technical.systemName, schema: dataset.technical.schema, partitions: ["_ingestion_id"]]
+    [
+      table: dataset.technical.systemName,
+      schema: dataset.technical.schema,
+      json_partitions: ["_extraction_start_time", "_ingestion_id"],
+      main_partitions: ["_ingestion_id"]
+    ]
     |> Forklift.DataWriter.init()
 
     :discard

--- a/apps/forklift/lib/forklift/jobs/data_migration.ex
+++ b/apps/forklift/lib/forklift/jobs/data_migration.ex
@@ -73,7 +73,7 @@ defmodule Forklift.Jobs.DataMigration do
   defp create_partitioned_table(table) do
     Logger.info("Table #{table} needs to be partitioned")
 
-    "create table #{table}__partitioned with (partitioned_by = ARRAY['os_partition'], format = 'ORC') as (select *, cast('pre_partitioned' as varchar) as os_partition from #{
+    "create table #{table}__partitioned with (partitioned_by = ARRAY['_ingestion_id', 'os_partition'], format = 'ORC') as (select *, cast('pre_partitioned' as varchar) as os_partition from #{
       table
     })"
     |> PrestigeHelper.execute_query()

--- a/apps/forklift/lib/forklift/message_handler.ex
+++ b/apps/forklift/lib/forklift/message_handler.ex
@@ -62,7 +62,7 @@ defmodule Forklift.MessageHandler do
   defp filter_end_of_data(msg, dataset) do
     case msg do
       end_of_data() ->
-        Forklift.DataWriter.write([msg], dataset: dataset, ingestion_id: nil)
+        Forklift.DataWriter.write([msg], dataset: dataset, ingestion_id: nil, extraction_start_time: nil)
         true
 
       _ ->

--- a/apps/forklift/lib/forklift/message_handler.ex
+++ b/apps/forklift/lib/forklift/message_handler.ex
@@ -28,9 +28,9 @@ defmodule Forklift.MessageHandler do
       |> Enum.map(&yeet_error/1)
       |> Enum.reject(&error_tuple?/1)
       |> Enum.reject(fn msg -> filter_end_of_data(msg, dataset) end)
-      |> Enum.group_by(fn msg -> Map.get(msg, :ingestion_id) end)
-      |> Enum.map(fn {ingestion_id, msgs} ->
-        Forklift.DataWriter.write(msgs, dataset: dataset, ingestion_id: ingestion_id)
+      |> group_by_each_extraction()
+      |> Enum.map(fn {%{ingestion_id: i, extraction_start_time: e}, msgs} ->
+        Forklift.DataWriter.write(msgs, dataset: dataset, ingestion_id: i, extraction_start_time: e)
       end)
       |> List.flatten()
 
@@ -79,4 +79,14 @@ defmodule Forklift.MessageHandler do
 
   defp error_tuple?({:error, _, _}), do: true
   defp error_tuple?(_), do: false
+
+  defp group_by_each_extraction(msgs) do
+    msgs
+    |> Enum.group_by(fn msg ->
+      i = Map.get(msg, :ingestion_id)
+      e = Map.get(msg, :extraction_start_time)
+      unix_e = e |> Timex.parse!("{ISO:Extended:Z}") |> Timex.to_unix()
+      %{:ingestion_id => i, :extraction_start_time => unix_e}
+    end)
+  end
 end

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.18.4",
+      version: "0.18.5",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/integration/forklift/jobs/data_migration_test.exs
+++ b/apps/forklift/test/integration/forklift/jobs/data_migration_test.exs
@@ -63,7 +63,7 @@ defmodule Forklift.Jobs.DataMigrationTest do
     eventually(fn -> assert table_exists?(dataset.technical.systemName <> "__json") end, 100, 1_000)
 
     {:ok, _} =
-      "insert into #{dataset.technical.systemName} values (1, 'Bob', cast(now() as date), 1.5, true, cast(now() as date), '1234-abc-zyx')"
+      "insert into #{dataset.technical.systemName} values (1, 'Bob', cast(now() as date), 1.5, true, 1662175490, '1234-abc-zyx')"
       |> PrestigeHelper.execute_query()
 
     expected_records = 10

--- a/apps/forklift/test/integration/test_helper.exs
+++ b/apps/forklift/test/integration/test_helper.exs
@@ -61,8 +61,7 @@ defmodule Helper do
       bucket: s3_writer_bucket(),
       table: dataset.technical.systemName,
       schema: DataWriter.add_ingestion_metadata_to_schema(dataset.technical.schema),
-      partition_key: "_ingestion_id",
-      partition_value: "1234-abcd"
+      partition_values: [_ingestion_id: "1234-abcd", _extraction_start_time: Timex.now() |> Timex.to_unix()]
     )
   end
 

--- a/apps/forklift/test/integration/test_helper.exs
+++ b/apps/forklift/test/integration/test_helper.exs
@@ -61,7 +61,9 @@ defmodule Helper do
       bucket: s3_writer_bucket(),
       table: dataset.technical.systemName,
       schema: DataWriter.add_ingestion_metadata_to_schema(dataset.technical.schema),
-      partition_values: [_ingestion_id: "1234-abcd", _extraction_start_time: Timex.now() |> Timex.to_unix()]
+      partition_values: [_extraction_start_time: Timex.now() |> Timex.to_unix(), _ingestion_id: "1234-abcd"],
+      json_partitions: ["_extraction_start_time", "_ingestion_id"],
+      main_partitions: ["_ingestion_id"]
     )
   end
 
@@ -71,9 +73,7 @@ defmodule Helper do
 
   defp insert_record(table, partition) do
     {:ok, _} =
-      "insert into #{table} values (1, 'Bob', cast(now() as date), 1.5, true, cast(now() as date), '1234-abc-zyx', '#{
-        partition
-      }')"
+      "insert into #{table} values (1, 'Bob', cast(now() as date), 1.5, true, 1662175490, '1234-abc-zyx', '#{partition}')"
       |> PrestigeHelper.execute_query()
   end
 

--- a/apps/forklift/test/unit/forklift/data_writer_test.exs
+++ b/apps/forklift/test/unit/forklift/data_writer_test.exs
@@ -50,7 +50,7 @@ defmodule Forklift.DataWriterTest do
       schema_with_ingestion_metadata =
         expected_dataset.technical.schema ++
           [
-            %{name: "_extraction_start_time", type: "timestamp", format: "{ISO:Extended:Z}"},
+            %{name: "_extraction_start_time", type: "long"},
             %{name: "_ingestion_id", type: "string"}
           ]
 
@@ -58,6 +58,10 @@ defmodule Forklift.DataWriterTest do
       :ok
     end)
 
-    DataWriter.write([fake_data], dataset: expected_dataset, ingestion_id: "1234-abcd")
+    DataWriter.write([fake_data],
+      dataset: expected_dataset,
+      ingestion_id: "1234-abcd",
+      extraction_start_time: "1662175490"
+    )
   end
 end

--- a/apps/forklift/test/unit/forklift/event/event_handling_test.exs
+++ b/apps/forklift/test/unit/forklift/event/event_handling_test.exs
@@ -31,7 +31,11 @@ defmodule Forklift.Event.EventHandlingTest do
       schema = dataset.technical.schema |> Forklift.DataWriter.add_ingestion_metadata_to_schema()
 
       Brook.Test.send(@instance_name, dataset_update(), :author, dataset)
-      assert_receive table: ^table_name, schema: ^schema, partitions: ["_ingestion_id"]
+
+      assert_receive table: ^table_name,
+                     schema: ^schema,
+                     json_partitions: ["_extraction_start_time", "_ingestion_id"],
+                     main_partitions: ["_ingestion_id"]
     end
 
     test "does not create table for non-ingestible dataset" do

--- a/apps/pipeline/mix.exs
+++ b/apps/pipeline/mix.exs
@@ -4,7 +4,7 @@ defmodule Pipeline.MixProject do
   def project do
     [
       app: :pipeline,
-      version: "0.1.11",
+      version: "0.1.12",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #792](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/792)

## Description

This is part 2 of 792, which partitions on extract start time, in addition to the already completed ingestion_id partition. 

Manually tested heavily in addition to written tests. Sets us up very well for 689.

- Store `_extraction_start_time` as unix timestamp, not datetime, so that it may be partitioned correctly.
- Specify unique partition values for `json` and `main` table
- Pattern match to ensure partition meta data sync is performed successfully

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
