### PR TITLE
fixing vuneravilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG app_name
 COPY . /app
 WORKDIR /app
 ENV NPM_CONFIG_UNSAFE_PERM true
-RUN apk update && \
+RUN apk upgrade && apk update && \
     apk --no-cache --update upgrade alpine-sdk && \
     apk --no-cache add alpine-sdk && \
     apk --no-cache --update add \

--- a/apps/alchemist/Dockerfile
+++ b/apps/alchemist/Dockerfile
@@ -7,7 +7,8 @@ ENV REPLACE_OS_VARS=true
 WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
   chown -R 1001:0 "${HOME}" && \
-  apk upgrade \
+  apk upgrade && \
+  apk update \
   && apk add --no-cache bash openssl \
   && rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/alchemist/ .

--- a/apps/andi/Dockerfile
+++ b/apps/andi/Dockerfile
@@ -15,6 +15,7 @@ ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
   chown -R 1001:0 "${HOME}" && \
   apk update && \
+  apk upgrade && \
   apk add --no-cache bash openssl && \
   rm -rf /var/cache/**/*
 COPY --from=builder ${CA_CERTFILE_PATH} ${CA_CERTFILE_PATH}

--- a/apps/discovery_api/Dockerfile
+++ b/apps/discovery_api/Dockerfile
@@ -8,8 +8,8 @@ ENV CA_CERTFILE_PATH /etc/ssl/certs/ca-certificates.crt
 WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
-    apk update && \
     apk upgrade && \
+    apk update && \
     apk add --no-cache bash zlib busybox ssl_client libssl1.1 openssl libcrypto1.1 && \
     rm -rf /var/cache/**/*
 COPY --from=builder ${CA_CERTFILE_PATH} ${CA_CERTFILE_PATH}

--- a/apps/discovery_streams/Dockerfile
+++ b/apps/discovery_streams/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
     apk upgrade && \
+    apk update && \
     apk add --no-cache bash openssl && \
     rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/discovery_streams/ .

--- a/apps/estuary/Dockerfile
+++ b/apps/estuary/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
     apk upgrade && \
+    apk update && \
     apk add --no-cache bash openssl && \
     rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/estuary/ .

--- a/apps/forklift/Dockerfile
+++ b/apps/forklift/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
     apk upgrade && \
+    apk update && \
     apk add --no-cache bash openssl && \
     rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/forklift/ .

--- a/apps/raptor/Dockerfile
+++ b/apps/raptor/Dockerfile
@@ -7,6 +7,7 @@ ENV REPLACE_OS_VARS=true
 WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
+    apk upgrade && \
     apk update && \
     apk add --no-cache bash openssl && \
     rm -rf /var/cache/**/*

--- a/apps/reaper/Dockerfile
+++ b/apps/reaper/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
     apk upgrade && \
+    apk update && \
     apk add --no-cache bash openssl && \
     rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/reaper/ .

--- a/apps/valkyrie/Dockerfile
+++ b/apps/valkyrie/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR ${HOME}
 RUN adduser -s /bin/sh -u 1001 -G root -h "${HOME}" -S -D default && \
     chown -R 1001:0 "${HOME}" && \
     apk upgrade && \
+    apk update && \
     apk add --no-cache bash openssl && \
     rm -rf /var/cache/**/*
 COPY --from=builder /app/_build/prod/rel/valkyrie/ .


### PR DESCRIPTION
## [Handle web-facing microservice scan results#710](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/710)

## Description
Change dockerfile for the followint projects to solve security issues:
* alchemist
* andi
* discovery_api
* discovery_streams
* estuary
* forklift
* raptor
* reaper
* valkyrie


## Reminders:

- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
