### PR TITLE
Forced platform type on hive and elasticsearch to make M1 chip happy

### DIFF
--- a/apps/e2e/test/docker-compose.yml
+++ b/apps/e2e/test/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - minio:/minio
     entrypoint: /workdir/setup.sh
   metastore:
+    platform: linux/amd64
     image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
     depends_on:
     - postgres
@@ -93,6 +94,7 @@ services:
       - "6379:6379"
 
   elasticsearch:
+    platform: linux/amd64
     image: elasticsearch:7.4.2
     ports:
     - "9200:9200"

--- a/scripts/gh-action-integration-test.sh
+++ b/scripts/gh-action-integration-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-DOCKER_COMPOSE_VERSION=1.23.1
+DOCKER_COMPOSE_VERSION=1.29.2
 
 app="$1"
 


### PR DESCRIPTION
## Description

- Added platform field in docker-compose of e2e test to force use of linux/amd64

## Reminders:

~~- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?~~
~~- [ ] If altering an API endpoint, was the relevant postman collection updated?~~
  ~~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
