### PR TITLE
514 division transformation

### DIFF
--- a/apps/transformers/lib/transformations/division.ex
+++ b/apps/transformers/lib/transformations/division.ex
@@ -16,7 +16,7 @@ defmodule Transformers.Division do
          {:ok, dividend} <- resolve_payload_field(payload, dividend),
          {:ok, divisor} <- resolve_divisor(payload, divisor),
          {:ok, quotient} <- {:ok, D.div(D.new(dividend), D.new(divisor))} do
-      {:ok, payload |> Map.put(target_field_name, quotient)}
+      {:ok, payload |> Map.put(target_field_name, D.to_float(quotient))}
     else
       {:error, reason} -> {:error, reason}
     end

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.6",
+      version: "1.0.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/transformations/division_test.exs
+++ b/apps/transformers/test/unit/transformations/division_test.exs
@@ -3,7 +3,6 @@ defmodule Transformers.DivisionTest do
   use Checkov
 
   alias Transformers.Division
-  alias Decimal, as: D
 
   describe "The division transform" do
     test "returns payload with target field equal to the quotient of a dividend and divisor" do
@@ -18,7 +17,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
-      assert actual_target_field == D.new(5)
+      assert actual_target_field == 5
     end
 
     test "returns payload with target field equal to the quotient of a single input dividend variable and divisor constant" do
@@ -33,7 +32,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
-      assert actual_target_field == D.new(4)
+      assert actual_target_field == 4
     end
 
     test "returns payload with target field with a specified target field name" do
@@ -48,7 +47,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "some_other_output_number")
-      assert actual_target_field == D.new(4)
+      assert actual_target_field == 4
     end
 
     test "returns payload with target field equal to the quotient of single input dividend constant and single divisor variables" do
@@ -63,7 +62,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
-      assert actual_target_field == D.new(4)
+      assert actual_target_field == 4
     end
 
     test "returns payload with a decimal in the target field equal to the quotient of dividend decimal constant and divisor decimal constant" do
@@ -78,7 +77,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
-      assert actual_target_field == D.new(4.1)
+      assert actual_target_field == 4.1
     end
 
     test "returns input fields along with output fields" do
@@ -93,7 +92,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
-      assert actual_target_field == D.new(14)
+      assert actual_target_field == 14
       {:ok, source_field1} = Map.fetch(transformed_payload, "input_number")
       assert source_field1 == 3
     end
@@ -110,7 +109,7 @@ defmodule Transformers.DivisionTest do
       {:ok, transformed_payload} = Division.transform(message_payload, params)
 
       {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
-      assert actual_target_field == D.new(3)
+      assert actual_target_field == 3
       {:ok, foo_field} = Map.fetch(transformed_payload, "foo")
       assert foo_field == 8
     end

--- a/apps/transformers/test/unit/transformations/multiplication_test.exs
+++ b/apps/transformers/test/unit/transformations/multiplication_test.exs
@@ -93,6 +93,20 @@ defmodule Transformers.MultiplicationTest do
       assert source_field2 == 6
     end
 
+    test "returns payload with target field a product of decimal values" do
+      params = %{
+        "multiplicands" => [12.5433, 2.33],
+        "targetField" => "output_number"
+      }
+
+      message_payload = %{}
+
+      {:ok, transformed_payload} = Transformers.Multiplication.transform(message_payload, params)
+
+      {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
+      assert actual_target_field == 29.225889
+    end
+
     test "returns an error if a field in the multiplicand doesnt exist" do
       params = %{
         "multiplicands" => ["some_other_input_number", "bar"],


### PR DESCRIPTION
## [Ticket Link #514](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/514)

## Description

- set division transformation to return a number instead of a string
- setup multiplication to align with division

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
