### PR TITLE
703 update andi for accessibility requirements

### DIFF
--- a/apps/andi/assets/css/app.scss
+++ b/apps/andi/assets/css/app.scss
@@ -35,171 +35,14 @@ body {
   right: 0;
 }
 
-.btn {
-  padding: 0.3rem 1.2rem;
-  display: inline-block;
-  text-decoration: none;
-  cursor: pointer;
-  background-color: black;
-  color: white;
-  border: none;
-
-  &:hover {
-    background-color: lighten(black, 20%);
-  }
-
-  &:active {
-    background-color: lighten(black, 40%);
-  }
-}
-
 .error-msg {
-  color: red;
+  color: $color-error;
   display: block; 
   margin: 5px 0 5px 0;
 }
 
-.btn--large {
-  padding: 0.6rem 1.7rem;
-  font-size: 20px;
-  min-width: 10rem;
-  border: 2px solid black;
-  background-color: white;
-  color: black;
-
-  &:hover {
-    background-color: lighten(#6C787F1A, 10%);
-  }
-
-  &:active {
-    background-color: lighten(#6C787F33, 20%);
-  }
-
-}
-
-.btn--cancel {
-    color: black;
-    background-color: white;
-    border: 0px;
-
-    &:hover {
-        color: black;
-        background-color: rgba(#6C787F, 10%);
-    }
-}
-
-.btn--review {
-    min-width: 10rem;
-    min-height: 2rem;
-    line-height: 2rem;
-    font-size: 1.2rem;
-    margin-right: 1rem;
-}
-
-.btn--action {
-  color: white;
-  background-color: $color-text-link;
-  border: 2px solid $color-text-link;
-  &:hover {
-    background-color: #1279D8;
-    border: 2px solid #1279D8;
-  }
-  &:disabled {
-      background-color: #7f7676;
-      border: 2px solid #7f7676;
-      cursor: default;
-  }
-}
-
-.btn--save {
-  color: $color-text-link;
-  background-color: white;
-  border: 2px solid $color-text-link;
-  :hover {
-    background: rgba($color-text-link, 10%);
-    border: 2px solid $color-text-link;
-  }
-
-}
-
-.btn--submit {
-  @extend .btn--save;
-  background-color: $color-text-link;
-  color: white;
-
-  &:disabled {
-    background-color: #a9d3e6;
-    border: 2px solid #a9d3e6;
-    cursor: default;
-
-    &:hover {
-      background-color: #a9d3e6;
-      border: 2px solid #a9d3e6;
-      color: white;
-      cursor: default;
-    }
-  }
-}
-
-.btn--next {
-  float: right;
-  margin-right: 0;
-  text-align: center;
-  min-width: 6.5rem;
-}
-
-.btn--back {
-    margin-right: 1rem;
-    text-align: center;
-    min-width: 6.5rem;
-}
-
-.btn--delete {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  color: black;
-  background-color: white;
-  border: 1px solid black;
-  
-  min-width: 10rem;
-  min-height: 2rem;
-  line-height: 2rem;
-  font-size: 1.2rem;
-
-  .delete-icon {
-    height: 1.65rem;
-    width: 1.5rem;
-    margin-right: .3em;
-    vertical-align: sub;
-  }
-
-  &:hover {
-    background-color: $color-error;
-    color: white;
-    border: 1px solid $color-error;
-  }
-}
-
-.btn--test {
-  font-size: 1rem;
-
-  &:disabled, &:disabled:hover {
-    background-color: $disabled-background;
-  }
-}
-
-.btn--submit:hover {
-  background: white;
-  color: $color-text-link;
-  border: 2px solid $color-text-link;
-}
-
-
-
 .label {
-  color: #7f7676;
+  color: #1D2528;
   display: block;
   margin-bottom: 0.3rem;
   letter-spacing: 0.03rem;
@@ -258,117 +101,20 @@ body {
     color: $disabled-background;
 }
 
-$primary-blue: #1170C8;
-$button-padding: 10px 50px;
-.btn--primary {
-  color: white;
-  background-color: $primary-blue;
-  border: none;
-  padding: $button-padding;
-  &:active {
-    background-color: #0F64B3;
-  }
-  &:hover {
-    background-color: #1279D8;
-    border: none;
-  }
-  &:disabled {
-      background-color: #AAD3F8;
-      border: none;
-      cursor: default;
-  }
-}
-
-.btn--primary-outline { 
-  background-color: white;
-  color: $primary-blue;
-  border: 1px solid $primary-blue;
-  padding: $button-padding;
-
-  &:active {
-    background-color: rgba($primary-blue, 20%);
-    //will the boader stay the same 
-  }
-  &:hover {
-    background-color:rgba($primary-blue, 10%);
-    border: 1px solid $primary-blue;
-  }
-  &:disabled {
-      background-color: rgba($primary-blue, 50%);
-      border: 1px solid $primary-blue;
-      cursor: default;
-  }
-}
-
-.btn--secondary{
-  //not seeing colors
-  background-color: white;
-  color: black;
-  border: 0px;
-  padding: $button-padding;
-  &:active {
-    background-color: rgba(#6C787F, 20%);
-    //will the boader stay the same 
-  }
-  &:hover {
-      color: black;
-      background-color: rgba(#6C787F, 10%);
-  }
-  &:disabled {
-    background-color: rgba(#6C787F, 50%);
-    cursor: default;
-}
-}
-
-.btn--danger {
-  background-color: white;
-  color: #DF1618;
-  border: 1px solid #DF1618;
-  padding: $button-padding;
-  .material-icons {
-    color:#DF1618;
-  }
-  &:active {
-    .material-icons {
-    color: white;
-    }
-    background-color: #B21212;
-    //will the boader stay the same 
-  }
-  &:hover {
-    .material-icons {
-    color: white;
-    }
-      color: white;
-      background-color:#CD1517;
-  }
-  &:disabled {
-    .material-icons {
-    color: white;
-    }
-    background-color: #FC7071;
-    cursor: default;
-  }
-}
-
-.btn--right {
-  margin-left: auto;
-}
-
-
-@import "./datasets.scss";
 @import "./access-groups.scss";
-@import "./edit.scss";
+@import "./button.scss";
 @import "./data_dictionary_form.scss";
-@import "./ingestions.scss";
-@import "./upload_data_dictionary.scss";
-@import "./metadata_form.scss";
-@import "./url_form.scss";
-@import "./finalize_form.scss";
-@import "./organizations.scss";
-@import "./users.scss";
+@import "./datasets.scss";
+@import "./edit.scss";
 @import "./extract_steps.scss";
-@import "./user.scss";
+@import "./finalize_form.scss";
+@import "./header.scss";
+@import "./ingestions.scss";
+@import "./metadata_form.scss";
+@import "./organizations.scss";
 @import "./search-modal.scss";
 @import "./transformations.scss";
-@import "./header.scss";
+@import "./upload_data_dictionary.scss";
+@import "./url_form.scss";
+@import "./user.scss";
+@import "./users.scss";

--- a/apps/andi/assets/css/button.scss
+++ b/apps/andi/assets/css/button.scss
@@ -269,3 +269,14 @@ $button-padding: 10px 50px;
 .btn--right {
     margin-left: auto;
 }
+
+.btn--transparent {
+    border: none;
+    background-color: transparent;
+    color: black;
+}
+
+.btn--transparent:hover {
+    background-color: transparent;
+    color: black;
+}

--- a/apps/andi/assets/css/button.scss
+++ b/apps/andi/assets/css/button.scss
@@ -1,0 +1,271 @@
+$button-padding: 10px 50px;
+
+.btn {
+    padding: 0.3rem 1.2rem;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    background-color: black;
+    color: white;
+    border: none;
+
+    &:hover {
+        background-color: lighten(black, 20%);
+    }
+
+    &:active {
+        background-color: lighten(black, 40%);
+    }
+}
+
+
+.btn--large {
+    padding: 0.6rem 1.7rem;
+    font-size: 20px;
+    min-width: 10rem;
+    border: 2px solid black;
+    background-color: white;
+    color: black;
+
+    &:hover {
+        background-color: lighten(#6C787F1A, 10%);
+    }
+
+    &:active {
+        background-color: lighten(#6C787F33, 20%);
+    }
+
+}
+
+.btn--cancel {
+    color: black;
+    background-color: white;
+    border: 0px;
+
+    &:hover {
+        color: black;
+        background-color: rgba(#6C787F, 10%);
+    }
+}
+
+.btn--review {
+    min-width: 10rem;
+    min-height: 2rem;
+    line-height: 2rem;
+    font-size: 1.2rem;
+    margin-right: 1rem;
+}
+
+.btn--action {
+    color: white;
+    background-color: $color-text-link;
+    border: 2px solid $color-text-link;
+
+    &:hover {
+        background-color: #1279D8;
+        border: 2px solid #1279D8;
+    }
+
+    &:disabled {
+        background-color: #7f7676;
+        border: 2px solid #7f7676;
+        cursor: default;
+    }
+}
+
+.btn--save {
+    color: $color-text-link;
+    background-color: white;
+    border: 2px solid $color-text-link;
+
+    :hover {
+        background: rgba($color-text-link, 10%);
+        border: 2px solid $color-text-link;
+    }
+
+}
+
+.btn--submit {
+    @extend .btn--save;
+    background-color: $color-text-link;
+    color: white;
+
+    &:disabled {
+        background-color: #a9d3e6;
+        border: 2px solid #a9d3e6;
+        cursor: default;
+
+        &:hover {
+            background-color: #a9d3e6;
+            border: 2px solid #a9d3e6;
+            color: white;
+            cursor: default;
+        }
+    }
+}
+
+.btn--next {
+    float: right;
+    margin-right: 0;
+    text-align: center;
+    min-width: 6.5rem;
+}
+
+.btn--back {
+    margin-right: 1rem;
+    text-align: center;
+    min-width: 6.5rem;
+}
+
+.btn--delete {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    color: black;
+    background-color: white;
+    border: 1px solid black;
+
+    min-width: 10rem;
+    min-height: 2rem;
+    line-height: 2rem;
+    font-size: 1.2rem;
+
+    .delete-icon {
+        height: 1.65rem;
+        width: 1.5rem;
+        margin-right: .3em;
+        vertical-align: sub;
+    }
+
+    &:hover {
+        background-color: $color-error;
+        color: white;
+        border: 1px solid $color-error;
+    }
+}
+
+.btn--test {
+    font-size: 1rem;
+
+    &:disabled,
+    &:disabled:hover {
+        background-color: $disabled-background;
+    }
+}
+
+.btn--submit:hover {
+    background: white;
+    color: $color-text-link;
+    border: 2px solid $color-text-link;
+}
+
+.btn--primary {
+    color: white;
+    background-color: $primary-blue;
+    border: none;
+    padding: $button-padding;
+
+    &:active {
+        background-color: #0F64B3;
+    }
+
+    &:hover {
+        background-color: #1279D8;
+        border: none;
+    }
+
+    &:disabled {
+        background-color: #AAD3F8;
+        border: none;
+        cursor: default;
+    }
+}
+
+.btn--primary-outline {
+    background-color: white;
+    color: $primary-blue;
+    border: 1px solid $primary-blue;
+    padding: $button-padding;
+
+    &:active {
+        background-color: rgba($primary-blue, 20%);
+        //will the boader stay the same 
+    }
+
+    &:hover {
+        background-color: rgba($primary-blue, 10%);
+        border: 1px solid $primary-blue;
+    }
+
+    &:disabled {
+        background-color: rgba($primary-blue, 50%);
+        border: 1px solid $primary-blue;
+        cursor: default;
+    }
+}
+
+.btn--secondary {
+    //not seeing colors
+    background-color: white;
+    color: black;
+    border: 0px;
+    padding: $button-padding;
+
+    &:active {
+        background-color: rgba(#6C787F, 20%);
+        //will the boader stay the same 
+    }
+
+    &:hover {
+        color: black;
+        background-color: rgba(#6C787F, 10%);
+    }
+
+    &:disabled {
+        background-color: rgba(#6C787F, 50%);
+        cursor: default;
+    }
+}
+
+.btn--danger {
+    background-color: white;
+    color: #DF1618;
+    border: 1px solid #DF1618;
+    padding: $button-padding;
+
+    .material-icons {
+        color: #DF1618;
+    }
+
+    &:active {
+        .material-icons {
+            color: white;
+        }
+
+        background-color: #B21212;
+        //will the boader stay the same 
+    }
+
+    &:hover {
+        .material-icons {
+            color: white;
+        }
+
+        color: white;
+        background-color:#CD1517;
+    }
+
+    &:disabled {
+        .material-icons {
+            color: white;
+        }
+
+        background-color: #FC7071;
+        cursor: default;
+    }
+}
+
+.btn--right {
+    margin-left: auto;
+}

--- a/apps/andi/assets/css/data_dictionary_form.scss
+++ b/apps/andi/assets/css/data_dictionary_form.scss
@@ -199,6 +199,8 @@ $tick-height: 1rem + $field-padding - 0.44;
       height: 24px;
       background-image: url('/static/images/delete_field.svg');
       cursor: pointer;
+      border: none;
+      background-color: transparent;
   }
 
   .data-dictionary-form__remove-field-button {

--- a/apps/andi/assets/css/datasets.scss
+++ b/apps/andi/assets/css/datasets.scss
@@ -1,3 +1,10 @@
+.edit-dataset-title {
+  display: inline-flex;
+  height: 3.5rem;
+  border-bottom: 1px solid $color-form-border;
+  margin-right: 2rem;
+}
+
 .datasets-view {
     flex: 1;
     background: $color-content-background;

--- a/apps/andi/assets/css/transformations.scss
+++ b/apps/andi/assets/css/transformations.scss
@@ -18,6 +18,8 @@
 
 .transformation-action {
   margin-left: 1rem;
+  border: none;
+  background-color: transparent;
   &:hover {
       cursor: pointer;
   }

--- a/apps/andi/assets/css/url_form.scss
+++ b/apps/andi/assets/css/url_form.scss
@@ -62,6 +62,8 @@
     cursor: pointer;
     max-width: 0;
     text-align: center;
+    border: none;
+    background-color: transparent;
 }
 
 .test-status {

--- a/apps/andi/assets/css/variables.scss
+++ b/apps/andi/assets/css/variables.scss
@@ -7,14 +7,14 @@ $disabled-background: #8a8a8a;
 $color-background: #f6f9ff;
 $color-content-background: white;
 
-$color-text-primary: black;
-$color-text-link: #1170C8;
+$color-text-primary: #1D2528;
+$color-text-link: #3344dd;
 
 $color-table-header: #cec9c9;
 $color-table-stripe: #f6f6f6;
 
 $color-success: green;
-$color-error: #CD1517;
+$color-error: #B80000;
 
 $table-border: 1px solid #d7d9db;
 $table-padding: 0.5em 1.5em;
@@ -22,6 +22,8 @@ $table-height: 2em;
 
 $box-shadow: 0 0 6px rgba(20, 20, 20, 0.2);
 
-$color-form-label: #7f7676;
+$color-form-label: #1D2528;
 $color-form-table-header: #ebedf0;
 $color-form-border: #C9C7C7;
+
+$primary-blue: #1170C8;

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -30,7 +30,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
 
         <div class="access-group-form__name">
           <%= label(form, :name, class: "label label--required") do "Access Group Name" end %>
-          <%= text_input(form, :name, class: "input") %>
+          <%= text_input(form, :name, [class: "input", required: true]) %>
         </div>
 
         <%= live_component(@socket, AndiWeb.AccessGroupLiveView.DatasetTable, selected_datasets: @selected_datasets) %>

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -19,7 +19,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_access_groups_path()) %>
     <div class="edit-page" id="access-groups-edit-page">
       <div class="edit-access-group-title">
-        <h2 class="component-title-text access-groups-component-title-text">Edit Access Group </h2>
+        <h1 class="component-title-text access-groups-component-title-text">Edit Access Group </h1>
       </div>
 
       <hr class="search-modal-divider">

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_add_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_add_field_editor.ex
@@ -29,7 +29,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__name form-block">
                 <div class="form-input">
                   <%= label(form, :name, "Name", class: "label label--required") %>
-                  <%= text_input(form, :name, id: id <> "_name", class: "input") %>
+                  <%= text_input(form, :name, [id: id <> "_name", class: "input", required: true]) %>
                 </div>
                 <%= error_tag(form, :name) %>
               </div>
@@ -37,7 +37,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__type form-block">
                 <div class="form-input">
                   <%= label(form, :type, "Type", class: "label label--required") %>
-                  <%= select(form, :type, get_item_types(), id: id <> "_type", class: "select") %>
+                  <%= select(form, :type, get_item_types(), [id: id <> "_type", class: "select", required: true]) %>
                 </div>
                 <%= error_tag(form, :type) %>
               </div>

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_field_editor.ex
@@ -31,7 +31,7 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
         <div class="data-dictionary-field-editor__selector">
-          <%= label(@form, :name, "Selector", class: "label label--required") %>
+          <%= label(@form, :selector, "Selector", class: "label label--required") %>
           <%= text_input(@form, :selector, [id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
         </div>

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_field_editor.ex
@@ -27,24 +27,24 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
 
         <div class="data-dictionary-field-editor__name">
           <%= label(@form, :name, "Name", class: "label label--required") %>
-          <%= text_input(@form, :name, id: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000") %>
+          <%= text_input(@form, :name, [id: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
         <div class="data-dictionary-field-editor__selector">
           <%= label(@form, :name, "Selector", class: "label label--required") %>
-          <%= text_input(@form, :selector, id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format)) %>
+          <%= text_input(@form, :selector, [id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
         </div>
         <div class="data-dictionary-field-editor__type">
           <%= label(@form, :type, "Type", class: "label label--required") %>
-          <%= select(@form, :type, DataDictionaryHelpers.get_item_types(), id: id <> "_type", class: "data-dictionary-field-editor__type select") %>
+          <%= select(@form, :type, DataDictionaryHelpers.get_item_types(), [id: id <> "_type", class: "data-dictionary-field-editor__type select", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :type) %>
         </div>
 
         <div class="data-dictionary-field-editor__type-info">
           <%= if field_type == "list" do %>
             <%= label(@form, :itemType, "Item Type", class: "label label--required") %>
-            <%= select(@form, :itemType, DataDictionaryHelpers.get_item_types(@form), id: id <> "_item_type", class: "data-dictionary-field-editor__item-type select") %>
+            <%= select(@form, :itemType, DataDictionaryHelpers.get_item_types(@form), [id: id <> "_item_type", class: "data-dictionary-field-editor__item-type select", required: true]) %>
             <%= ErrorHelpers.error_tag(form_with_errors, :itemType) %>
           <% end %>
 
@@ -53,7 +53,7 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
               <%= label(@form, :format, "Format", class: "label label--required") %>
               <a href="https://hexdocs.pm/timex/Timex.Format.DateTime.Formatters.Default.html" target="_blank">Help</a>
             </div>
-            <%= text_input(@form, :format, id: id <> "_format", class: "data-dictionary-field-editor__format input") %>
+            <%= text_input(@form, :format, [id: id <> "_format", class: "data-dictionary-field-editor__format input", required: true]) %>
             <%= ErrorHelpers.error_tag(form_with_errors, :format) %>
           <% end %>
         </div>

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_tree.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_tree.ex
@@ -125,9 +125,7 @@ defmodule AndiWeb.DataDictionary.Tree do
 
     ~E"""
       <div class="data-dictionary-tree__getting-started-help">
-        <span>Click the&nbsp;</span>
-        <span class="data-dictionary-form__add-field-button" phx-click="<%= @event_name %>"></span>
-        <span>&nbsp;button below to add a new field or <a phx-click="<%= @event_name %>">Click here...</a></span>
+        <span>Click the add button below to add a new field or <a phx-click="<%= @event_name %>">Click here...</a></span>
       </div>
     """
   end

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_tree.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_tree.ex
@@ -28,7 +28,16 @@ defmodule AndiWeb.DataDictionary.Tree do
           <% {icon_modifier, selected_modifier} = get_action(field, assigns) %>
 
           <div class="data-dictionary-tree-field data-dictionary-tree__field data-dictionary-tree__field--<%= icon_modifier %> data-dictionary-tree__field--<%= selected_modifier %>">
-          <div class="data-dictionary-tree-field__action" phx-click="<%= if is_set?(field, :subSchema), do: "toggle_expanded", else: "toggle_selected" %>" phx-value-field-id="<%= input_value(field, :id) %>" phx-value-index="<%= field.index %>" phx-value-name="<%= field.name %>" phx-value-id="<%= field.id %>" phx-target="#<%= @root_id %>"></div>
+          <%= checkbox(field, :selected_modifier,
+              [class: "data-dictionary-tree-field__action",
+              checked: selected_modifier == "selected",
+              "phx-click": if(is_set?(field, :subSchema), do: "toggle_expanded", else: "toggle_selected"),
+              "phx-value-field-id": input_value(field, :id),
+              "phx-value-index": field.index,
+              "phx-value-name": field.name,
+              "phx-value-id": field.id,
+              "phx-target": "##{@root_id}"]) %>
+
           <div class="data-dictionary-tree-field__text" phx-click="toggle_selected" phx-value-field-id="<%= input_value(field, :id) %>" phx-value-index="<%= field.index %>" phx-value-name="<%= field.name %>" phx-value-id="<%= field.id %>" phx-target="#<%= @root_id %>">
               <div class="data-dictionary-tree-field__name data-dictionary-tree-field-attribute"><%= input_value(field, :name) %></div>
               <div class="data-dictionary-tree-field__type data-dictionary-tree-field-attribute"><%= input_value(field, :type) %></div>
@@ -49,12 +58,14 @@ defmodule AndiWeb.DataDictionary.Tree do
   end
 
   def handle_event("toggle_expanded", %{"field-id" => field_id}, %{assigns: %{expansion_map: expansion_map}} = socket) do
+    IO.inspect "hello, world 1"
     updated_expansion_map = toggle_expansion(field_id, expansion_map)
 
     {:noreply, assign(socket, expansion_map: updated_expansion_map)}
   end
 
   def handle_event("toggle_selected", %{"field-id" => field_id, "index" => index, "name" => name, "id" => id}, socket) do
+    IO.inspect "hello, world 2"
     assign_current_dictionary_field(field_id, index, name, id)
     {:noreply, assign(socket, selected_field_id: field_id, new_field_initial_render: false)}
   end

--- a/apps/andi/lib/andi_web/live/edit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view.ex
@@ -17,6 +17,10 @@ defmodule AndiWeb.EditLiveView do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_datasets_path()) %>
     <div class="edit-page" id="dataset-edit-page">
+      <div class="edit-dataset-title">
+        <h1 class="component-title-text">Define Dataset</h1>
+      </div>
+
       <%= f = form_for @changeset, "" %>
         <% [business] = inputs_for(f, :business) %>
         <% [technical] = inputs_for(f, :technical) %>

--- a/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
@@ -117,7 +117,7 @@ defmodule AndiWeb.EditLiveView.DataDictionaryForm do
 
                 <div class="data-dictionary-form__tree-footer data-dictionary-form-tree-footer" >
                   <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
-                  <div class="data-dictionary-form__remove-field-button" phx-click="remove_data_dictionary_field"></div>
+                  <button id="remove-button" name="remove-button" class="data-dictionary-form__remove-field-button shadow-none" phx-click="remove_data_dictionary_field"></button>
                 </div>
               </div>
 

--- a/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
@@ -67,10 +67,12 @@ defmodule AndiWeb.EditLiveView.DataDictionaryForm do
         </div>
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %> ">Data Dictionary</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
@@ -116,7 +116,7 @@ defmodule AndiWeb.EditLiveView.DataDictionaryForm do
                 </div>
 
                 <div class="data-dictionary-form__tree-footer data-dictionary-form-tree-footer" >
-                  <div class="data-dictionary-form__add-field-button" phx-click="add_data_dictionary_field"></div>
+                  <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
                   <div class="data-dictionary-form__remove-field-button" phx-click="remove_data_dictionary_field"></div>
                 </div>
               </div>

--- a/apps/andi/lib/andi_web/live/edit_live_view/key_value_editor.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/key_value_editor.ex
@@ -34,17 +34,17 @@ defmodule AndiWeb.EditLiveView.KeyValueEditor do
             <%= text_input(f, :value, class: "input full-width url-form__#{@css_label}-value-input #{input_value(f, :id)}") %>
           </td>
           <td class="url-form-table__cell url-form-table__cell--delete">
-            <div class="url-form__<%= @css_label %>-delete-btn url-form-table__btn" phx-click="remove" phx-target=<%= event_handler_target %> phx-value-id="<%= input_value(f, :id) %>" phx-value-field="<%= @field %>">
+            <button type="button" class="url-form__<%= @css_label %>-add-btn url-form-table__btn" phx-click="remove" phx-target="<%= event_handler_target %>" phx-value-id="<%= input_value(f, :id) %>" phx-value-field="<%= @field %>">
               <img src="/images/remove.svg" alt="Remove"/>
-            </div>
+            </button>
           </td>
         </tr>
         <% end %>
       <% end %>
       </table>
-      <div class="url-form__<%= @css_label %>-add-btn url-form-table__btn" style="margin-top: 0.8em;" phx-click="add" phx-target="<%= event_handler_target %>" phx-value-field="<%= @field %>">
+      <button type="button" class="url-form__<%= @css_label %>-add-btn url-form-table__btn" phx-click="add" phx-target="<%= event_handler_target %>" phx-value-field="<%= @field %>">
         <img src="/images/add.svg" alt="Add"/>
-      </div>
+      </button>
       <%= error_tag(@form, @field, bind_to_input: false) %>
     </div>
     """

--- a/apps/andi/lib/andi_web/live/edit_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/metadata_form.ex
@@ -71,19 +71,19 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
             <div class="metadata-form-edit-section form-grid">
               <div class="metadata-form__title">
                 <%= label(f, :dataTitle, DisplayNames.get(:dataTitle), class: "label label--required") %>
-                <%= text_input(f, :dataTitle, class: "input", phx_value_field: "dataTitle", phx_blur: "validate_system_name", phx_debounce: "1000") %>
+                <%= text_input(f, :dataTitle, [class: "input", phx_value_field: "dataTitle", phx_blur: "validate_system_name", phx_debounce: "1000", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :dataTitle, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__data-name">
                 <%= label(f, :dataName, DisplayNames.get(:dataName), class: "label label--required") %>
-                <%= text_input(f, :dataName, [class: "input input--text", readonly: true]) %>
+                <%= text_input(f, :dataName, [class: "input input--text", readonly: true, required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :dataName, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__description">
                 <%= label(f, :description, DisplayNames.get(:description), class: "label label--required") %>
-                <%= textarea(f, :description, class: "input textarea") %>
+                <%= textarea(f, :description, [class: "input textarea", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :description, bind_to_input: false) %>
               </div>
 
@@ -95,13 +95,13 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
 
               <div class="metadata-form__maintainer-name">
                 <%= label(f, :contactName, DisplayNames.get(:contactName), class: "label label--required") %>
-                <%= text_input(f, :contactName, class: "input") %>
+                <%= text_input(f, :contactName, [class: "input", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :contactName, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__maintainer-email">
                 <%= label(f, :contactEmail, DisplayNames.get(:contactEmail), class: "label label--required") %>
-                <%= text_input(f, :contactEmail, class: "input") %>
+                <%= text_input(f, :contactEmail, [class: "input", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :contactEmail, bind_to_input: false) %>
               </div>
 
@@ -112,13 +112,13 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
 
               <div class="metadata-form__release-date">
                 <%= label(f, :issuedDate, DisplayNames.get(:issuedDate), class: "label label--required") %>
-                <%= date_input(f, :issuedDate, class: "input", value: MetadataFormHelpers.safe_calendar_value(input_value(f, :issuedDate))) %>
+                <%= date_input(f, :issuedDate, [class: "input", value: MetadataFormHelpers.safe_calendar_value(input_value(f, :issuedDate)), required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :issuedDate, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__update-frequency">
                 <%= label(f, :publishFrequency, DisplayNames.get(:publishFrequency), class: "label label--required") %>
-                <%= text_input(f, :publishFrequency, class: "input") %>
+                <%= text_input(f, :publishFrequency, [class: "input", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :publishFrequency, bind_to_input: false) %>
               </div>
 
@@ -130,7 +130,7 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
 
               <div class="metadata-form__risk-rating">
                 <%= label(f, :riskRating, DisplayNames.get(:riskRating), class: "label label--required") %>
-                <%= select(f, :riskRating, MetadataFormHelpers.get_rating_options(), class: "select", prompt: MetadataFormHelpers.rating_selection_prompt()) %>
+                <%= select(f, :riskRating, MetadataFormHelpers.get_rating_options(), [class: "select", prompt: MetadataFormHelpers.rating_selection_prompt(), required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :riskRating, bind_to_input: false) %>
               </div>
 
@@ -158,19 +158,19 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
 
               <div class="metadata-form__type">
                 <%= label(f, :sourceType, DisplayNames.get(:sourceType), class: "label label--required") %>
-                <%= select(f, :sourceType, MetadataFormHelpers.get_source_type_options(), [class: "select", disabled: @dataset_published?]) %>
+                <%= select(f, :sourceType, MetadataFormHelpers.get_source_type_options(), [class: "select", disabled: @dataset_published?, required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :sourceType, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__organization">
                 <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required") %>
-                <%= select(f, :orgId, MetadataFormHelpers.get_org_options(), [class: "select", disabled: @dataset_published?, selected: ""]) %>
+                <%= select(f, :orgId, MetadataFormHelpers.get_org_options(), [class: "select", disabled: @dataset_published?, selected: "", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :orgId, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__level-of-access">
                 <%= label(f, :private, DisplayNames.get(:private), class: "label label--required") %>
-                <%= select(f, :private, MetadataFormHelpers.get_level_of_access_options(), class: "select", selected: "") %>
+                <%= select(f, :private, MetadataFormHelpers.get_level_of_access_options(), [class: "select", selected: "", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :private, bind_to_input: false) %>
               </div>
 
@@ -189,7 +189,7 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
                   <%= label(f, :license, DisplayNames.get(:license), class: "label label--required") %>
                   <%= link("About Licenses", to: "https://creativecommons.org/licenses/", target: "_blank") %>
                 </div>
-                <%= text_input(f, :license, class: "input", value: MetadataFormHelpers.get_license(input_value(f, :license))) %>
+                <%= text_input(f, :license, [class: "input", value: MetadataFormHelpers.get_license(input_value(f, :license)), required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :license, bind_to_input: false) %>
                 <div>
                 </div>
@@ -197,7 +197,7 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
 
               <div class="metadata-form__benefit-rating">
                 <%= label(f, :benefitRating, DisplayNames.get(:benefitRating), class: "label label--required") %>
-                <%= select(f, :benefitRating, MetadataFormHelpers.get_rating_options(), class: "select", prompt: MetadataFormHelpers.rating_selection_prompt()) %>
+                <%= select(f, :benefitRating, MetadataFormHelpers.get_rating_options(), [class: "select", prompt: MetadataFormHelpers.rating_selection_prompt(), required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :benefitRating, bind_to_input: false) %>
               </div>
 

--- a/apps/andi/lib/andi_web/live/edit_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/metadata_form.ex
@@ -163,7 +163,7 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
               </div>
 
               <div class="metadata-form__organization">
-                <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required") %>
+                <%= label(f, :orgId, DisplayNames.get(:orgTitle), class: "label label--required") %>
                 <%= select(f, :orgId, MetadataFormHelpers.get_org_options(), [class: "select", disabled: @dataset_published?, selected: "", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :orgId, bind_to_input: false) %>
               </div>

--- a/apps/andi/lib/andi_web/live/edit_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/metadata_form.ex
@@ -50,10 +50,12 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
 
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %>">Enter Metadata</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/edit_organization_live_view.ex
@@ -34,19 +34,19 @@ defmodule AndiWeb.EditOrganizationLiveView do
         <div class="organization-form-edit-section form-grid">
           <div class="organization-form__title">
             <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required") %>
-            <%= text_input(f, :orgTitle, class: "input", phx_blur: "validate_unique_org_name") %>
+            <%= text_input(f, :orgTitle, [class: "input", phx_blur: "validate_unique_org_name", required: true]) %>
             <%= ErrorHelpers.error_tag(f, :orgTitle, bind_to_input: false) %>
           </div>
 
           <div class="organization-form__name">
             <%= label(f, :orgName, DisplayNames.get(:orgName), class: "label label--required") %>
-            <%= text_input(f, :orgName, [class: "input input--text", readonly: true]) %>
+            <%= text_input(f, :orgName, [class: "input input--text", readonly: true, required: true]) %>
             <%= ErrorHelpers.error_tag(f, :orgName, bind_to_input: false) %>
           </div>
 
           <div class="organization-form__description">
             <%= label(f, :description, DisplayNames.get(:description), class: "label label--required") %>
-            <%= textarea(f, :description, class: "input textarea") %>
+            <%= textarea(f, :description, class: "input textarea", required: true) %>
             <%= ErrorHelpers.error_tag(f, :description, bind_to_input: false) %>
           </div>
 

--- a/apps/andi/lib/andi_web/live/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/edit_organization_live_view.ex
@@ -21,7 +21,7 @@ defmodule AndiWeb.EditOrganizationLiveView do
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_organizations_path()) %>
     <div id="edit-organization-live-view" class="organization-edit-page edit-page">
       <div class="edit-organization-title">
-        <h2 class="component-title-text">Edit Organization </h2>
+        <h1 class="component-title-text">Edit Organization </h1>
       </div>
 
       <%= f = form_for @changeset, "#", [phx_change: :validate, as: :form_data] %>

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_auth_step_form.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_auth_step_form.ex
@@ -36,13 +36,13 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
 
             <div class="extract-auth-step-form__destination">
               <%= label(f, :destination, DisplayNames.get(:destination),  class: "label label--required") %>
-              <%= text_input(f, :destination, id: "step_#{@id}__auth_destination", class: "input") %>
+              <%= text_input(f, :destination, [id: "step_#{@id}__auth_destination", class: "input", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :destination, bind_to_input: false) %>
             </div>
 
             <div class="extract-auth-step-form__url">
               <%= label(f, :url, DisplayNames.get(:url), class: "label label--required") %>
-              <%= text_input(f, :url, id: "step_#{@id}__auth_url", class: "input full-width") %>
+              <%= text_input(f, :url, [id: "step_#{@id}__auth_url", class: "input full-width", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 
@@ -57,7 +57,7 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
             <div class="extract-auth-step-form__path">
               <%= label(f, :path, DisplayNames.get(:path),  class: "label label--required") %>
               <% form_path = input_value(f, :path) %>
-              <%= text_input(f, :path, id: "step_#{@id}__auth_path", class: "input", value: path_to_string(form_path)) %>
+              <%= text_input(f, :path, [id: "step_#{@id}__auth_path", class: "input", value: path_to_string(form_path), required: true]) %>
               <span class="input__help-text">Separate response path keys with a period (.) (e.g. 'data.token' for response {"data": {"token": "abc123"}}) </span>
               <%= ErrorHelpers.error_tag(f, :path, bind_to_input: false) %>
             </div>
@@ -65,7 +65,7 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
             <div class="extract-auth-step-form__cacheTtl">
               <%= label(f, :cacheTtl, DisplayNames.get(:cacheTtl),  class: "label label--required") %>
               <% form_ttl = input_value(f, :cacheTtl) %>
-              <%= text_input(f, :cacheTtl, id: "step_#{@id}__auth_cache_ttl", class: "input", value: milliseconds_to_minutes(form_ttl)) %>
+              <%= text_input(f, :cacheTtl, [id: "step_#{@id}__auth_cache_ttl", class: "input", value: milliseconds_to_minutes(form_ttl), required: true]) %>
               <span class="input__help-text">Time in minutes that credentials are stored (defaults to 15 minutes)</span>
               <%= ErrorHelpers.error_tag(f, :cacheTtl, bind_to_input: false) %>
             </div>

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_auth_step_form.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_auth_step_form.ex
@@ -46,13 +46,13 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 
+            <%= live_component(@socket, KeyValueEditor, id: "step_#{@id}__key_value_editor_headers" <> @extract_step.id, css_label: "source-headers", form: f, field: :headers, target: "step-" <> @id) %>
+
             <div class="extract-auth-step-form__body">
               <%= label(f, :body, DisplayNames.get(:body),  class: "label") %>
               <%= textarea(f, :body, id: "step_#{@id}__auth_url", class: "input full-width", phx_hook: "prettify") %>
               <%= ErrorHelpers.error_tag(f, :body, bind_to_input: false) %>
             </div>
-
-            <%= live_component(@socket, KeyValueEditor, id: "step_#{@id}__key_value_editor_headers" <> @extract_step.id, css_label: "source-headers", form: f, field: :headers, target: "step-" <> @id) %>
 
             <div class="extract-auth-step-form__path">
               <%= label(f, :path, DisplayNames.get(:path),  class: "label label--required") %>

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_date_step_form.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_date_step_form.ex
@@ -34,7 +34,7 @@ defmodule AndiWeb.ExtractSteps.ExtractDateStepForm do
             <div class="extract-date-step-form-edit-section form-grid">
               <div class="extract-date-step-form__destination">
                 <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required") %>
-                <%= text_input(f, :destination, id: "step-#{@id}__date-destination", class: "extract-date-step-form__destination input", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
+                <%= text_input(f, :destination, [id: "step-#{@id}__date-destination", class: "extract-date-step-form__destination input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :destination) %>
               </div>
 
@@ -55,7 +55,7 @@ defmodule AndiWeb.ExtractSteps.ExtractDateStepForm do
                   <%= label(f, :format, "Format", class: "label label--required") %>
                   <a href="https://hexdocs.pm/timex/Timex.Format.DateTime.Formatters.Default.html" target="_blank">Help</a>
                 </div>
-                <%= text_input(f, :format, id: "step_#{@id}__date_format", class: "extract-date-step-form__format input", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
+                <%= text_input(f, :format, [id: "step_#{@id}__date_format", class: "extract-date-step-form__format input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :format) %>
               </div>
 

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_http_step_form.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_http_step_form.ex
@@ -43,13 +43,13 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
 
                 <div class="extract-http-step-form__method">
                   <%= label(f, :action, DisplayNames.get(:method), class: "label label--required") %>
-                  <%= select(f, :action, get_http_methods(), id: "step_#{@id}__http_method", class: "extract-http-step-form__method select") %>
+                  <%= select(f, :action, get_http_methods(), [id: "step_#{@id}__http_method", class: "extract-http-step-form__method select", required: true]) %>
                   <%= ErrorHelpers.error_tag(f, :action) %>
                 </div>
 
                 <div class="extract-http-step-form__url">
                   <%= label(f, :url, DisplayNames.get(:url), class: "label label--required") %>
-                  <%= text_input(f, :url, id: "step_#{@id}__url", class: "input full-width", disabled: @testing) %>
+                  <%= text_input(f, :url, [id: "step_#{@id}__url", class: "input full-width", disabled: @testing, required: true]) %>
                   <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
                 </div>
 

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_s3_step_form.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_s3_step_form.ex
@@ -34,7 +34,7 @@ defmodule AndiWeb.ExtractSteps.ExtractS3StepForm do
 
             <div class="extract-s3-step-form__url">
               <%= label(f, :url, DisplayNames.get(:url), class: "label label--required") %>
-              <%= text_input(f, :url, id: "step_#{@id}__s3_url", class: "input full-width") %>
+              <%= text_input(f, :url, [id: "step_#{@id}__s3_url", class: "input full-width", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_secret_step_form.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_secret_step_form.ex
@@ -37,14 +37,14 @@ defmodule AndiWeb.ExtractSteps.ExtractSecretStepForm do
 
               <div class="extract-secret-step-form__destination">
                 <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required") %>
-                <%= text_input(f, :destination, id: "step_#{@id}__secret_destination", class: "extract-secret-step-form__destination input", phx_target: "#step-#{@id}") %>
+                <%= text_input(f, :destination, [id: "step_#{@id}__secret_destination", class: "extract-secret-step-form__destination input", phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :destination) %>
               </div>
 
               <div class="extract-secret-step-form__value">
                 <%= label(f, :secret_value, DisplayNames.get(:secret_value), class: "label label--required") %>
                 <div class="secret_value_add">
-                  <%= text_input(f, :secret_value, id: "step_#{@id}__secret_destination", type: "password", class: "extract-secret-step-form__secret-value input", phx_target: "#step-#{@id}", placeholder: "Secrets are not displayed after being saved") %>
+                  <%= text_input(f, :secret_value, [id: "step_#{@id}__secret_destination", type: "password", class: "extract-secret-step-form__secret-value input", phx_target: "#step-#{@id}", placeholder: "Secrets are not displayed after being saved", required: true]) %>
                   <% secret_value = FormData.input_value(nil, f, :secret_value) %>
                   <button type="button" class="btn btn--action" phx-click="save_secret" <%= disable_add_button(@changeset, secret_value) %> phx-target='<%="#step-#{@id}"%>' phx-value-secret="<%= secret_value %>">Add</button>
                   <span class="secret__status-msg <%= save_success_class(@save_success) %>"><%= @save_secret_message %></span>

--- a/apps/andi/lib/andi_web/live/extract_steps/extract_step_header.ex
+++ b/apps/andi/lib/andi_web/live/extract_steps/extract_step_header.ex
@@ -9,9 +9,9 @@ defmodule AndiWeb.ExtractSteps.ExtractStepHeader do
     <div class="extract-step-header full-width">
       <h3><%= @step_name %></h3>
       <div class="edit-buttons">
-        <span class="extract-step-header__up material-icons" phx-click="move-extract-step" phx-value-id=<%= @step_id %> phx-value-move-index="-1">keyboard_arrow_up</span>
-        <span class="extract-step-header__down material-icons" phx-click="move-extract-step" phx-value-id=<%= @step_id %> phx-value-move-index="1">keyboard_arrow_down</span>
-        <div class="extract-step-header__remove" phx-click="remove-extract-step" phx-value-id=<%= @step_id %>></div>
+        <button type="button" class="btn btn--right btn--transparent extract-step-header__up material-icons" style="padding: 0" phx-click="move-extract-step" phx-value-id="<%= @step_id %>" phx-value-move-index="-1">keyboard_arrow_up</button>
+        <button type="button" class="btn btn--right btn--transparent extract-step-header__down material-icons" style="padding: 0" phx-click="move-extract-step" phx-value-id="<%= @step_id %>" phx-value-move-index="1">keyboard_arrow_down</button>
+        <button type="button" class="btn btn--right btn--transparent extract-step-header__remove" style="padding: 0" phx-click="remove-extract-step" phx-value-id="<%= @step_id %>"></button>
       </div>
     </div>
     """

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
@@ -111,7 +111,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
                 </div>
 
                 <div class="data-dictionary-form__tree-footer data-dictionary-form-tree-footer" >
-                  <div class="data-dictionary-form__add-field-button" phx-click="add_data_dictionary_field"></div>
+                <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
                   <div class="data-dictionary-form__remove-field-button" phx-click="remove_data_dictionary_field"></div>
                 </div>
               </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
@@ -66,10 +66,12 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
         </div>
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %> ">Ingestion Schema</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 
@@ -111,8 +113,8 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
                 </div>
 
                 <div class="data-dictionary-form__tree-footer data-dictionary-form-tree-footer" >
-                <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
-                  <div class="data-dictionary-form__remove-field-button" phx-click="remove_data_dictionary_field"></div>
+                  <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
+                  <button id="remove-button" name="remove-button" class="data-dictionary-form__remove-field-button shadow-none" phx-click="remove_data_dictionary_field"></button>
                 </div>
               </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -21,7 +21,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
       <%= f = form_for @changeset, "" %>
         <%= hidden_input(f, :sourceFormat) %>
         <div class="edit-ingestion-title">
-          <h2 class="component-title-text">Define Data Ingestion</h2>
+          <h1 class="component-title-text">Define Data Ingestion</h1>
         </div>
 
         <div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_step_form.ex
@@ -57,10 +57,12 @@ defmodule AndiWeb.IngestionLiveView.ExtractSteps.ExtractStepForm do
         </div>
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %> ">Configure Ingest Steps</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
@@ -68,10 +68,12 @@ defmodule AndiWeb.IngestionLiveView.FinalizeForm do
         </div>
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %> ">Finalize</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
@@ -40,11 +40,11 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
         <%= ErrorHelpers.error_tag(f, :sourceFormat, bind_to_input: false) %>
       </div>
       <div class="ingestion-metadata-form ingestion-metadata-form__target-dataset">
-        <%= label(f, :targetDataset, "Dataset Name", class: "label label--required") %>
-        <%= hidden_input(f, :targetDataset, value: @selected_dataset) %>
+        <%= label(f, :targetDatasetName, "Dataset Name", class: "label label--required") %>
+        <%= hidden_input(f, :targetDatasetName, value: @selected_dataset) %>
         <%= text_input(f, :targetDatasetName, [class: "input ingestion-form-fields", value: get_dataset_name(@selected_dataset), disabled: true, required: true]) %>
         <button class="btn btn--select-dataset-search btn--primary-outline" phx-click="select-dataset" type="button">Select Dataset</button>
-        <%= ErrorHelpers.error_tag(f, :targetDataset, bind_to_input: false) %>
+        <%= ErrorHelpers.error_tag(f, :targetDatasetName, bind_to_input: false) %>
       </div>
 
     </form>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
@@ -31,18 +31,18 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
     <%= f = form_for @changeset, "#", [ as: :form_data, phx_change: :validate, id: :ingestion_metadata_form] %>
       <div class="ingestion-metadata-form ingestion-metadata-form__name">
         <%= label(f, :name, "Name", class: "label label--required") %>
-        <%= text_input(f, :name, class: "ingestion-name input ingestion-form-fields", phx_debounce: "1000") %>
+        <%= text_input(f, :name, [class: "ingestion-name input ingestion-form-fields", phx_debounce: "1000", required: true]) %>
         <%= ErrorHelpers.error_tag(f, :name, bind_to_input: false) %>
       </div>
       <div class="ingestion-metadata-form ingestion-metadata-form__format">
         <%= label(f, :sourceFormat, "Source Format", class: "label label--required") %>
-        <%= select(f, :sourceFormat, MetadataFormHelpers.get_source_format_options(), [class: "select ingestion-form-fields"]) %>
+        <%= select(f, :sourceFormat, MetadataFormHelpers.get_source_format_options(), [class: "select ingestion-form-fields", required: true]) %>
         <%= ErrorHelpers.error_tag(f, :sourceFormat, bind_to_input: false) %>
       </div>
       <div class="ingestion-metadata-form ingestion-metadata-form__target-dataset">
         <%= label(f, :targetDataset, "Dataset Name", class: "label label--required") %>
         <%= hidden_input(f, :targetDataset, value: @selected_dataset) %>
-        <%= text_input(f, :targetDatasetName, class: "input ingestion-form-fields", value: get_dataset_name(@selected_dataset), disabled: true) %>
+        <%= text_input(f, :targetDatasetName, [class: "input ingestion-form-fields", value: get_dataset_name(@selected_dataset), disabled: true, required: true]) %>
         <button class="btn btn--select-dataset-search btn--primary-outline" phx-click="select-dataset" type="button">Select Dataset</button>
         <%= ErrorHelpers.error_tag(f, :targetDataset, bind_to_input: false) %>
       </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/select_dataset_modal.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/select_dataset_modal.ex
@@ -53,7 +53,9 @@ defmodule AndiWeb.IngestionLiveView.SelectDatasetModal do
                     <td class="search-table__cell search-table__cell--break search-table__data-title-cell wide-column"><%= dataset.business.dataTitle %></td>
                     <td class="search-table__cell search-table__cell--break wide-column"><%= dataset.business.orgTitle %></td>
                     <td class="search-table__cell search-table__cell--break wide-column"><%= Enum.join(dataset.business.keywords, ", ") %></td>
-                    <td class="search-table__cell search-table__cell--break modal-action-text thin-column" phx-click="select-dataset-search" phx-value-id=<%= dataset.id %>><%=selected_value(dataset.id, @selected_dataset)%></td>
+                    <td class="search-table__cell search-table__cell--break modal-action-text thin-column">
+                      <a href="javascript:void(0)" phx-click="select-dataset-search" phx-value-id=<%= dataset.id %>><%=selected_value(dataset.id, @selected_dataset)%></a>
+                    </td>
                   </tr>
                 <% end %>
               <% end %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
@@ -11,7 +11,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
     ~L"""
     <div class="transformation-field">
       <%= label(form, name, field.field_label, class: "transformation-field-label label label--required") %>
-      <%= text_input(form, name, value: value, class: "input transformation-form-fields", phx_debounce: "1000") %>
+      <%= text_input(form, name, [value: value, class: "input transformation-form-fields", phx_debounce: "1000", required: true]) %>
       <%= ErrorHelpers.error_tag_with_label(form.source, name, field.field_label, bind_to_input: false) %>
     </div>
     """

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -45,13 +45,13 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
         <div class="transformation-form transformation-edit-form--<%= @visibility %>">
           <div class="transformation-form__name">
             <%= label(f, :name, "Name", class: "label label--required") %>
-            <%= text_input(f, :name, class: "transformation-name input transformation-form-fields", phx_debounce: "1000") %>
+            <%= text_input(f, :name, [class: "transformation-name input transformation-form-fields", phx_debounce: "1000", required: true]) %>
             <%= ErrorHelpers.error_tag(f.source, :name, bind_to_input: false) %>
           </div>
 
           <div class="transformation-form__type">
             <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required") %>
-            <%= select(f, :type, get_transformation_types(), phx_click: "transformation-type-selected", class: "select") %>
+            <%= select(f, :type, get_transformation_types(), [phx_click: "transformation-type-selected", class: "select", required: true]) %>
             <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
           </div>
           <div class="transformation-form__fields">

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -35,10 +35,10 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
         <div class="transformation-header full-width" phx-click="toggle-component-visibility" phx-value-component="transformations_form">
           <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
           <div class="transformation-actions">
-            <div class="material-icons-outlined transformation-action delete-transformation-button delete-<%= @transformation_changeset.changes.id %>" phx-click="delete-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-target="#transformations-form">delete</div>
-            <div class="material-icons-outlined transformation-action">edit</div>
-            <div class="material-icons transformation-action move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1">arrow_upward</div>
-            <div class="material-icons transformation-action move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1">arrow_downward</div>
+            <button class="material-icons-outlined transformation-action delete-transformation-button delete-<%= @transformation_changeset.changes.id %>" phx-click="delete-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-target="#transformations-form">delete</button>
+            <button class="material-icons-outlined transformation-action" type="button">edit</button>
+            <button class="material-icons transformation-action move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1">arrow_upward</button>
+            <button class="material-icons transformation-action move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1">arrow_downward</button>
           </div>
         </div>
         <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
@@ -47,10 +47,12 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStep do
         </div>
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %> ">Transformations</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/submit_live_view/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view/data_dictionary_field_editor.ex
@@ -26,24 +26,24 @@ defmodule AndiWeb.SubmitLiveView.DataDictionaryFieldEditor do
 
         <div class="data-dictionary-field-editor__name">
           <%= label(@form, :name, "Name", class: "label label--required") %>
-          <%= text_input(@form, :name, id: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000") %>
+          <%= text_input(@form, :name, [id: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
         <div class="data-dictionary-field-editor__selector">
           <%= label(@form, :name, "Selector", class: "label label--required") %>
-          <%= text_input(@form, :selector, id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format)) %>
+          <%= text_input(@form, :selector, [id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
         </div>
         <div class="data-dictionary-field-editor__type">
           <%= label(@form, :type, "Type", class: "label label--required") %>
-          <%= select(@form, :type, DataDictionaryHelpers.get_item_types(), id: id <> "_type", class: "data-dictionary-field-editor__type select") %>
+          <%= select(@form, :type, DataDictionaryHelpers.get_item_types(), [id: id <> "_type", class: "data-dictionary-field-editor__type select", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :type) %>
         </div>
 
       <div class="data-dictionary-field-editor__type-info">
         <%= if field_type == "list" do %>
           <%= label(@form, :itemType, "Item Type", class: "label label--required") %>
-          <%= select(@form, :itemType, DataDictionaryHelpers.get_item_types(@form), id: id <> "_item_type", class: "data-dictionary-field-editor__item-type select") %>
+          <%= select(@form, :itemType, DataDictionaryHelpers.get_item_types(@form), [id: id <> "_item_type", class: "data-dictionary-field-editor__item-type select", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :itemType) %>
         <% end %>
 
@@ -52,7 +52,7 @@ defmodule AndiWeb.SubmitLiveView.DataDictionaryFieldEditor do
             <%= label(@form, :format, "Format", class: "label label--required") %>
             <a href="https://hexdocs.pm/timex/Timex.Format.DateTime.Formatters.Default.html" target="_blank">Help</a>
           </div>
-          <%= text_input(@form, :format, id: id <> "_format", class: "data-dictionary-field-editor__format input") %>
+          <%= text_input(@form, :format, [id: id <> "_format", class: "data-dictionary-field-editor__format input", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :format) %>
         <% end %>
       </div>

--- a/apps/andi/lib/andi_web/live/submit_live_view/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view/data_dictionary_field_editor.ex
@@ -30,7 +30,7 @@ defmodule AndiWeb.SubmitLiveView.DataDictionaryFieldEditor do
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
         <div class="data-dictionary-field-editor__selector">
-          <%= label(@form, :name, "Selector", class: "label label--required") %>
+          <%= label(@form, :selector, "Selector", class: "label label--required") %>
           <%= text_input(@form, :selector, [id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
         </div>

--- a/apps/andi/lib/andi_web/live/submit_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view/metadata_form.ex
@@ -50,10 +50,12 @@ defmodule AndiWeb.SubmitLiveView.MetadataForm do
 
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %>">Enter Metadata</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/submit_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view/metadata_form.ex
@@ -68,31 +68,31 @@ defmodule AndiWeb.SubmitLiveView.MetadataForm do
             <div class="submission-metadata-form-edit-section form-grid">
               <div class="metadata-form__title">
                 <%= label(f, :dataTitle, DisplayNames.get(:dataTitle), class: "label label--required") %>
-                <%= text_input(f, :dataTitle, class: "input", phx_value_field: "dataTitle", phx_debounce: "1000") %>
+                <%= text_input(f, :dataTitle, [class: "input", phx_value_field: "dataTitle", phx_debounce: "1000", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :dataTitle, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__description">
                 <%= label(f, :description, DisplayNames.get(:description), class: "label label--required") %>
-                <%= textarea(f, :description, class: "input textarea") %>
+                <%= textarea(f, :description, [class: "input textarea", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :description, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__format">
                 <%= label(f, :sourceFormat, DisplayNames.get(:sourceFormat), class: "label label--required") %>
-                <%= select(f, :sourceFormat, MetadataFormHelpers.get_source_format_options(input_value(f, :sourceType)), [class: "select", disabled: @dataset_published?]) %>
+                <%= select(f, :sourceFormat, MetadataFormHelpers.get_source_format_options(input_value(f, :sourceType)), [class: "select", disabled: @dataset_published?, required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :sourceFormat, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__maintainer-name">
                 <%= label(f, :contactName, DisplayNames.get(:contactName), class: "label label--required") %>
-                <%= text_input(f, :contactName, class: "input") %>
+                <%= text_input(f, :contactName, class: "input", required: true) %>
                 <%= ErrorHelpers.error_tag(f, :contactName, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__keywords">
                 <%= label(f, :keywords, DisplayNames.get(:keywords), class: "label") %>
-                <%= text_input(f, :keywords, value: MetadataFormHelpers.keywords_to_string(input_value(f, :keywords)), class: "input") %>
+                <%= text_input(f, :keywords, [value: MetadataFormHelpers.keywords_to_string(input_value(f, :keywords)), class: "input", required: true]) %>
                 <div class="label label--inline">Separated by comma</div>
               </div>
 

--- a/apps/andi/lib/andi_web/live/submit_live_view/upload_data_dictionary.ex
+++ b/apps/andi/lib/andi_web/live/submit_live_view/upload_data_dictionary.ex
@@ -57,10 +57,12 @@ defmodule AndiWeb.SubmitLiveView.UploadDataDictionary do
 
         <div class="component-title full-width">
           <h2 class="component-title-text component-title-text--<%= @visibility %>">Upload Dataset Sample</h2>
-          <div class="component-title-action">
-            <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
-            <div class="component-title-icon--<%= @visibility %>"></div>
-          </div>
+          <button type="button" class="btn btn--right btn--transparent">
+            <div class="component-title-action">
+              <div class="component-title-action-text--<%= @visibility %>"><%= action %></div>
+              <div class="component-title-icon--<%= @visibility %>"></div>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
@@ -24,7 +24,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
           <%= f = form_for @changeset, "#", [phx_change: :validate, as: :form_data, phx_submit: :associate] %>
               <div class="user-form__email">
                   <%= label(f, :email, class: "label label--required") %>
-                  <%= text_input(f, :email, class: "input", readonly: true) %>
+                  <%= text_input(f, :email, [class: "input", readonly: true, required: true]) %>
               </div>
               <div class="user-form__role">
                   <%= label(f, :role, class: "label") %>

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_users_path()) %>
       <div id="edit-user-live-view" class="user-edit-page edit-page">
           <div class="edit-user-title">
-              <h2 class="component-title-text">Edit User </h2>
+              <h1 class="component-title-text">Edit User </h1>
           </div>
 
           <%= f = form_for @changeset, "#", [phx_change: :validate, as: :form_data, phx_submit: :associate] %>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.3.7",
+      version: "2.3.8",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Added keyboard accessibility to all buttons on screen (minus top view, as that is another task)
- updated scss variables
- updated labelling

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
~~- [ ] If altering an API endpoint, was the relevant postman collection updated?~~
  ~~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
