### PR TITLE
Changed publishing strategy to push image matching elixir version and…

### DIFF
--- a/scripts/gh-action-publish.sh
+++ b/scripts/gh-action-publish.sh
@@ -3,6 +3,21 @@
 set -e
 
 app="${1}"
+echo "app:"
+printf "%s \n\n" "$app"
 
-./scripts/build.sh $app development false
-./scripts/publish.sh $app development
+tag_as_development="${2:-true}"
+echo "tag_as_development:"
+printf "%s \n\n" "$tag_as_development"
+
+mix_vsn=$(mix cmd --app $app mix app.version | tail -1)
+echo "mix_vsn:"
+printf "%s \n\n" "$mix_vsn"
+
+./scripts/build.sh $app $mix_vsn false
+./scripts/publish.sh $app $mix_vsn
+
+if [[ $tag_as_development == true ]]; then
+  docker tag smartcitiesdata/$app:$mix_vsn smartcitiesdata/$app:deployment
+  ./scripts/publish.sh $app development
+fi

--- a/scripts/gh-action-publish.sh
+++ b/scripts/gh-action-publish.sh
@@ -18,6 +18,6 @@ printf "%s \n\n" "$mix_vsn"
 ./scripts/publish.sh $app $mix_vsn
 
 if [[ $tag_as_development == true ]]; then
-  docker tag smartcitiesdata/$app:$mix_vsn smartcitiesdata/$app:deployment
+  docker tag smartcitiesdata/$app:$mix_vsn smartcitiesdata/$app:development
   ./scripts/publish.sh $app development
 fi


### PR DESCRIPTION
Changed publishing strategy to push image matching elixir version and tag as development

## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

Changed publishing strategy to push image matching elixir version and tag as development

## Reminders:

- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
