### PR TITLE
fix(789): allow all https img src

### DIFF
--- a/apps/andi/lib/andi_web/router.ex
+++ b/apps/andi/lib/andi_web/router.ex
@@ -6,7 +6,7 @@ defmodule AndiWeb.Router do
          "style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;" <>
          "script-src 'self' 'unsafe-inline' 'unsafe-eval';" <>
          "font-src https://fonts.gstatic.com data: 'self';" <>
-         "img-src 'self' #{System.get_env("ANDI_LOGO_URL")} #{Application.get_env(:andi, :logo_url)} data:;"
+         "img-src 'self' https: data:;"
 
   pipeline :browser do
     plug Plug.Logger

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.3.10",
+      version: "2.3.11",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #789](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/789)

## Description

Just going with https in here for now. Since we're already exposing the ability to change the cors rule around this it doesn't seem to make much sense to worry about locking it down to the rules users set.

## Reminders:

- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
