### PR TITLE
add button type to buttons

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -36,10 +36,10 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
         <div class="transformation-header full-width" phx-click="toggle-component-visibility" phx-value-component="transformations_form">
           <h3 class="transformation-header-name"> <%= transformation_name(f) %> </h3>
           <div class="transformation-actions">
-            <button class="material-icons-outlined transformation-action delete-transformation-button delete-<%= @transformation_changeset.changes.id %>" phx-click="delete-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-target="#transformations-form">delete</button>
+            <button class="material-icons-outlined transformation-action delete-transformation-button delete-<%= @transformation_changeset.changes.id %>" type="button" phx-click="delete-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-target="#transformations-form">delete</button>
             <button class="material-icons-outlined transformation-action" type="button">edit</button>
-            <button class="material-icons transformation-action move-button move-up move-up-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1" phx-target="#transformations-form">arrow_upward</button>
-            <button class="material-icons transformation-action move-button move-down move-down-<%= @transformation_changeset.changes.id %>" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1" phx-target="#transformations-form">arrow_downward</button>
+            <button class="material-icons transformation-action move-button move-up move-up-<%= @transformation_changeset.changes.id %>" type="button" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="-1" phx-target="#transformations-form">arrow_upward</button>
+            <button class="material-icons transformation-action move-button move-down move-down-<%= @transformation_changeset.changes.id %>" type="button" phx-click="move-transformation" phx-value-id=<%= @transformation_changeset.changes.id %> phx-value-move-index="1" phx-target="#transformations-form">arrow_downward</button>
           </div>
         </div>
         <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.0",
+      version: "2.4.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #864](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/864)

## Description

- Add type="button" to transformation icons

## Reminders:
- ~~[ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app~~
- - ~~[ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.~~
  - ~~[ ] If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- ~~[ ] If altering an API endpoint, was the relevant postman collection updated?~~
  - ~~[ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
