### PR TITLE
fix(790): tune brightness levels required for color modification

### DIFF
--- a/apps/andi/lib/andi_web/views/layout_view.ex
+++ b/apps/andi/lib/andi_web/views/layout_view.ex
@@ -8,7 +8,7 @@ defmodule AndiWeb.LayoutView do
   def get_primary_button_text_color() do
     color = CssColors.parse!(get_primary_color())
 
-    case CssColors.get_lightness(color) < 0.25 do
+    case CssColors.get_lightness(color) < 0.5 do
       false -> "black"
       true -> "white"
     end
@@ -17,7 +17,7 @@ defmodule AndiWeb.LayoutView do
   def get_primary_text_color() do
     color = CssColors.parse!(get_primary_color())
 
-    case CssColors.get_lightness(color) < 0.25 do
+    case CssColors.get_lightness(color) < 0.5 do
       false -> to_string(CssColors.darken(color, 0.2))
       true -> to_string(color)
     end
@@ -26,7 +26,7 @@ defmodule AndiWeb.LayoutView do
   def get_hover_primary_color() do
     color = CssColors.parse!(get_primary_color())
 
-    case CssColors.get_lightness(color) < 0.25 do
+    case CssColors.get_lightness(color) < 0.5 do
       false -> to_string(CssColors.darken(color, 0.1))
       true -> to_string(CssColors.lighten(color, 0.1))
     end
@@ -35,7 +35,7 @@ defmodule AndiWeb.LayoutView do
   def get_active_primary_color() do
     color = CssColors.parse!(get_primary_color())
 
-    case CssColors.get_lightness(color) < 0.25 do
+    case CssColors.get_lightness(color) < 0.5 do
       false -> to_string(CssColors.darken(color, 0.2))
       true -> to_string(CssColors.lighten(color, 0.2))
     end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.1",
+      version: "2.4.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #790](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/790)

## Description

The threshold for lightness a color had to be at to trigger a color modification was a bit too easy to cross. 

Before:
<img width="291" alt="Screen Shot 2022-09-29 at 3 49 35 PM" src="https://user-images.githubusercontent.com/54278348/193140190-b8585d3f-8eb5-4aae-b752-19c64e835d3f.png">


After:
<img width="278" alt="Screen Shot 2022-09-29 at 3 49 39 PM" src="https://user-images.githubusercontent.com/54278348/193140211-94335b07-02da-422c-b809-ae873be50d10.png">


## Reminders:
- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
