### PR TITLE
created ingestion_timer and added that to igestion_progress

### DIFF
--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -125,11 +125,11 @@ defmodule Forklift.Event.EventHandler do
       }) do
     data_extract_end() |> add_event_count(author, dataset_id)
 
-    ingestion_status = Forklift.IngestionProgress.store_target(msg_target, ingestion_id, extract_start)
+    dataset = Forklift.Datasets.get!(dataset_id)
+
+    ingestion_status = Forklift.IngestionProgress.store_target(dataset, msg_target, ingestion_id, extract_start)
 
     if ingestion_status == :ingestion_complete do
-      dataset = Forklift.Datasets.get!(dataset_id)
-
       Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_start)
     end
 

--- a/apps/forklift/lib/forklift/ingestion_progress.ex
+++ b/apps/forklift/lib/forklift/ingestion_progress.ex
@@ -14,11 +14,18 @@ defmodule Forklift.IngestionProgress do
     end
   end
 
-  @spec store_target(SmartCity.Dataset.t(), Integer.t(), String.t(), Integer.t()) :: :in_progress | :ingestion_complete
-  def store_target(dataset, target, ingestion_id, extract_time) do
+  @spec store_target(SmartCity.Dataset.t(), Integer.t(), String.t(), Integer.t(), Integer.t()) ::
+          :in_progress | :ingestion_complete
+  def store_target(dataset, target, ingestion_id, extract_time, timer_time \\ 240_000) do
     extract_id = get_extract_id(ingestion_id, extract_time)
 
-    timer = :timer.apply_after(240000, Forklift.IngestionTimer, :compact_if_not_finished, [dataset, ingestion_id, extract_id, extract_time])
+    timer =
+      :timer.apply_after(timer_time, Forklift.IngestionTimer, :compact_if_not_finished, [
+        dataset,
+        ingestion_id,
+        extract_id,
+        extract_time
+      ])
 
     set_extract_target(extract_id, target)
 
@@ -71,6 +78,7 @@ defmodule Forklift.IngestionProgress do
     if timer != nil do
       :timer.cancel(timer)
     end
+
     :ingestion_complete
   end
 

--- a/apps/forklift/lib/forklift/ingestion_timer.ex
+++ b/apps/forklift/lib/forklift/ingestion_timer.ex
@@ -1,19 +1,9 @@
 defmodule Forklift.IngestionTimer do
-  def start(dataset, ingestion_id, extract_id, extract_time, timeout_timer \\ 240000) do
-    Task.async(fn -> timer(dataset, ingestion_id, extract_id, extract_time, timeout_timer) end)
-  end
-
-  defp timer(dataset, ingestion_id, extract_id, extract_time, timeout_timer) do
-    IO.inspect(timeout_timer, label: "remaining")
-    if timeout_timer <= 0 do
+  @spec compact_if_not_finished(SmartCity.Dataset.t(), String.t(), String.t(), String.t()) :: nil | {:abort, any} | {:error, any} | {:ok, any}
+  def compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time) do
+    if not Forklift.IngestionProgress.is_extract_done(extract_id) do
       Forklift.IngestionProgress.complete_extract(extract_id)
       Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time)
-      IO.inspect("completed via timeout")
-    else
-      :timer.sleep(1000)
-      if not Forklift.IngestionProgress.is_extract_done(extract_id) do
-        timer(dataset, ingestion_id, extract_id, extract_time, timeout_timer - 1000)
-      end
     end
   end
 end

--- a/apps/forklift/lib/forklift/ingestion_timer.ex
+++ b/apps/forklift/lib/forklift/ingestion_timer.ex
@@ -1,5 +1,6 @@
 defmodule Forklift.IngestionTimer do
-  @spec compact_if_not_finished(SmartCity.Dataset.t(), String.t(), String.t(), String.t()) :: nil | {:abort, any} | {:error, any} | {:ok, any}
+  @spec compact_if_not_finished(SmartCity.Dataset.t(), String.t(), String.t(), String.t()) ::
+          nil | {:abort, any} | {:error, any} | {:ok, any}
   def compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time) do
     if not Forklift.IngestionProgress.is_extract_done(extract_id) do
       Forklift.IngestionProgress.complete_extract(extract_id)

--- a/apps/forklift/lib/forklift/ingestion_timer.ex
+++ b/apps/forklift/lib/forklift/ingestion_timer.ex
@@ -1,0 +1,19 @@
+defmodule Forklift.IngestionTimer do
+  def start(dataset, ingestion_id, extract_id, extract_time, timeout_timer \\ 240000) do
+    Task.async(fn -> timer(dataset, ingestion_id, extract_id, extract_time, timeout_timer) end)
+  end
+
+  defp timer(dataset, ingestion_id, extract_id, extract_time, timeout_timer) do
+    IO.inspect(timeout_timer, label: "remaining")
+    if timeout_timer <= 0 do
+      Forklift.IngestionProgress.complete_extract(extract_id)
+      Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time)
+      IO.inspect("completed via timeout")
+    else
+      :timer.sleep(1000)
+      if not Forklift.IngestionProgress.is_extract_done(extract_id) do
+        timer(dataset, ingestion_id, extract_id, extract_time, timeout_timer - 1000)
+      end
+    end
+  end
+end

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -42,6 +42,7 @@ defmodule Forklift.MixProject do
       {:libcluster, "~> 3.1"},
       {:libvault, "~> 0.2"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
+      {:mock, "~> 0.3", only: [:dev, :test, :integration]},
       {:observer_cli, "~> 1.5"},
       {:placebo, "~> 2.0.0-rc2", only: [:dev, :test, :integration]},
       {:poison, "~> 3.1", override: true},

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.19.0",
+      version: "0.19.1",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/integration/forklift/ingestion_progress_test.exs
+++ b/apps/forklift/test/integration/forklift/ingestion_progress_test.exs
@@ -2,8 +2,6 @@ defmodule Forklift.IngestionProgressTest do
   alias Forklift.IngestionProgress
   use ExUnit.Case
 
-  import Mock
-
   setup_all do
     on_exit(fn ->
       {:ok, _} = Redix.command(:redix, ["flushall"])
@@ -63,7 +61,7 @@ defmodule Forklift.IngestionProgressTest do
       extract_time: extract_time,
       dataset: dataset
     } do
-      IngestionProgress.store_target(dataset, 7, ingestion_id, extract_time)
+      IngestionProgress.store_target(dataset, 7, ingestion_id, extract_time, 1000)
       assert Redix.command!(:redix, ["GET", get_extract_id(ingestion_id, extract_time) <> "_target"]) == "7"
     end
 
@@ -72,7 +70,7 @@ defmodule Forklift.IngestionProgressTest do
       extract_time: extract_time,
       dataset: dataset
     } do
-      assert IngestionProgress.store_target(dataset, 7, ingestion_id, extract_time) == :in_progress
+      assert IngestionProgress.store_target(dataset, 7, ingestion_id, extract_time, 1000) == :in_progress
     end
 
     test "store_target returns :in_progress if count is *less than* new target", %{
@@ -81,7 +79,7 @@ defmodule Forklift.IngestionProgressTest do
       dataset: dataset
     } do
       Redix.command!(:redix, ["SET", get_extract_id(ingestion_id, extract_time) <> "_count", 6])
-      assert IngestionProgress.store_target(dataset, 7, ingestion_id, extract_time) == :in_progress
+      assert IngestionProgress.store_target(dataset, 7, ingestion_id, extract_time, 1000) == :in_progress
     end
 
     test "store_target returns :ingestion_complete if count meets new target", %{
@@ -90,7 +88,7 @@ defmodule Forklift.IngestionProgressTest do
       dataset: dataset
     } do
       Redix.command!(:redix, ["SET", get_extract_id(ingestion_id, extract_time) <> "_count", 3])
-      assert IngestionProgress.store_target(dataset, 3, ingestion_id, extract_time) == :ingestion_complete
+      assert IngestionProgress.store_target(dataset, 3, ingestion_id, extract_time, 1000) == :ingestion_complete
     end
 
     test "ingestion count and target are cleared when target is achieved", %{
@@ -99,7 +97,7 @@ defmodule Forklift.IngestionProgressTest do
       dataset: dataset
     } do
       Redix.command!(:redix, ["SET", get_extract_id(ingestion_id, extract_time) <> "_count", 3])
-      IngestionProgress.store_target(dataset, 3, ingestion_id, extract_time)
+      IngestionProgress.store_target(dataset, 3, ingestion_id, extract_time, 1000)
       assert Redix.command!(:redix, ["GET", get_extract_id(ingestion_id, extract_time) <> "_target"]) == nil
       assert Redix.command!(:redix, ["GET", get_extract_id(ingestion_id, extract_time) <> "_count"]) == nil
     end

--- a/apps/forklift/test/unit/forklift/event/event_handling_test.exs
+++ b/apps/forklift/test/unit/forklift/event/event_handling_test.exs
@@ -160,7 +160,11 @@ defmodule Forklift.Event.EventHandlingTest do
       msg_target: msg_target,
       fake_extract_end_msg: fake_extract_end_msg
     } do
-      expect(Forklift.IngestionProgress.store_target(msg_target, ingestion_id, extract_start), return: :in_progress)
+      expect(Forklift.IngestionProgress.store_target(dataset, msg_target, ingestion_id, extract_start),
+        return: :in_progress
+      )
+
+      expect(Forklift.Datasets.get!(dataset.id), return: dataset)
 
       Brook.Test.with_event(@instance_name, fn ->
         EventHandler.handle_event(
@@ -180,7 +184,7 @@ defmodule Forklift.Event.EventHandlingTest do
       msg_target: msg_target,
       fake_extract_end_msg: fake_extract_end_msg
     } do
-      expect(Forklift.IngestionProgress.store_target(msg_target, ingestion_id, extract_start),
+      expect(Forklift.IngestionProgress.store_target(dataset, msg_target, ingestion_id, extract_start),
         return: :ingestion_complete
       )
 
@@ -205,7 +209,7 @@ defmodule Forklift.Event.EventHandlingTest do
       msg_target: msg_target,
       fake_extract_end_msg: fake_extract_end_msg
     } do
-      expect(Forklift.IngestionProgress.store_target(msg_target, ingestion_id, extract_start),
+      expect(Forklift.IngestionProgress.store_target(dataset, msg_target, ingestion_id, extract_start),
         return: :in_progress
       )
 
@@ -222,7 +226,6 @@ defmodule Forklift.Event.EventHandlingTest do
         )
       end)
 
-      refute_called Forklift.Datasets.get!(any())
       refute_called Forklift.Jobs.DataMigration.compact(any(), any(), any())
     end
   end

--- a/apps/forklift/test/unit/forklift/ingestion_timer_test.exs
+++ b/apps/forklift/test/unit/forklift/ingestion_timer_test.exs
@@ -1,0 +1,52 @@
+defmodule Forklift.IngestionTimerTest do
+  use ExUnit.Case
+  use Placebo
+
+  import Mock
+
+  setup do
+    [ingestion_id: Faker.UUID.v4(), extract_time: Timex.now() |> Timex.to_unix(), dataset: %{}]
+  end
+
+  describe "IngestionTimerTest" do
+    test "should not compact if finished", %{ingestion_id: ingestion_id, extract_time: extract_time, dataset: dataset} do
+      with_mocks([
+        {Forklift.IngestionProgress, [],
+          [
+            complete_extract: fn _any -> :ingestion_complete end,
+            is_extract_done: fn _any -> true end
+          ]},
+          {Forklift.Jobs.DataMigration, [], [compact: fn(_dataset, _ingestion_id, _extract_time) -> {:ok, "completed"} end]}
+        ]) do
+          extract_id = get_extract_id(ingestion_id, extract_time)
+
+          Forklift.IngestionTimer.compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time)
+
+          assert_not_called(Forklift.IngestionProgress.complete_extract(extract_id))
+          assert_not_called(Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time))
+      end
+    end
+
+    test "should compact if not finished", %{ingestion_id: ingestion_id, extract_time: extract_time, dataset: dataset} do
+      with_mocks([
+        {Forklift.IngestionProgress, [],
+          [
+            complete_extract: fn _any -> :ingestion_complete end,
+            is_extract_done: fn _any -> false end
+          ]},
+          {Forklift.Jobs.DataMigration, [], [compact: fn(_dataset, _ingestion_id, _extract_time) -> {:ok, "completed"} end]}
+        ]) do
+          extract_id = get_extract_id(ingestion_id, extract_time)
+
+          Forklift.IngestionTimer.compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time)
+
+          Mock.assert_called(Forklift.IngestionProgress.complete_extract(extract_id))
+          Mock.assert_called(Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time))
+      end
+    end
+  end
+
+  defp get_extract_id(ingestion_id, extract_time) do
+    ingestion_id <> "_" <> (extract_time |> Integer.to_string())
+  end
+end

--- a/apps/forklift/test/unit/forklift/ingestion_timer_test.exs
+++ b/apps/forklift/test/unit/forklift/ingestion_timer_test.exs
@@ -12,36 +12,38 @@ defmodule Forklift.IngestionTimerTest do
     test "should not compact if finished", %{ingestion_id: ingestion_id, extract_time: extract_time, dataset: dataset} do
       with_mocks([
         {Forklift.IngestionProgress, [],
-          [
-            complete_extract: fn _any -> :ingestion_complete end,
-            is_extract_done: fn _any -> true end
-          ]},
-          {Forklift.Jobs.DataMigration, [], [compact: fn(_dataset, _ingestion_id, _extract_time) -> {:ok, "completed"} end]}
-        ]) do
-          extract_id = get_extract_id(ingestion_id, extract_time)
+         [
+           complete_extract: fn _any -> :ingestion_complete end,
+           is_extract_done: fn _any -> true end
+         ]},
+        {Forklift.Jobs.DataMigration, [],
+         [compact: fn _dataset, _ingestion_id, _extract_time -> {:ok, "completed"} end]}
+      ]) do
+        extract_id = get_extract_id(ingestion_id, extract_time)
 
-          Forklift.IngestionTimer.compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time)
+        Forklift.IngestionTimer.compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time)
 
-          assert_not_called(Forklift.IngestionProgress.complete_extract(extract_id))
-          assert_not_called(Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time))
+        assert_not_called(Forklift.IngestionProgress.complete_extract(extract_id))
+        assert_not_called(Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time))
       end
     end
 
     test "should compact if not finished", %{ingestion_id: ingestion_id, extract_time: extract_time, dataset: dataset} do
       with_mocks([
         {Forklift.IngestionProgress, [],
-          [
-            complete_extract: fn _any -> :ingestion_complete end,
-            is_extract_done: fn _any -> false end
-          ]},
-          {Forklift.Jobs.DataMigration, [], [compact: fn(_dataset, _ingestion_id, _extract_time) -> {:ok, "completed"} end]}
-        ]) do
-          extract_id = get_extract_id(ingestion_id, extract_time)
+         [
+           complete_extract: fn _any -> :ingestion_complete end,
+           is_extract_done: fn _any -> false end
+         ]},
+        {Forklift.Jobs.DataMigration, [],
+         [compact: fn _dataset, _ingestion_id, _extract_time -> {:ok, "completed"} end]}
+      ]) do
+        extract_id = get_extract_id(ingestion_id, extract_time)
 
-          Forklift.IngestionTimer.compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time)
+        Forklift.IngestionTimer.compact_if_not_finished(dataset, ingestion_id, extract_id, extract_time)
 
-          Mock.assert_called(Forklift.IngestionProgress.complete_extract(extract_id))
-          Mock.assert_called(Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time))
+        Mock.assert_called(Forklift.IngestionProgress.complete_extract(extract_id))
+        Mock.assert_called(Forklift.Jobs.DataMigration.compact(dataset, ingestion_id, extract_time))
       end
     end
   end


### PR DESCRIPTION
## [Ticket Link #691](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/691)

## Description

- Set timer for forklift to compact if the messages are taking too long.

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  ~~- [ ] If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
~~- [ ] If altering an API endpoint, was the relevant postman collection updated?~~
  ~~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
