### PR TITLE
Can tab into all header buttons and "click" them with enter or space

### DIFF
--- a/apps/andi/lib/andi_web/live/header_live_view.ex
+++ b/apps/andi/lib/andi_web/live/header_live_view.ex
@@ -34,30 +34,30 @@ defmodule AndiWeb.HeaderLiveView do
       <span class="page-header__primary" phx-click="show-datasets">
         <img id="header-logo" src=<%= get_logo() %>></img>
         <span><%= get_header_text() %></span>
-        <span class="log-out-link primary-color-text" phx-click="log-out">
+        <span id="log-out-link" class="log-out-link primary-color-text" phx-click="log-out" phx-keydown="log-out" tabindex="0">
           <span class="material-icons">person</span>
           <span class="log-out-link__text">Log Out</span>
         </span>
       </span>
       <span class="page-header__secondary">
         <%= if @is_curator do %>
-          <span id="datasets-link" class='link <%= show_selected_if_active(header_datasets_path(), assigns.path) %>' phx-click="show-datasets">
+          <span id="datasets-link" class='link <%= show_selected_if_active(header_datasets_path(), assigns.path) %>' phx-click="show-datasets" phx-keydown="show-datasets" tabindex="0">
             <span class="material-icons">storage</span>
             <span>Datasets</span>
           </span>
-          <span id="ingestions-link" class="link <%= show_selected_if_active(header_ingestions_path(), assigns.path) %>" phx-click="show-ingestions">
+          <span id="ingestions-link" class="link <%= show_selected_if_active(header_ingestions_path(), assigns.path) %>" phx-click="show-ingestions" phx-keydown="show-ingestions" tabindex="0">
             <span class="material-icons">input</span>
             <span>Ingestions</span>
           </span>
-          <span id="organizations-link" class="link <%= show_selected_if_active(header_organizations_path(), assigns.path) %>" phx-click="show-organizations">
+          <span id="organizations-link" class="link <%= show_selected_if_active(header_organizations_path(), assigns.path) %>" phx-click="show-organizations" phx-keydown="show-organizations" tabindex="0">
             <span class="material-icons">settings</span>
             <span>Organizations</span>
           </span>
-          <span id="access-groups-link" class="link <%= show_selected_if_active(header_access_groups_path(), assigns.path) %>" phx-click="show-access-groups">
+          <span id="access-groups-link" class="link <%= show_selected_if_active(header_access_groups_path(), assigns.path) %>" phx-click="show-access-groups" phx-keydown="show-access-groups" tabindex="0">
             <span class="material-icons">lock</span>
             <span>Access Groups</span>
           </span>
-          <span id="users-link" class="link <%= show_selected_if_active(header_users_path(), assigns.path) %>" phx-click="show-users">
+          <span id="users-link" class="link <%= show_selected_if_active(header_users_path(), assigns.path) %>" phx-click="show-users" phx-keydown="show-users" tabindex="0">
             <span class="material-icons">people</span>
             <span>Users</span>
           </span>
@@ -71,28 +71,36 @@ defmodule AndiWeb.HeaderLiveView do
     quote do
       import AndiWeb.HeaderLiveView
 
-      def handle_event("show-datasets", _, socket) do
+      @click %{}
+      @enter %{"key" => "Enter"}
+      @space %{"key" => " "}
+
+      def handle_event("show-datasets", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_datasets_path())
       end
 
-      def handle_event("show-organizations", _, socket) do
+      def handle_event("show-organizations", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_organizations_path())
       end
 
-      def handle_event("show-users", _, socket) do
+      def handle_event("show-users", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_users_path())
       end
 
-      def handle_event("show-access-groups", _, socket) do
+      def handle_event("show-access-groups", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_access_groups_path())
       end
 
-      def handle_event("show-ingestions", _, socket) do
+      def handle_event("show-ingestions", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_ingestions_path())
       end
 
-      def handle_event("log-out", _, socket) do
+      def handle_event("log-out", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_log_out_path())
+      end
+
+      def handle_event(_, _, socket) do
+        {:noreply, socket}
       end
     end
   end

--- a/apps/andi/lib/andi_web/live/header_live_view.ex
+++ b/apps/andi/lib/andi_web/live/header_live_view.ex
@@ -79,27 +79,47 @@ defmodule AndiWeb.HeaderLiveView do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_datasets_path())
       end
 
+      def handle_event("show-datasets", _, socket) do
+        {:noreply, socket}
+      end
+
       def handle_event("show-organizations", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_organizations_path())
+      end
+
+      def handle_event("show-organizations", _, socket) do
+        {:noreply, socket}
       end
 
       def handle_event("show-users", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_users_path())
       end
 
+      def handle_event("show-users", _, socket) do
+        {:noreply, socket}
+      end
+
       def handle_event("show-access-groups", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_access_groups_path())
+      end
+
+      def handle_event("show-access-groups", _, socket) do
+        {:noreply, socket}
       end
 
       def handle_event("show-ingestions", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_ingestions_path())
       end
 
+      def handle_event("show-ingestions", _, socket) do
+        {:noreply, socket}
+      end
+
       def handle_event("log-out", key, socket) when key in [@click, @enter, @space] do
         AndiWeb.HeaderLiveView.__redirect__(socket, header_log_out_path())
       end
 
-      def handle_event(_, _, socket) do
+      def handle_event("log-out", _, socket) do
         {:noreply, socket}
       end
     end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.5",
+      version: "2.4.6",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/header_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/header_live_view_test.exs
@@ -8,7 +8,7 @@ defmodule AndiWeb.HeaderLiveViewTest do
   @moduletag shared_data_connection: true
 
   import Phoenix.LiveViewTest
-
+  import Checkov
   import FlokiHelpers,
     only: [
       find_elements: 2
@@ -84,6 +84,32 @@ defmodule AndiWeb.HeaderLiveViewTest do
 
       render_click(ingestions_button)
       assert_redirected(view, "/ingestions")
+    end
+  end
+
+  describe "accessibility" do
+    data_test "#{button} button responds to #{key_type}", %{curator_conn: conn} do
+      {:ok, view, _html} = live(conn, @url_path)
+
+      datasets_button = element(view, selector)
+      render_keydown(datasets_button, %{"key" => key})
+      assert_redirected(view, redirect)
+
+      where ([
+          [:button, :key_type, :selector, :key, :redirect],
+          ["datasets", "enter", "#datasets-link", "Enter", "/datasets"],
+          ["datasets", "space", "#datasets-link", " ", "/datasets"],
+          ["ingestions", "enter", "#ingestions-link", "Enter", "/ingestions"],
+          ["ingestions", "space", "#ingestions-link", " ", "/ingestions"],
+          ["organizations", "enter", "#organizations-link", "Enter", "/organizations"],
+          ["organizations", "space", "#organizations-link", " ", "/organizations"],
+          ["access groups", "enter", "#access-groups-link", "Enter", "/access-groups"],
+          ["access groups", "space", "#access-groups-link", " ", "/access-groups"],
+          ["users", "enter", "#users-link", "Enter", "/users"],
+          ["users", "space", "#users-link", " ", "/users"],
+          ["log-out", "enter", "#log-out-link", "Enter", "/auth/auth0/logout"],
+          ["log-out", "space", "#log-out-link", " ", "/auth/auth0/logout"]
+        ])
     end
   end
 end

--- a/apps/andi/test/integration/andi_web/live/header_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/header_live_view_test.exs
@@ -9,6 +9,7 @@ defmodule AndiWeb.HeaderLiveViewTest do
 
   import Phoenix.LiveViewTest
   import Checkov
+
   import FlokiHelpers,
     only: [
       find_elements: 2
@@ -95,21 +96,21 @@ defmodule AndiWeb.HeaderLiveViewTest do
       render_keydown(datasets_button, %{"key" => key})
       assert_redirected(view, redirect)
 
-      where ([
-          [:button, :key_type, :selector, :key, :redirect],
-          ["datasets", "enter", "#datasets-link", "Enter", "/datasets"],
-          ["datasets", "space", "#datasets-link", " ", "/datasets"],
-          ["ingestions", "enter", "#ingestions-link", "Enter", "/ingestions"],
-          ["ingestions", "space", "#ingestions-link", " ", "/ingestions"],
-          ["organizations", "enter", "#organizations-link", "Enter", "/organizations"],
-          ["organizations", "space", "#organizations-link", " ", "/organizations"],
-          ["access groups", "enter", "#access-groups-link", "Enter", "/access-groups"],
-          ["access groups", "space", "#access-groups-link", " ", "/access-groups"],
-          ["users", "enter", "#users-link", "Enter", "/users"],
-          ["users", "space", "#users-link", " ", "/users"],
-          ["log-out", "enter", "#log-out-link", "Enter", "/auth/auth0/logout"],
-          ["log-out", "space", "#log-out-link", " ", "/auth/auth0/logout"]
-        ])
+      where([
+        [:button, :key_type, :selector, :key, :redirect],
+        ["datasets", "enter", "#datasets-link", "Enter", "/datasets"],
+        ["datasets", "space", "#datasets-link", " ", "/datasets"],
+        ["ingestions", "enter", "#ingestions-link", "Enter", "/ingestions"],
+        ["ingestions", "space", "#ingestions-link", " ", "/ingestions"],
+        ["organizations", "enter", "#organizations-link", "Enter", "/organizations"],
+        ["organizations", "space", "#organizations-link", " ", "/organizations"],
+        ["access groups", "enter", "#access-groups-link", "Enter", "/access-groups"],
+        ["access groups", "space", "#access-groups-link", " ", "/access-groups"],
+        ["users", "enter", "#users-link", "Enter", "/users"],
+        ["users", "space", "#users-link", " ", "/users"],
+        ["log-out", "enter", "#log-out-link", "Enter", "/auth/auth0/logout"],
+        ["log-out", "space", "#log-out-link", " ", "/auth/auth0/logout"]
+      ])
     end
   end
 end

--- a/apps/andi/test/unit/andi_web/live/header_live_view_test.exs
+++ b/apps/andi/test/unit/andi_web/live/header_live_view_test.exs
@@ -2,8 +2,6 @@ defmodule AndiWeb.HeaderLiveViewTest do
   use AndiWeb.Test.AuthConnCase.UnitCase
   use Placebo
 
-  alias AndiWeb.HeaderLiveView
-
   import Phoenix.LiveViewTest
 
   describe "Header Live View" do


### PR DESCRIPTION
## [Ticket Link #882](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/882)

## Description

Improvements for screen readers

- Can tab into header buttons
- Enter and space function like clicks

I tried to make the code for this as "dry" as possible, but guard clauses have limitations I couldn't get around. For example I wanted to make the guard clause a function or the module attribute a list of all three permitted actions, but neither compiles. Happy to hear suggestions for better ways to do this.

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  ~- [ ] If updating Major or Minor versions , did you update the sauron chart configuration?~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
~- [ ] If altering an API endpoint, was the relevant postman collection updated?~
  ~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~
