### PR TITLE
854 - custom outline on input focus ; stop wordbreak for small words in tables

### DIFF
--- a/apps/andi/assets/css/datasets.scss
+++ b/apps/andi/assets/css/datasets.scss
@@ -69,10 +69,6 @@
   border: 1px solid $search-unfocused;
 }
 
-.datasets-index__search-input-container:focus-within {
-  border: 1px solid $search-focused;
-}
-
 .datasets-index__search-icon {
   padding: 0.1rem;
   color: $search-unfocused;

--- a/apps/andi/assets/css/organizations.scss
+++ b/apps/andi/assets/css/organizations.scss
@@ -67,10 +67,6 @@
   border: 1px solid $search-unfocused;
 }
 
-.organizations-index__search-input-container:focus-within {
-  border: 1px solid $search-focused;
-}
-
 .organizations-index__search-icon {
   padding: 0.1rem;
   color: $search-unfocused;

--- a/apps/andi/assets/css/search-modal.scss
+++ b/apps/andi/assets/css/search-modal.scss
@@ -38,10 +38,6 @@
   border: 1px solid $search-unfocused;
 }
 
-.search-modal__search_bar-input-container:focus-within {
-  border: 1px solid $search-focused;
-}
-
 .search-modal__search_bar-icon {
   padding: 0.1rem;
   color: $search-unfocused;

--- a/apps/andi/assets/css/users.scss
+++ b/apps/andi/assets/css/users.scss
@@ -1,9 +1,9 @@
 .users-view {
-    flex: 1;
-    background: $color-content-background;
-    box-shadow: $box-shadow;
-    height: max-content;
-    margin: 1em;
+  flex: 1;
+  background: $color-content-background;
+  box-shadow: $box-shadow;
+  height: max-content;
+  margin: 1em;
 }
 
 .users-line {
@@ -12,20 +12,20 @@
 }
 
 .users-index {
-    padding: 1rem 3rem;
+  padding: 1rem 3rem;
 }
 
 .users-index__header {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 }
 
 .users-index__title {
-    font-size: 1.5rem;
-  }
+  font-size: 1.5rem;
+}
 
 .users-index__search {
-    width: 50%;
+  width: 50%;
 }
 
 .users-index__search-input-container {
@@ -33,10 +33,6 @@
   width: 100%;
   margin: 0.5rem;
   border: 1px solid $search-unfocused;
-}
-
-.users-index__search-input-container:focus-within {
-  border: 1px solid $search-focused;
 }
 
 .users-index__search-icon {

--- a/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
@@ -26,7 +26,7 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTable do
                 <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break access-groups-sub-table__data-title-cell wide-column"><%= dataset.business.dataTitle %></td>
                 <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= dataset.business.orgTitle %></td>
                 <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= Enum.join(dataset.business.keywords, ", ") %></td>
-                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break thin-column">
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell  thin-column">
                   <a class="modal-action-text" href="javascript:void(0)" phx-click="remove-selected-dataset" phx-value-id=<%= dataset.id %>>Remove</a>
                 </td>
               </tr>

--- a/apps/andi/lib/andi_web/live/access_group_live_view/table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/table.ex
@@ -23,7 +23,7 @@ defmodule AndiWeb.AccessGroupLiveView.Table do
           <tr class="access-groups-table__tr">
               <td class="access-groups-table__cell access-groups-table__cell--break access-groups-table__data-title-cell"><%= access_group["name"] %></td>
               <td class="access-groups-table__cell access-groups-table__cell--break"><%= format_modified_date(access_group["modified_date"]) %></td>
-              <td class="access-groups-table__cell access-groups-table__cell--break primary-color-link" style="width: 10%;"><%= Link.link("Edit", to: "/access-groups/#{access_group["id"]}", class: "btn") %></td>
+              <td class="access-groups-table__cell access-groups-table__cell primary-color-link" style="width: 10%;"><%= Link.link("Edit", to: "/access-groups/#{access_group["id"]}", class: "btn") %></td>
             </tr>
           <% end %>
         <% end %>

--- a/apps/andi/lib/andi_web/live/access_group_live_view/user_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/user_table.ex
@@ -27,7 +27,7 @@ defmodule AndiWeb.AccessGroupLiveView.UserTable do
                 <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break access-groups-sub-table__data-title-cell wide-column"><%= user.name %></td>
                 <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= user.email %></td>
                 <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break wide-column"><%= Enum.join(Enum.map(user.organizations, fn org -> org.orgTitle end), ", ") %></td>
-                <td class="access-groups-sub-table__cell access-groups-sub-table__cell--break modal-action-text thin-column" phx-click="remove-selected-user" phx-value-id=<%= user.subject_id %>>Remove</td>
+                <td class="access-groups-sub-table__cell access-groups-sub-table__cell modal-action-text thin-column" phx-click="remove-selected-user" phx-value-id=<%= user.subject_id %>>Remove</td>
               </tr>
             <% end %>
           <% end %>

--- a/apps/andi/lib/andi_web/live/dataset_live_view/table.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/table.ex
@@ -25,7 +25,7 @@ defmodule AndiWeb.DatasetLiveView.Table do
             <% status_modifier = get_status_class(status) %>
 
             <tr class="datasets-table__tr">
-              <td class="datasets-table__cell datasets-table__cell--break dataset__status dataset__status--<%= status_modifier %>">
+              <td class="datasets-table__cell datasets-table__cell dataset__status dataset__status--<%= status_modifier %>">
                 <div class="status">
                   <div class="status__icon"></div>
                   <div class="status__message"><%= status %></div>
@@ -33,7 +33,7 @@ defmodule AndiWeb.DatasetLiveView.Table do
               </td>
               <td class="datasets-table__cell datasets-table__cell--break datasets-table__data-title-cell"><%= dataset["data_title"] %></td>
               <td class="datasets-table__cell datasets-table__cell--break"><%= dataset["org_title"] %></td>
-              <td class="datasets-table__cell datasets-table__cell--break primary-color-link" style="width: 10%;"><%= Link.link("Edit", to: "/#{edit_type(@is_curator)}/#{dataset["id"]}", class: "btn") %></td>
+              <td class="datasets-table__cell datasets-table__cell primary-color-link" style="width: 10%;"><%= Link.link("Edit", to: "/#{edit_type(@is_curator)}/#{dataset["id"]}", class: "btn") %></td>
             </tr>
           <% end %>
         <% end %>

--- a/apps/andi/lib/andi_web/live/organization_live_view/table.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view/table.ex
@@ -21,7 +21,7 @@ defmodule AndiWeb.OrganizationLiveView.Table do
           <%= for org <- @organizations do %>
           <tr class="organizations-table__tr">
             <td class="organizations-table__cell organizations-table__cell--break" style="width: 80%;"><%= org["org_title"] %></td>
-            <td class="organizations-table__cell organizations-table__cell--break primary-color-link"><%= Link.link("Edit", to: "/organizations/#{org["id"]}", class: "btn") %></td>
+            <td class="organizations-table__cell organizations-table__cell primary-color-link"><%= Link.link("Edit", to: "/organizations/#{org["id"]}", class: "btn") %></td>
           </tr>
           <% end %>
         <% end %>

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_role_table.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_role_table.ex
@@ -20,7 +20,7 @@ defmodule AndiWeb.EditUserLiveView.EditUserLiveViewRoleTable do
           <%= for role <- @user_roles do %>
             <tr class="roles-table__tr">
               <td class="roles-table__cell roles-table__cell--break"><%= Map.get(role, "description", "") %></td>
-              <td class="roles-table__cell roles-table__cell--break" style="width: 10%;">
+              <td class="roles-table__cell roles-table__cell" style="width: 10%;">
                   <%= if not @self do %>
                     <button phx-click="remove_role" phx-value-role-id="<%= role["id"] %>" phx-target="<%= @myself %>" class="btn btn--remove-organization">Remove</button>
                   <% end %>

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_table.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_table.ex
@@ -21,7 +21,7 @@ defmodule AndiWeb.EditUserLiveView.EditUserLiveViewTable do
           <%= for organization <- @organizations do %>
             <tr class="organizations-table__tr">
               <td class="organizations-table__cell organizations-table__cell--break"><%= Map.get(organization, :orgName, "") %></td>
-              <td class="organizations-table__cell organizations-table__cell--break primary-color-link" style="width: 10%;">
+              <td class="organizations-table__cell organizations-table__cell primary-color-link" style="width: 10%;">
                 <%= Link.link("Edit", to: "/organizations/#{Map.get(organization, :id)}", class: "btn") %>
                 <button phx-click="remove_org" phx-value-org-id="<%= organization.id %>" phx-target="<%= @myself %>" class="btn btn--remove-organization">Remove</button>
               </td>

--- a/apps/andi/lib/andi_web/live/user_live_view/table.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/table.ex
@@ -21,7 +21,7 @@ defmodule AndiWeb.UserLiveView.Table do
           <%= for user <- @users do %>
           <tr class="users-table__tr">
             <td class="users-table__cell users-table__cell--break users-table__cell--email" style="width: 80%;"><%= user["email"] %></td>
-            <td class="users-table__cell users-table__cell--break primary-color-link"><%= Link.link("Edit", to: "/user/#{user["id"]}", class: "btn") %></td>
+            <td class="users-table__cell users-table__cell primary-color-link"><%= Link.link("Edit", to: "/user/#{user["id"]}", class: "btn") %></td>
           </tr>
           <% end %>
         <% end %>

--- a/apps/andi/lib/andi_web/templates/layout/style.html.eex
+++ b/apps/andi/lib/andi_web/templates/layout/style.html.eex
@@ -1,4 +1,4 @@
- <%# This file is needed because it's the best way too access the styles set in the env %>
+ <%# This file is needed because it's the best way too access the styles set in the env (i.e. coolor) %>
  <style>
   .root {
     accent-color: <%= get_primary_color() %>;

--- a/apps/andi/lib/andi_web/templates/layout/style.html.eex
+++ b/apps/andi/lib/andi_web/templates/layout/style.html.eex
@@ -1,3 +1,4 @@
+ <%# This file is needed because it's the best way too access the styles set in the env %>
  <style>
   .root {
     accent-color: <%= get_primary_color() %>;
@@ -45,5 +46,20 @@
   }
   .primary-color-link a:active {
     background-color: #ddd;
+  }
+  .datasets-index__search-input-container:focus-within {
+    border: 1px solid <%= get_primary_text_color() %>;
+  }
+  .organizations-index__search-input-container:focus-within {
+    border: 1px solid <%= get_primary_text_color() %>;
+  }
+  .search-modal__search_bar-input-container:focus-within {
+    border: 1px solid <%= get_primary_text_color() %>;
+  }
+  .users-index__search-input-container:focus-within {
+    border: 1px solid <%= get_primary_text_color() %>;
+  }
+  .input {
+    outline-color: <%= get_primary_text_color() %>;
   }
 </style>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.5",
+      version: "2.4.6",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/access_group_live_view/manage_users_modal_test.exs
+++ b/apps/andi/test/integration/andi_web/live/access_group_live_view/manage_users_modal_test.exs
@@ -116,7 +116,7 @@ defmodule AndiWeb.AccessGroupLiveView.ManageUsersModalTest do
 
     assert get_text(html, ".selected-results-from-search") =~ user.name
 
-    remove_action = element(view, ".access-groups-sub-table__cell--break.modal-action-text", "Remove")
+    remove_action = element(view, ".access-groups-sub-table__cell.modal-action-text", "Remove")
     html = render_click(remove_action)
 
     refute get_text(html, ".selected-results-from-search") =~ user.name


### PR DESCRIPTION
## [Ticket Link #854](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/854)

## Description
Custom outline on input focus - 
<img width="502" alt="Screen Shot 2022-10-19 at 2 01 33 PM" src="https://user-images.githubusercontent.com/54278348/196781336-37dfc00d-10bc-484c-a4fd-adc68d03f287.png">

<img width="1129" alt="Screen Shot 2022-10-19 at 1 52 53 PM" src="https://user-images.githubusercontent.com/54278348/196781445-eacc835e-5ef2-45f2-b52c-887df656c66d.png">


I also was getting tired of seeing the words "Edit" and "Draft" get broken in the table, so I changed that too. Before and after - 

<img width="908" alt="Screen Shot 2022-10-19 at 2 05 27 PM" src="https://user-images.githubusercontent.com/54278348/196781568-57029b24-3a3a-428d-a825-b54221a73d1a.png">


<img width="795" alt="Screen Shot 2022-10-19 at 1 44 01 PM" src="https://user-images.githubusercontent.com/54278348/196781444-0dfd2d0b-0b03-418a-99f8-72a587b02ccb.png">





## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [x] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [x] If altering an API endpoint, was the relevant postman collection updated?
  - [x] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
