### PR TITLE
Have test cron continue on error

### DIFF
--- a/.github/workflows/all_tests_cron.yml
+++ b/.github/workflows/all_tests_cron.yml
@@ -7,6 +7,7 @@ jobs:
   unit_tests:
     name: Run all unit tests
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         app: [andi, discovery_api]
@@ -26,6 +27,7 @@ jobs:
   integration_tests:
     name: Run all integration tests
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         app: [andi, discovery_api, pipeline, e2e]


### PR DESCRIPTION
## [Ticket Link #880](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/880)

## Description

Currently, flakey tests are causing the rest of the test suite to stop prematurely. This should have them `continue-on-error`

<img width="346" alt="image" src="https://user-images.githubusercontent.com/54278348/197212484-3dd4a053-e63b-4df6-b3cc-f567c6a85e3c.png">


