### PR TITLE
Reduce frequency of test cron

### DIFF
--- a/.github/workflows/all_tests_cron.yml
+++ b/.github/workflows/all_tests_cron.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *"
-    - cron: "30 * * * 6,0"
 jobs:
   unit_tests:
     name: Run all unit tests


### PR DESCRIPTION
We have a lot of good data on test failures, no need to run this 48 times each weekend