### PR TITLE
Remove dockerfile build step in andi github action

### DIFF
--- a/.github/workflows/andi.yml
+++ b/.github/workflows/andi.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Run integration tests
         run: |
           bash scripts/gh-action-integration-test.sh ${GITHUB_WORKFLOW}
-      - name: Build docker image
-        run: |
-          bash scripts/build.sh ${GITHUB_WORKFLOW} development true
-        if: github.event_name == 'pull_request'
       - name: Publish development image
         run: |
           bash scripts/gh-action-publish.sh ${GITHUB_WORKFLOW}


### PR DESCRIPTION
## [Ticket Link #890](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/890)

## Description

Removing the `Build docker image` step in the andi flow.

The image produced by this step isn't actually used anywhere. The `Publish Development Image` makes its own, and `Publish to Quay` runs mutually exclusively to the `Build docker image` step.

The only reason I can think to have this step here is as a test, but it's a very long running and low value test to have run with every push to every PR.