### PR TITLE
Have reaper clean up ingestions associated with deleted datasets

### DIFF
--- a/apps/reaper/lib/reaper/event/event_handler.ex
+++ b/apps/reaper/lib/reaper/event/event_handler.ex
@@ -1,22 +1,29 @@
 defmodule Reaper.Event.EventHandler do
   @moduledoc "This module processes all events for Reaper"
   use Brook.Event.Handler
+  require Logger
 
   import SmartCity.Event,
     only: [
       data_ingest_start: 0,
       data_extract_start: 0,
       data_extract_end: 0,
+      dataset_delete: 0,
       ingestion_update: 0,
       ingestion_delete: 0,
       error_ingestion_update: 0
     ]
 
   alias Reaper.Collections.Extractions
+  alias Reaper.Event.Handlers.IngestionDelete
+  alias SmartCity.{Dataset}
 
   @instance_name Reaper.instance_name()
 
-  def handle_event(%Brook.Event{type: ingestion_update(), data: %SmartCity.Ingestion{} = ingestion}) do
+  def handle_event(%Brook.Event{
+        type: ingestion_update(),
+        data: %SmartCity.Ingestion{} = ingestion
+      }) do
     ingestion_update()
     |> add_event_count(ingestion.targetDataset)
 
@@ -32,7 +39,10 @@ defmodule Reaper.Event.EventHandler do
       :discard
   end
 
-  def handle_event(%Brook.Event{type: ingestion_delete(), data: %SmartCity.Ingestion{} = ingestion}) do
+  def handle_event(%Brook.Event{
+        type: ingestion_delete(),
+        data: %SmartCity.Ingestion{} = ingestion
+      }) do
     ingestion_delete()
     |> add_event_count(ingestion.id)
 
@@ -40,7 +50,10 @@ defmodule Reaper.Event.EventHandler do
     Extractions.delete_ingestion(ingestion.id)
   end
 
-  def handle_event(%Brook.Event{type: data_extract_start(), data: %SmartCity.Ingestion{} = ingestion}) do
+  def handle_event(%Brook.Event{
+        type: data_extract_start(),
+        data: %SmartCity.Ingestion{} = ingestion
+      }) do
     data_extract_start()
     |> add_event_count(ingestion.targetDataset)
 
@@ -70,6 +83,34 @@ defmodule Reaper.Event.EventHandler do
     |> add_event_count(dataset_id)
 
     Extractions.update_last_fetched_timestamp(ingestion_id)
+  end
+
+  def handle_event(%Brook.Event{
+        type: dataset_delete(),
+        data: %Dataset{} = dataset
+      }) do
+    dataset_delete()
+    |> add_event_count(dataset.id)
+
+    {:ok, extractions} = Brook.ViewState.get_all(@instance_name, :extractions)
+
+    extractions_to_delete =
+      Enum.filter(extractions, fn {key, e} ->
+        with {:ok, ingestion} <- Map.fetch(e, "ingestion") do
+          ingestion[:targetDataset] == dataset[:id]
+        else
+          :error -> Logger.error("Extraction #{key} does not have an Ingestion object")
+        end
+      end)
+
+    Enum.each(
+      extractions_to_delete,
+      fn {_id, extraction} ->
+        IngestionDelete.handle(extraction["ingestion"])
+      end
+    )
+
+    :ok
   end
 
   defp add_event_count(event_type, dataset_id) do

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.14",
+      version: "2.0.15",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/test/unit/reaper/event/event_handler_test.exs
+++ b/apps/reaper/test/unit/reaper/event/event_handler_test.exs
@@ -10,6 +10,7 @@ defmodule Reaper.Event.EventHandlerTest do
       data_ingest_start: 0,
       data_extract_start: 0,
       data_extract_end: 0,
+      dataset_delete: 0,
       ingestion_update: 0,
       ingestion_delete: 0,
       error_ingestion_update: 0
@@ -17,6 +18,7 @@ defmodule Reaper.Event.EventHandlerTest do
 
   import SmartCity.TestHelper, only: [eventually: 1]
   alias SmartCity.TestDataGenerator, as: TDG
+  alias Reaper.Event.Handlers.IngestionDelete
 
   @instance_name Reaper.instance_name()
 
@@ -24,8 +26,11 @@ defmodule Reaper.Event.EventHandlerTest do
 
   setup do
     {:ok, brook} = Brook.start_link(brook() |> Keyword.put(:instance, @instance_name))
+
     {:ok, horde_supervisor} = Horde.DynamicSupervisor.start_link(name: Reaper.Horde.Supervisor, strategy: :one_for_one)
+
     {:ok, reaper_horde_registry} = Reaper.Horde.Registry.start_link(name: Reaper.Horde.Registry, keys: :unique)
+
     allow(TelemetryEvent.add_event_metrics(any(), [:events_handled]), return: :ok)
     Brook.Test.register(@instance_name)
 
@@ -48,13 +53,18 @@ defmodule Reaper.Event.EventHandlerTest do
       assert_receive {:brook_event,
                       %Brook.Event{
                         type: error_ingestion_update(),
-                        data: %{"reason" => _, "ingestion" => %SmartCity.Ingestion{id: "ds-empty-cron"}}
+                        data: %{
+                          "reason" => _,
+                          "ingestion" => %SmartCity.Ingestion{id: "ds-empty-cron"}
+                        }
                       }},
                      10_000
     end
 
     test "sends error event for raised errors while performing ingestion update" do
-      allow(Reaper.Event.Handlers.IngestionUpdate.handle(any()), exec: fn _ -> raise "bad stuff" end)
+      allow(Reaper.Event.Handlers.IngestionUpdate.handle(any()),
+        exec: fn _ -> raise "bad stuff" end
+      )
 
       ingestion = TDG.create_ingestion(%{})
 
@@ -72,7 +82,7 @@ defmodule Reaper.Event.EventHandlerTest do
   describe "#{data_extract_start()}" do
     setup do
       date = DateTime.utc_now()
-      allow DateTime.utc_now(), return: date, meck_options: [:passthrough]
+      allow(DateTime.utc_now(), return: date, meck_options: [:passthrough])
       ingestion = TDG.create_ingestion(%{id: "ds2"})
 
       [ingestion: ingestion, date: date]
@@ -81,22 +91,32 @@ defmodule Reaper.Event.EventHandlerTest do
     test "should ask horde to start process with appropriate name", %{ingestion: ingestion} do
       test_pid = self()
 
-      Brook.Test.with_event(@instance_name, fn -> Reaper.Collections.Extractions.update_ingestion(ingestion) end)
+      Brook.Test.with_event(@instance_name, fn ->
+        Reaper.Collections.Extractions.update_ingestion(ingestion)
+      end)
 
-      allow Reaper.DataExtract.Processor.process(any(), any()),
+      allow(Reaper.DataExtract.Processor.process(any(), any()),
         exec: fn processor_ingestion, timestamp ->
           [{_pid, _}] = Horde.Registry.lookup(Reaper.Horde.Registry, ingestion.id)
           send(test_pid, {:registry, processor_ingestion})
         end
+      )
 
       Brook.Test.send(@instance_name, data_extract_start(), "testing", ingestion)
 
       assert_receive {:registry, ^ingestion}
     end
 
-    test "should persist the ingestion and start time in the view state", %{ingestion: ingestion, date: date} do
-      allow Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid}
-      Brook.Test.with_event(@instance_name, fn -> Reaper.Collections.Extractions.update_ingestion(ingestion) end)
+    test "should persist the ingestion and start time in the view state", %{
+      ingestion: ingestion,
+      date: date
+    } do
+      allow(Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid})
+
+      Brook.Test.with_event(@instance_name, fn ->
+        Reaper.Collections.Extractions.update_ingestion(ingestion)
+      end)
+
       Brook.Test.send(@instance_name, data_extract_start(), "testing", ingestion)
 
       eventually(fn ->
@@ -108,39 +128,58 @@ defmodule Reaper.Event.EventHandlerTest do
     end
 
     test "should send ingest_start event", %{ingestion: ingestion} do
-      allow Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid}
-      Brook.Test.with_event(@instance_name, fn -> Reaper.Collections.Extractions.update_ingestion(ingestion) end)
+      allow(Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid})
+
+      Brook.Test.with_event(@instance_name, fn ->
+        Reaper.Collections.Extractions.update_ingestion(ingestion)
+      end)
+
       Brook.Test.send(@instance_name, data_extract_start(), :reaper, ingestion)
 
       assert_receive {:brook_event, %Brook.Event{type: "data:ingest:start", data: ingestion}}
     end
 
     test "should send ingest_start event for streaming data on the first event" do
-      allow Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid}
+      allow(Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid})
       ingestion = TDG.create_ingestion(%{id: "ds2", cadence: "1 2 24 * * *"})
-      Brook.Test.with_event(@instance_name, fn -> Reaper.Collections.Extractions.update_ingestion(ingestion) end)
+
+      Brook.Test.with_event(@instance_name, fn ->
+        Reaper.Collections.Extractions.update_ingestion(ingestion)
+      end)
+
       Brook.Test.send(@instance_name, data_extract_start(), :reaper, ingestion)
 
       assert_receive {:brook_event, %Brook.Event{type: "data:ingest:start", data: ingestion}}
     end
 
     test "should not send ingest_start event for data that updates more than once per minute on subsequent events" do
-      allow Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid}
+      allow(Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid})
+
       ingestion = TDG.create_ingestion(%{id: "in1", targetDataset: "ds2", cadence: "* 2 24 * * *"})
-      Brook.Test.with_event(@instance_name, fn -> Reaper.Collections.Extractions.update_ingestion(ingestion) end)
+
+      Brook.Test.with_event(@instance_name, fn ->
+        Reaper.Collections.Extractions.update_ingestion(ingestion)
+      end)
+
       Brook.Test.send(@instance_name, data_extract_start(), :reaper, ingestion)
       send_data_extract_end(ingestion.id, ingestion.targetDataset, 0, Timex.to_unix(Timex.now()))
 
       assert_receive {:brook_event, %Brook.Event{type: "data:ingest:start", data: ^ingestion}}
 
       Brook.Test.send(@instance_name, data_extract_start(), :reaper, ingestion)
-      refute_receive {:brook_event, %Brook.Event{type: "data:ingest:start", data: ^ingestion}}, 1_000
+
+      refute_receive {:brook_event, %Brook.Event{type: "data:ingest:start", data: ^ingestion}},
+                     1_000
     end
 
     test "should send #{data_extract_end()} when processor is completed" do
-      allow Reaper.DataExtract.Processor.process(any(), any()), return: :ok
+      allow(Reaper.DataExtract.Processor.process(any(), any()), return: :ok)
       ingestion = TDG.create_ingestion(%{id: "ds3"})
-      Brook.Test.with_event(@instance_name, fn -> Reaper.Collections.Extractions.update_ingestion(ingestion) end)
+
+      Brook.Test.with_event(@instance_name, fn ->
+        Reaper.Collections.Extractions.update_ingestion(ingestion)
+      end)
+
       Brook.Test.send(@instance_name, data_extract_start(), :reaper, ingestion)
 
       assert_receive {:brook_event, %Brook.Event{type: data_extract_end(), data: ingestion}}
@@ -150,7 +189,7 @@ defmodule Reaper.Event.EventHandlerTest do
   describe "#{data_extract_end()}" do
     test "should persist last fetched timestamp" do
       date = DateTime.utc_now()
-      allow DateTime.utc_now(), return: date, meck_options: [:passthrough]
+      allow(DateTime.utc_now(), return: date, meck_options: [:passthrough])
       ingestion = TDG.create_ingestion(%{id: "ing1", targetDataset: "ds1"})
       send_data_extract_end(ingestion.id, ingestion.targetDataset, 0, Timex.to_unix(date))
 
@@ -162,24 +201,58 @@ defmodule Reaper.Event.EventHandlerTest do
     end
   end
 
+  describe "#{dataset_delete()}" do
+    @tag focus: true
+    test "should delete associated raw topic when dataset:delete event fires" do
+      dataset = TDG.create_dataset(id: "dataset_id", technical: %{sourceType: "ingest"})
+
+      non_matching_ingestion = TDG.create_ingestion(%{id: 1, targetDataset: "other_dataset"})
+      matching_ingestion = TDG.create_ingestion(%{id: 2, targetDataset: "dataset_id"})
+      another_matching_ingestion = TDG.create_ingestion(%{id: 3, targetDataset: "dataset_id"})
+
+      mock_view_state = %{
+        1 => %{
+          "ingestion" => non_matching_ingestion
+        },
+        2 => %{
+          "ingestion" => matching_ingestion
+        },
+        3 => %{
+          "ingestion" => another_matching_ingestion
+        }
+      }
+
+      allow(IngestionDelete.handle(any()), return: :ok)
+      allow(Brook.ViewState.get_all(@instance_name, :extractions), return: {:ok, mock_view_state})
+
+      Brook.Test.send(@instance_name, dataset_delete(), :reaper, dataset)
+
+      assert_called(IngestionDelete.handle(matching_ingestion))
+      assert_called(IngestionDelete.handle(another_matching_ingestion))
+      refute_called(IngestionDelete.handle(non_matching_ingestion))
+    end
+  end
+
   describe "#{ingestion_delete()}" do
     test "successfully deletes an ingestion when event is sent" do
       ingestion = TDG.create_ingestion(%{id: "ds9"})
 
-      allow Reaper.Event.Handlers.IngestionDelete.handle(any()), return: :result_not_relevant
-      allow Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid}
+      allow(Reaper.Event.Handlers.IngestionDelete.handle(any()), return: :result_not_relevant)
+      allow(Horde.DynamicSupervisor.start_child(any(), any()), return: {:ok, :pid})
 
       Brook.Test.send(@instance_name, data_extract_start(), :author, ingestion)
       Brook.Test.send(@instance_name, ingestion_delete(), :author, ingestion)
 
       eventually(fn ->
         assert nil == Brook.get!(@instance_name, :extractions, ingestion.id)
-        assert_called Reaper.Event.Handlers.IngestionDelete.handle(ingestion)
+        assert_called(Reaper.Event.Handlers.IngestionDelete.handle(ingestion))
       end)
     end
 
     test "sends error event for raised errors while performing ingestion update" do
-      allow(Reaper.Event.Handlers.IngestionUpdate.handle(any()), exec: fn _ -> raise "bad stuff" end)
+      allow(Reaper.Event.Handlers.IngestionUpdate.handle(any()),
+        exec: fn _ -> raise "bad stuff" end
+      )
 
       ingestion = TDG.create_ingestion(%{})
 

--- a/apps/reaper/test/unit/reaper/event/event_handler_test.exs
+++ b/apps/reaper/test/unit/reaper/event/event_handler_test.exs
@@ -202,7 +202,6 @@ defmodule Reaper.Event.EventHandlerTest do
   end
 
   describe "#{dataset_delete()}" do
-    @tag focus: true
     test "should delete associated raw topic when dataset:delete event fires" do
       dataset = TDG.create_dataset(id: "dataset_id", technical: %{sourceType: "ingest"})
 


### PR DESCRIPTION
## [Ticket Link #902](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/902)

## Description

When creating an ingestion from a dataset, a raw stream is made in kafka. When this dataset is deleted, nothing was cleaning up this stream.

Now Reaper will respond to dataset:delete events, and find and clean the relevant streams.


Example of it working locally:

![Screen Shot 2022-11-02 at 9 05 20 AM](https://user-images.githubusercontent.com/54278348/199512297-727c6652-8fa3-48d5-86b1-5750e043c4d2.png)

To make this happen, I used andi to create a dataset, then an ingestion, then deleted the dataset. Previously this would have kept the `raw-` stream.


## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] ~~If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
