### PR TITLE
added error result to http responses

### DIFF
--- a/apps/reaper/lib/reaper/data_slurper/http.ex
+++ b/apps/reaper/lib/reaper/data_slurper/http.ex
@@ -30,6 +30,7 @@ defmodule Reaper.DataSlurper.Http do
       Logger.error(fn ->
         "Unable to retrieve data for #{ingestion_id}: #{Exception.message(error)}"
       end)
+
       reraise inspect(error), __STACKTRACE__
   end
 

--- a/apps/reaper/lib/reaper/data_slurper/http.ex
+++ b/apps/reaper/lib/reaper/data_slurper/http.ex
@@ -30,8 +30,7 @@ defmodule Reaper.DataSlurper.Http do
       Logger.error(fn ->
         "Unable to retrieve data for #{ingestion_id}: #{Exception.message(error)}"
       end)
-
-      reraise error, __STACKTRACE__
+      reraise inspect(error), __STACKTRACE__
   end
 
   defp download(ingestion_id, url, filename, headers, protocol, action, body) do
@@ -44,6 +43,6 @@ defmodule Reaper.DataSlurper.Http do
       raise HttpDownloadTimeoutError, message
 
     :exit, error ->
-      reraise error, __STACKTRACE__
+      reraise inspect(error), __STACKTRACE__
   end
 end

--- a/apps/reaper/lib/reaper/http/downloader.ex
+++ b/apps/reaper/lib/reaper/http/downloader.ex
@@ -118,6 +118,10 @@ defmodule Reaper.Http.Downloader do
     {:ok, response}
   end
 
+  defp stream_responses({response, %Mint.HTTPError{} = reason}, _opts) do
+    {:error, response.conn, reason}
+  end
+
   defp stream_responses({response, file}, opts) do
     idle_timeout = Keyword.get(opts, :idle_timeout, :infinity)
 
@@ -161,6 +165,10 @@ defmodule Reaper.Http.Downloader do
 
   defp handle_http_message({:done, _request_ref}, {response, file}) do
     {%{response | done: true}, file}
+  end
+
+  defp handle_http_message({:error, _request_ref, reason}, {response, _file}) do
+    {response, reason}
   end
 
   defp handle_status(%Response{status: 200} = response, _headers) do

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.14",
+      version: "2.0.16",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/test/unit/reaper/data_slurper/http_test.exs
+++ b/apps/reaper/test/unit/reaper/data_slurper/http_test.exs
@@ -81,14 +81,15 @@ defmodule Reaper.DataSlurper.HttpTest do
 
       url = "http://localhost:#{bypass.port}/some/johnson.csv"
 
-      expected_message = "%Reaper.DataSlurper.Http.HttpDownloadTimeoutError{message: \"Timed out downloading ingestion #{@ingestion_id} at #{url} in 1 ms\"}"
+      expected_message =
+        "%Reaper.DataSlurper.Http.HttpDownloadTimeoutError{message: \"Timed out downloading ingestion #{@ingestion_id} at #{
+          url
+        } in 1 ms\"}"
 
       assert_raise RuntimeError, expected_message, fn ->
         DataSlurper.Http.slurp(url, @ingestion_id)
       end
     end
-
-    #RuntimeError ()
 
     test "makes call with headers", %{bypass: bypass} do
       file_url = "/some/other/csv-file2.csv"

--- a/apps/reaper/test/unit/reaper/data_slurper/http_test.exs
+++ b/apps/reaper/test/unit/reaper/data_slurper/http_test.exs
@@ -81,12 +81,14 @@ defmodule Reaper.DataSlurper.HttpTest do
 
       url = "http://localhost:#{bypass.port}/some/johnson.csv"
 
-      expected_message = "Timed out downloading ingestion #{@ingestion_id} at #{url} in 1 ms"
+      expected_message = "%Reaper.DataSlurper.Http.HttpDownloadTimeoutError{message: \"Timed out downloading ingestion #{@ingestion_id} at #{url} in 1 ms\"}"
 
-      assert_raise DataSlurper.Http.HttpDownloadTimeoutError, expected_message, fn ->
+      assert_raise RuntimeError, expected_message, fn ->
         DataSlurper.Http.slurp(url, @ingestion_id)
       end
     end
+
+    #RuntimeError ()
 
     test "makes call with headers", %{bypass: bypass} do
       file_url = "/some/other/csv-file2.csv"


### PR DESCRIPTION
## [Ticket Link #885](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/885)

## Description

- added an error handling portion for when a website will return :ok, but with an error message, which seems to break ingestion consumption.

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  ~~- [ ] If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
~~- [ ] If altering an API endpoint, was the relevant postman collection updated?~~
  ~~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
