### PR TITLE
Add endpoint to publish ingestion

### DIFF
--- a/apps/andi/lib/andi_web/router.ex
+++ b/apps/andi/lib/andi_web/router.ex
@@ -78,6 +78,7 @@ defmodule AndiWeb.Router do
     get "/v1/ingestion/:ingestion_id", IngestionController, :get
     put "/v1/dataset", DatasetController, :create
     put "/v1/ingestion", IngestionController, :create
+    post "/v1/ingestion/publish", IngestionController, :publish
     post "/v1/dataset/disable", DatasetController, :disable
     post "/v1/dataset/delete", DatasetController, :delete
     post "/v1/ingestion/delete", IngestionController, :delete

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.7",
+      version: "2.4.8",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #889](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/889)

## Description

There currently isn't an endpoint for publishing a draft ingestion. This PR refactors out the function that publishes (via brook event) so it's less closely tied to the button in andi, and then calls it when a specific endpoint is hit.

## Reminders:
- [ x Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [x] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [x] If altering an API endpoint, was the relevant postman collection updated? 
  - [x] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
