### PR TITLE
XML with topLevelSelector

### DIFF
--- a/apps/alchemist/config/integration.exs
+++ b/apps/alchemist/config/integration.exs
@@ -16,7 +16,7 @@ config :logger,
 config :alchemist,
   elsa_brokers: endpoints,
   input_topic_prefix: "raw",
-  output_topic_prefix: "validated",
+  output_topic_prefix: "transformed",
   profiling_enabled: true,
   divo: [
     {DivoKafka,

--- a/apps/alchemist/config/integration.exs
+++ b/apps/alchemist/config/integration.exs
@@ -16,7 +16,7 @@ config :logger,
 config :alchemist,
   elsa_brokers: endpoints,
   input_topic_prefix: "raw",
-  output_topic_prefix: "transformed",
+  output_topic_prefix: "validated",
   profiling_enabled: true,
   divo: [
     {DivoKafka,

--- a/apps/andi/assets/css/app.scss
+++ b/apps/andi/assets/css/app.scss
@@ -117,6 +117,10 @@ body {
   border-radius: 2px;
 }
 
+.disable-focus {
+  outline: none;
+}
+
 .input--text:read-only {
   background: #f3f3f3;
   color: $disabled-background;

--- a/apps/andi/assets/css/finalize_form.scss
+++ b/apps/andi/assets/css/finalize_form.scss
@@ -12,7 +12,6 @@
         .finalize-form__schedule-option-label {
             color: #000000;
             letter-spacing: 0.03rem;
-            margin-left: 0.5rem;
         }
     }
 

--- a/apps/andi/config/integration.exs
+++ b/apps/andi/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-System.put_env("AUTH0_DOMAIN", "project-hercules.us.auth0.com")
-System.put_env("AUTH0_CLIENT_ID", "VHr6xrLKUMsLg1AZYXXLgJBI3LOhcLbY")
+System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
+System.put_env("AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
 
 host =
   case System.get_env("HOST_IP") do
@@ -75,8 +75,8 @@ config :andi, :brook,
   ]
 
 config :andi, :auth0,
-  url: "https://project-hercules.us.auth0.com/oauth/token",
-  audience: "https://project-hercules.us.auth0.com/api/v2/"
+  url: "https://urbanos-dev.us.auth0.com/oauth/token",
+  audience: "https://urbanos-dev.us.auth0.com/api/v2/"
 
 config :andi, AndiWeb.Endpoint,
   pubsub_server: Andi.PubSub,
@@ -126,12 +126,12 @@ config :ueberauth, Ueberauth,
   ]
 
 config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
-  domain: "project-hercules.us.auth0.com",
-  client_id: "VHr6xrLKUMsLg1AZYXXLgJBI3LOhcLbY",
+  domain: "urbanos-dev.us.auth0.com",
+  client_id: "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa",
   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
 config :andi, AndiWeb.Auth.TokenHandler,
-  issuer: "https://project-hercules.us.auth0.com/",
+  issuer: "https://urbanos-dev.us.auth0.com/",
   allowed_algos: ["RS256"],
   verify_issuer: false,
   allowed_drift: 3_000_000_000_000

--- a/apps/andi/config/test.exs
+++ b/apps/andi/config/test.exs
@@ -27,7 +27,7 @@ config :andi,
   access_level: :private
 
 config :andi, AndiWeb.Auth.TokenHandler,
-  issuer: "https://project-hercules.us.auth0.com/",
+  issuer: "https://urbanos-dev.us.auth0.com/",
   allowed_algos: ["RS256"],
   verify_issuer: false,
   allowed_drift: 3_000_000_000_000

--- a/apps/andi/lib/andi_web/input_schemas/ingestion_metatadata_form_schema.ex
+++ b/apps/andi/lib/andi_web/input_schemas/ingestion_metatadata_form_schema.ex
@@ -10,12 +10,14 @@ defmodule AndiWeb.InputSchemas.IngestionMetadataFormSchema do
     field(:name, :string)
     field(:sourceFormat, :string)
     field(:targetDataset, :string)
+    field(:topLevelSelector, :string)
   end
 
   @cast_fields [
     :name,
     :sourceFormat,
-    :targetDataset
+    :targetDataset,
+    :topLevelSelector
   ]
 
   @required_fields [
@@ -30,6 +32,7 @@ defmodule AndiWeb.InputSchemas.IngestionMetadataFormSchema do
     current
     |> cast(changes, @cast_fields, empty_values: [])
     |> validate_required(@required_fields, message: "is required")
+    |> validate_top_level_selector()
     |> target_dataset_exists()
   end
 
@@ -42,8 +45,13 @@ defmodule AndiWeb.InputSchemas.IngestionMetadataFormSchema do
   defp target_dataset_exists(changeset) do
     validate_change(changeset, :targetDataset, fn :targetDataset, targetDataset ->
       case Andi.InputSchemas.Datasets.get(targetDataset) do
-        nil -> [targetDataset: "Dataset with id: #{targetDataset} does not exist. It may have been deleted."]
-        _ -> []
+        nil ->
+          [
+            targetDataset: "Dataset with id: #{targetDataset} does not exist. It may have been deleted."
+          ]
+
+        _ ->
+          []
       end
     end)
   end
@@ -54,4 +62,19 @@ defmodule AndiWeb.InputSchemas.IngestionMetadataFormSchema do
     |> AtomicMap.convert(safe: false, underscore: false)
     |> changeset()
   end
+
+  defp validate_top_level_selector(%{changes: %{sourceFormat: source_format}} = changeset)
+       when source_format in ["xml", "text/xml"] do
+    validate_required(changeset, [:topLevelSelector], message: "is required")
+  end
+
+  defp validate_top_level_selector(%{changes: %{sourceFormat: source_format, topLevelSelector: top_level_selector}} = changeset)
+       when source_format in ["json", "application/json"] do
+    case Jaxon.Path.parse(top_level_selector) do
+      {:error, error_msg} -> add_error(changeset, :topLevelSelector, error_msg.message)
+      _ -> changeset
+    end
+  end
+
+  defp validate_top_level_selector(changeset), do: changeset
 end

--- a/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/data_dictionary/data_dictionary_field_editor.ex
@@ -17,6 +17,7 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
     id = Atom.to_string(assigns.id)
     form_with_errors = DataDictionaryHelpers.add_errors_to_form(assigns.form)
     field_type = input_value(assigns.form, :type)
+    editing_ingestion? = assigns.dataset_or_ingestion == :ingestion
 
     ~L"""
       <div id="<%= @id %>" class="data-dictionary-field-editor" >
@@ -30,11 +31,19 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
           <%= text_input(@form, :name, [id: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
+
+        <%= if editing_ingestion? do %>
         <div class="data-dictionary-field-editor__selector">
-          <%= label(@form, :selector, "Selector", class: "label label--required") %>
+          <%= if DataDictionaryHelpers.is_source_format_xml(@source_format) do %>
+            <%= label(@form, :selector, "Selector", class: "label label--required") %>
+          <% else %>
+            <%= label(@form, :selector, "Selector", class: "label") %>
+          <% end %>
           <%= text_input(@form, :selector, [id: id <> "_name", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
         </div>
+        <% end %>
+
         <div class="data-dictionary-field-editor__type">
           <%= label(@form, :type, "Type", class: "label label--required") %>
           <%= select(@form, :type, DataDictionaryHelpers.get_item_types(), [id: id <> "_type", class: "data-dictionary-field-editor__type select", required: true]) %>

--- a/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view/data_dictionary_form.ex
@@ -125,7 +125,7 @@ defmodule AndiWeb.EditLiveView.DataDictionaryForm do
 
               <div class="data-dictionary-form__edit-section">
                 <%= if @is_curator do %>
-                  <%= live_component(@socket, AndiWeb.DataDictionary.FieldEditor, id: :data_dictionary_field_editor, form: @current_data_dictionary_item) %>
+                  <%= live_component(@socket, AndiWeb.DataDictionary.FieldEditor, id: :data_dictionary_field_editor, form: @current_data_dictionary_item, dataset_or_ingestion: :dataset) %>
                 <% else %>
                   <%= live_component(@socket, AndiWeb.SubmitLiveView.DataDictionaryFieldEditor, id: :data_dictionary_field_editor, form: @current_data_dictionary_item) %>
                 <% end %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary_form.ex
@@ -119,7 +119,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
               </div>
 
               <div class="data-dictionary-form__edit-section">
-                  <%= live_component(@socket, AndiWeb.DataDictionary.FieldEditor, id: :data_dictionary_field_editor, form: @current_data_dictionary_item, source_format: @sourceFormat) %>
+                  <%= live_component(@socket, AndiWeb.DataDictionary.FieldEditor, id: :data_dictionary_field_editor, form: @current_data_dictionary_item, source_format: @sourceFormat, dataset_or_ingestion: :ingestion) %>
               </div>
             </div>
           </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -198,6 +198,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
         :ok ->
           Ingestions.update_submission_status(ingestion_id, :published)
           Andi.Schemas.AuditEvents.log_audit_event(user_id, ingestion_update(), smrt_ingestion)
+          AndiWeb.Endpoint.broadcast_from(self(), "ingestion-published", "ingestion-published", %{})
 
         error ->
           Logger.warn("Unable to create new SmartCity.Ingestion: #{inspect(error)}")

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
@@ -9,11 +9,13 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
   alias AndiWeb.ErrorHelpers
   alias AndiWeb.Helpers.MetadataFormHelpers
   alias AndiWeb.IngestionLiveView.FormUpdate
+  alias AndiWeb.Views.DisplayNames
 
   def mount(_, %{"ingestion" => ingestion}, socket) do
     changeset = IngestionMetadataFormSchema.changeset_from_andi_ingestion(ingestion)
     AndiWeb.Endpoint.subscribe("form-save")
     AndiWeb.Endpoint.subscribe("source-format")
+    ingestion_published? = ingestion.submissionStatus == :published
 
     {:ok,
      assign(socket,
@@ -21,6 +23,7 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
        select_dataset_modal_visibility: "hidden",
        search_results: [],
        search_text: "",
+       ingestion_published?: ingestion_published?,
        selected_dataset: ingestion.targetDataset,
        ingestion_id: ingestion.id
      )}
@@ -34,11 +37,23 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
         <%= text_input(f, :name, [class: "ingestion-name input ingestion-form-fields", phx_debounce: "1000", required: true]) %>
         <%= ErrorHelpers.error_tag(f, :name, bind_to_input: false) %>
       </div>
+
       <div class="ingestion-metadata-form ingestion-metadata-form__format">
         <%= label(f, :sourceFormat, "Source Format", class: "label label--required") %>
-        <%= select(f, :sourceFormat, MetadataFormHelpers.get_source_format_options(), [class: "select ingestion-form-fields", required: true]) %>
+        <%= select(f, :sourceFormat, MetadataFormHelpers.get_source_format_options(), [class: "select ingestion-form-fields", required: true, disabled: @ingestion_published?]) %>
         <%= ErrorHelpers.error_tag(f, :sourceFormat, bind_to_input: false) %>
       </div>
+
+      <div class="metadata-form__top-level-selector">
+        <%= label(f, :topLevelSelector, DisplayNames.get(:topLevelSelector), class: MetadataFormHelpers.top_level_selector_label_class(input_value(f, :sourceFormat))) %>
+        <%= if input_value(f, :sourceFormat) not in ["xml", "json", "text/xml", "application/json"] do %>
+          <%= text_input(f, :emptyValue, [class: "input--text input disable-focus", readonly: true]) %>
+        <% else %>
+          <%= text_input(f, :topLevelSelector, [class: "input--text input"]) %>
+        <% end %>
+        <%= ErrorHelpers.error_tag(f, :topLevelSelector) %>
+      </div>
+
       <div class="ingestion-metadata-form ingestion-metadata-form__target-dataset">
         <%= label(f, :targetDatasetName, "Dataset Name", class: "label label--required") %>
         <%= hidden_input(f, :targetDataset, value: @selected_dataset) %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/metadata_form.ex
@@ -14,6 +14,7 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
   def mount(_, %{"ingestion" => ingestion}, socket) do
     changeset = IngestionMetadataFormSchema.changeset_from_andi_ingestion(ingestion)
     AndiWeb.Endpoint.subscribe("form-save")
+    AndiWeb.Endpoint.subscribe("ingestion-published")
     AndiWeb.Endpoint.subscribe("source-format")
     ingestion_published? = ingestion.submissionStatus == :published
 
@@ -78,6 +79,13 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
     valid? = if status == :ok, do: "valid", else: "invalid"
     FormUpdate.send_value(socket.parent_pid, {:update_save_message, valid?})
     {:noreply, socket}
+  end
+
+  def handle_info(
+        %{topic: "ingestion-published"},
+        socket
+      ) do
+    {:noreply, assign(socket, ingestion_published?: true)}
   end
 
   def handle_event("select-dataset", _, socket) do

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.19",
+      version: "2.4.20",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.21",
+      version: "2.4.22",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/data_dictionary_field_editor_test_ingestion_view.exs
+++ b/apps/andi/test/integration/andi_web/live/data_dictionary_field_editor_test_ingestion_view.exs
@@ -1,0 +1,38 @@
+defmodule AndiWeb.EditLiveView.CuratorDataDictionaryFieldEditorTest do
+  use ExUnit.Case
+  use Andi.DataCase
+  use AndiWeb.Test.AuthConnCase.IntegrationCase
+  import Phoenix.LiveViewTest
+  import Checkov
+
+  @moduletag shared_data_connection: true
+
+  alias IngestionHelpers
+
+  import FlokiHelpers,
+    only: [
+      get_attributes: 3
+    ]
+
+  @ingestions_url_path "/ingestions/"
+
+  test "xml selector is *disabled* when source type is *not* xml", %{conn: conn} do
+    {:ok, ingestion} =
+      IngestionHelpers.create_ingestion(%{sourceFormat: "text/csv"})
+      |> IngestionHelpers.save_ingestion()
+
+    {:ok, _view, html} = live(conn, @ingestions_url_path <> ingestion.id)
+
+    refute Enum.empty?(get_attributes(html, ".data-dictionary-field-editor__selector", "disabled"))
+  end
+
+  test "xml selector is *enabled* when source type *is* xml", %{conn: conn} do
+    {:ok, ingestion} =
+      IngestionHelpers.create_ingestion(%{sourceFormat: "text/xml"})
+      |> IngestionHelpers.save_ingestion()
+
+    {:ok, _view, html} = live(conn, @ingestions_url_path <> ingestion.id)
+
+    assert Enum.empty?(get_attributes(html, ".data-dictionary-field-editor__selector", "disabled"))
+  end
+end

--- a/apps/andi/test/integration/andi_web/live/data_dictionary_field_editor_test_submission_view.exs
+++ b/apps/andi/test/integration/andi_web/live/data_dictionary_field_editor_test_submission_view.exs
@@ -1,4 +1,4 @@
-defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
+defmodule AndiWeb.EditLiveView.PublicDataDictionaryFieldEditorTest do
   use ExUnit.Case
   use AndiWeb.Test.PublicAccessCase
   use Andi.DataCase
@@ -27,7 +27,9 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
   @url_path "/submissions/"
   @ingestions_url_path "/ingestions/"
 
-  test "type-info input is not displayed when type is neither list, date, nor timestamp", %{conn: conn} do
+  test "type-info input is not displayed when type is neither list, date, nor timestamp", %{
+    conn: conn
+  } do
     smrt_dataset = TDG.create_dataset(%{technical: %{schema: [%{name: "one", type: "string"}]}})
 
     {:ok, dataset} = Datasets.update(smrt_dataset)
@@ -40,7 +42,11 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
 
   test "item type selector is shown when field type is a list", %{conn: conn} do
     field_id = UUID.uuid4()
-    smrt_dataset = TDG.create_dataset(%{technical: %{schema: [%{id: field_id, name: "one", itemType: "string", type: "list"}]}})
+
+    smrt_dataset =
+      TDG.create_dataset(%{
+        technical: %{schema: [%{id: field_id, name: "one", itemType: "string", type: "list"}]}
+      })
 
     {:ok, dataset} = Datasets.update(smrt_dataset)
 
@@ -51,19 +57,33 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
 
   test "item type selector does not allow list of lists", %{conn: conn} do
     field_id = UUID.uuid4()
-    smrt_dataset = TDG.create_dataset(%{technical: %{schema: [%{id: field_id, name: "one", itemType: "list", type: "list"}]}})
+
+    smrt_dataset =
+      TDG.create_dataset(%{
+        technical: %{schema: [%{id: field_id, name: "one", itemType: "list", type: "list"}]}
+      })
 
     {:ok, dataset} = Datasets.update(smrt_dataset)
 
     {:ok, _, html} = live(conn, @url_path <> dataset.id)
 
     refute Enum.empty?(find_elements(html, "#itemType-error-msg"))
-    assert {"List", "list"} not in get_all_select_options(html, ".data-dictionary-field-editor__item-type")
+
+    assert {"List", "list"} not in get_all_select_options(
+             html,
+             ".data-dictionary-field-editor__item-type"
+           )
   end
 
   data_test "format input is shown when field type is #{field}", %{conn: conn} do
     field_id = UUID.uuid4()
-    smrt_dataset = TDG.create_dataset(%{technical: %{schema: [%{id: field_id, name: "one", type: field, format: "{ISO:Extended}"}]}})
+
+    smrt_dataset =
+      TDG.create_dataset(%{
+        technical: %{
+          schema: [%{id: field_id, name: "one", type: field, format: "{ISO:Extended}"}]
+        }
+      })
 
     {:ok, dataset} = Datasets.update(smrt_dataset)
 
@@ -84,7 +104,9 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
     case field_type do
       "select" ->
         assert get_select(html, ".data-dictionary-field-editor__#{selector_name}") == []
-        assert get_select_first_option(html, ".data-dictionary-field-editor__#{selector_name}") == {"", []}
+
+        assert get_select_first_option(html, ".data-dictionary-field-editor__#{selector_name}") ==
+                 {"", []}
 
       "text" ->
         assert get_value(html, ".data-dictionary-field-editor__#{selector_name}") == nil
@@ -101,15 +123,6 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
       ["biased", "select"],
       ["rationale", "text"]
     ])
-  end
-
-  test "xml selector is disabled when source type is not xml", %{conn: conn} do
-    smrt_dataset = TDG.create_dataset(%{technical: %{sourceFormat: "text/csv"}})
-    {:ok, dataset} = Datasets.update(smrt_dataset)
-
-    {:ok, _view, html} = live(conn, @url_path <> dataset.id)
-
-    refute Enum.empty?(get_attributes(html, ".data-dictionary-field-editor__selector", "disabled"))
   end
 
   describe "validation" do
@@ -157,7 +170,8 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
 
       {:ok, _view, html} = live(conn, @url_path <> dataset.id)
 
-      assert Enum.empty?(find_elements(html, ".data-dictionary-field-editor__name > .error-msg")) == valid?
+      assert Enum.empty?(find_elements(html, ".data-dictionary-field-editor__name > .error-msg")) ==
+               valid?
 
       where([
         [:name, :valid?],
@@ -173,11 +187,19 @@ defmodule AndiWeb.EditLiveView.DataDictionaryFieldEditorTest do
 
   describe "certain fields in the data dictionary editor are unavailable for non curator users" do
     setup %{public_subject: public_subject} do
-      {:ok, public_user} = Andi.Schemas.User.create_or_update(public_subject, %{email: "bob@example.com", name: "Bob"})
+      {:ok, public_user} =
+        Andi.Schemas.User.create_or_update(public_subject, %{
+          email: "bob@example.com",
+          name: "Bob"
+        })
+
       [public_user: public_user]
     end
 
-    data_test "PII, Rationale, Demographics, Bias fields are removed", %{public_conn: conn, public_user: public_user} do
+    data_test "PII, Rationale, Demographics, Bias fields are removed", %{
+      public_conn: conn,
+      public_user: public_user
+    } do
       blank_dataset = %Dataset{id: UUID.uuid4(), technical: %{}, business: %{}}
 
       {:ok, andi_dataset} = Datasets.update(blank_dataset)

--- a/apps/andi/test/integration/andi_web/live/metadata_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/metadata_form_test.exs
@@ -577,24 +577,6 @@ defmodule AndiWeb.MetadataFormTest do
       assert get_text(html, "#issuedDate-error-msg") == ""
     end
 
-    # todo: ticket #757 will move this test to an /ingestions page test
-    @tag :skip
-    test "displays error when topLevelSelector jpath is invalid", %{conn: conn} do
-      smrt_dataset = TDG.create_dataset(%{})
-
-      {:ok, dataset} =
-        InputConverter.smrt_dataset_to_draft_changeset(smrt_dataset)
-        |> Datasets.save()
-
-      assert {:ok, view, html} = live(conn, @url_path <> dataset.id)
-      metadata_view = find_live_child(view, "metadata_form_editor")
-
-      form_data = %{"sourceFormat" => "application/json", "topLevelSelector" => "$.data[x]"}
-      html = render_change(metadata_view, :validate, %{"form_data" => form_data})
-
-      assert get_text(html, "#topLevelSelector-error-msg") == "Error: Expected an integer at `x]`"
-    end
-
     test "dataset owner lists all the users in the system by email", %{conn: conn} do
       smrt_dataset = TDG.create_dataset(%{})
       {:ok, user} = User.create_or_update("64d1c660-4734-4b96-96e4-075f7ac9ae30", %{email: "hello@world.com", name: "Hello World"})

--- a/apps/andi/test/unit/andi_web/input_schemas/ingestion_metadata_form_schema_test.exs
+++ b/apps/andi/test/unit/andi_web/input_schemas/ingestion_metadata_form_schema_test.exs
@@ -48,6 +48,22 @@ defmodule AndiWeb.InputSchemas.IngestionMetadataFormSchemaTest do
       assert changeset.errors == [{:name, {"is required", [validation: :required]}}]
     end
 
+    test "displays error when topLevelSelector json Jaxon validation is invalid" do
+      badJsonPath = "$.data[x]"
+
+      form_data = %{
+        sourceFormat: "application/json",
+        targetDataset: "Dataset Name",
+        name: "ingestion123",
+        topLevelSelector: badJsonPath
+      }
+
+      allow(Andi.InputSchemas.Datasets.get(any()), return: %{id: "dataset_id"})
+      changeset = IngestionMetadataFormSchema.changeset_from_form_data(form_data)
+      refute changeset.valid?
+      assert changeset.errors == [{:topLevelSelector, {"Expected an integer at `x]`", []}}]
+    end
+
     test "generates a changeset with errors when targetDataset is absent" do
       form_data = %{
         sourceFormat: "csv",

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/metadata_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/metadata_form_test.exs
@@ -22,7 +22,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
 
   describe "name field" do
     test "can be updated" do
-      ingestion = TDG.create_ingestion(%{name: "Original"})
+      ingestion = create_ingestion(%{name: "Original"})
       allow Ingestions.get(ingestion.id), return: ingestion
       allow Ingestions.update(ingestion, %{name: "Updated"}), return: {:ok, ingestion}
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
@@ -41,7 +41,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
     end
 
     test "shows an error if blank" do
-      ingestion = TDG.create_ingestion(%{})
+      ingestion = create_ingestion(%{})
       form_data = %{"name" => ""}
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
 
@@ -56,7 +56,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
 
   describe "source format" do
     test "can be updated" do
-      ingestion = TDG.create_ingestion(%{sourceFormat: "text/xml"})
+      ingestion = create_ingestion(%{sourceFormat: "text/xml"})
       allow Ingestions.get(ingestion.id), return: ingestion
       allow Ingestions.update(ingestion, any()), return: {:ok, ingestion}
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
@@ -75,7 +75,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
     end
 
     test "shows an error if blank" do
-      ingestion = TDG.create_ingestion(%{})
+      ingestion = create_ingestion(%{})
       form_data = %{"sourceFormat" => ""}
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
 
@@ -90,7 +90,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
 
   describe "selected dataset" do
     test "button opens select dataset modal" do
-      ingestion = TDG.create_ingestion(%{})
+      ingestion = create_ingestion(%{})
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
       assert {:ok, view, html} = live_isolated(build_conn(), MetadataForm, session: %{"ingestion" => ingestion})
       assert element(view, ".manage-datasets-modal--hidden") |> has_element?
@@ -100,7 +100,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
     end
 
     test "form can be updated" do
-      ingestion = TDG.create_ingestion(%{})
+      ingestion = create_ingestion(%{})
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
       assert {:ok, view, html} = live_isolated(build_conn(), MetadataForm, session: %{"ingestion" => ingestion})
       assert element(view, ".manage-datasets-modal--hidden") |> has_element?
@@ -109,7 +109,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
     end
 
     test "shows an error if blank" do
-      ingestion = TDG.create_ingestion(%{})
+      ingestion = create_ingestion(%{})
       form_data = %{"targetDatasetName" => ""}
       allow Datasets.get(any()), return: nil
 
@@ -122,7 +122,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
     end
 
     test "shows an error if there is a target dataset that does not exist in the database" do
-      ingestion = TDG.create_ingestion(%{})
+      ingestion = create_ingestion(%{})
       form_data = %{"targetDataset" => "id_of_deleted_dataset"}
       allow Datasets.get(any()), return: nil
 
@@ -140,7 +140,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
 
   describe "after successful save" do
     test "notify if no missing fields" do
-      ingestion = TDG.create_ingestion(%{name: "Validity Is Great"})
+      ingestion = create_ingestion(%{name: "Validity Is Great"})
       allow Ingestions.get(ingestion.id), return: ingestion
       allow Ingestions.update(any(), any()), return: {:ok, ingestion}
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
@@ -155,7 +155,7 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
     end
 
     test "notify if required fields missing" do
-      ingestion = TDG.create_ingestion(%{name: ""})
+      ingestion = create_ingestion(%{name: ""})
       allow Ingestions.get(ingestion.id), return: ingestion
       allow Ingestions.update(any(), any()), return: {:error, %Ecto.Changeset{errors: [name: {"is required", []}]}}
       allow Datasets.get(any()), return: %{business: %{dataTitle: "Dataset Name"}}
@@ -172,5 +172,9 @@ defmodule AndiWeb.Unit.IngestionLiveView.MetadataFormTest do
 
   defp find_select_dataset_btn(view) do
     element(view, ".btn", "Select Dataset")
+  end
+
+  def create_ingestion(overrides) do
+    ingestion = TDG.create_ingestion(overrides) |> Map.put(:submissionStatus, :draft)
   end
 end

--- a/apps/discovery_api/config/integration.exs
+++ b/apps/discovery_api/config/integration.exs
@@ -114,7 +114,7 @@ config :discovery_api, DiscoveryApi.Repo,
   port: "5456"
 
 config :discovery_api, DiscoveryApiWeb.Auth.TokenHandler,
-  issuer: "https://project-hercules.us.auth0.com/",
+  issuer: "https://urbanos-dev.us.auth0.com/",
   allowed_algos: ["RS256"],
   verify_issuer: false,
   allowed_drift: 3_000_000_000_000

--- a/apps/discovery_api/config/test.exs
+++ b/apps/discovery_api/config/test.exs
@@ -42,7 +42,7 @@ config :discovery_api,
   user_visualization_limit: 4
 
 config :discovery_api, DiscoveryApiWeb.Auth.TokenHandler,
-  issuer: "https://project-hercules.us.auth0.com/",
+  issuer: "https://urbanos-dev.us.auth0.com/",
   allowed_algos: ["RS256"],
   verify_issuer: false,
   allowed_drift: 3_000_000_000_000

--- a/apps/raptor/config/integration.exs
+++ b/apps/raptor/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-System.put_env("AUTH0_DOMAIN", "project-hercules.us.auth0.com")
-System.put_env("AUTH0_CLIENT_ID", "VHr6xrLKUMsLg1AZYXXLgJBI3LOhcLbY")
+System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
+System.put_env("AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
 
 host = "localhost"
 endpoints = [{to_charlist(host), 9092}]
@@ -13,8 +13,8 @@ config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
 config :raptor, :auth0,
-  url: "https://project-hercules.us.auth0.com/oauth/token",
-  audience: "https://project-hercules.us.auth0.com/api/v2/"
+  url: "https://urbanos-dev.us.auth0.com/oauth/token",
+  audience: "https://urbanos-dev.us.auth0.com/api/v2/"
 
 config :raptor, RaptorWeb.Endpoint,
   url: [scheme: "https", host: "data.integrationtests.example.com", port: 443],


### PR DESCRIPTION
## [Ticket Link #757](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/757)

## Description

- topLevelSelector now shows in ingestion metadata
  - this enables xml ingestions
  - tests that used to test this on datasets have been moved to ingestions
  - topLevelSelector validation with Jaxon is restored from pre-ingestion introduction

- DataDictionaryFieldEditor used to show topLeveISelector field when editing a dataset. This was meaningless, as the field would never have any effect. It is now removed for dataset edits but enabled for ingestions.
  - It used to be marked as required always, despite being disabled when non xml sourceFormats were selected. It's required `*` symbol now aligns when it is disabled or active.

- Ingestion sourceFormat cannot be altered once an ingestion has been published.
  - This is a requirement of the urbanos system, that was not being enforced by the UI. The test to ensure formats cannot be altered is reinstated.

Bonus:

- Default auth0 tenant for local dev to the proper UrbanOS-dev tenant, utilized currently by product. Not the AIP hercules environment. Once merged, will need to update your local auth0 secret value, will notify the team when that happens
- Adjusted finalize form radio options to align with header, like other inputs in the section

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] ~~If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~

## Images:

| data from xml, json, json with selector all in trino |
| --- |
| <img width="865" alt="image" src="https://user-images.githubusercontent.com/33632286/202322196-47f2e478-2cee-4a40-8378-c81467ea931c.png"> |

| ingestions for those three defined in andi |
| --- |
| <img width="738" alt="image" src="https://user-images.githubusercontent.com/33632286/202322285-64523df4-08bf-4861-a655-094b8d55bf8f.png"> |

 

