### PR TITLE
docker-compose add platform to enforce emulation on M1 docker

### DIFF
--- a/apps/andi/docker-compose.yml
+++ b/apps/andi/docker-compose.yml
@@ -3,12 +3,14 @@ version: '3.4'
 services:
   init:
     image: alpine:3.16.0
+    platform: linux/amd64
     volumes:
       - ${PWD}/test/integration:/workdir
       - minio:/minio
     entrypoint: /workdir/setup.sh
   minio:
     image: minio/minio:RELEASE.2022-10-15T19-57-03Z.fips
+    platform: linux/amd64
     command: server /data --console-address ":9001"
     volumes:
       - minio:/data
@@ -19,6 +21,7 @@ services:
       - init
   ecto-postgres:
     image: postgres:14.4-alpine
+    platform: linux/amd64
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -27,10 +30,12 @@ services:
       - "5456:5432"
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
     - zookeeper
     ports:
@@ -52,6 +57,7 @@ services:
 
   kafka-init:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
       - kafka
     entrypoint: ['/bin/bash', '-c']
@@ -68,6 +74,7 @@ services:
 
   redis:
     image: redis:latest
+    platform: linux/amd64
     ports:
       - "6379:6379"
 

--- a/apps/discovery_api/test/integration/docker-compose.yaml
+++ b/apps/discovery_api/test/integration/docker-compose.yaml
@@ -2,12 +2,14 @@
 version: '3.4'
 services:
   init:
+    platform: linux/amd64
     image: alpine:3.16.0
     volumes:
       - ${PWD}/test/integration:/workdir
       - minio:/minio
     entrypoint: /workdir/setup.sh
   metastore:
+    platform: linux/amd64
     image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
     depends_on:
     - postgres
@@ -29,6 +31,7 @@ services:
       DATABASE_NAME: metastore
 
   postgres:
+    platform: linux/amd64
     image: postgres:14.4-alpine
     environment:
       POSTGRES_USER: hive
@@ -37,6 +40,7 @@ services:
     ports:
       - "5455:5432"
   ecto-postgres:
+    platform: linux/amd64
     image: postgres:14.4-alpine
     environment:
       POSTGRES_USER: postgres
@@ -45,6 +49,7 @@ services:
     ports:
       - "5456:5432"
   minio:
+    platform: linux/amd64
     image: minio/minio:RELEASE.2022-10-15T19-57-03Z.fips
     command: server /data --console-address ":9001"
     volumes:
@@ -58,6 +63,7 @@ services:
     depends_on:
     - metastore
     - minio
+    platform: linux/amd64
     image: trinodb/trino:389
     ports:
     - "8080:8080"
@@ -70,10 +76,12 @@ services:
       - ${PWD}/test/integration/hive.properties:/etc/trino/catalog/hive.properties
 
   zookeeper:
+    platform: linux/amd64
     image: wurstmeister/zookeeper
     ports:
     - "2181:2181"
   kafka:
+    platform: linux/amd64
     image: bitnami/kafka:3.1.2
     depends_on:
     - zookeeper
@@ -92,11 +100,13 @@ services:
       timeout: 20s
       retries: 3
   redis:
+    platform: linux/amd64
     image: redis:latest
     ports:
       - "6379:6379"
 
   elasticsearch:
+    platform: linux/amd64
     image: elasticsearch:7.4.2
     ports:
     - "9200:9200"

--- a/apps/discovery_streams/docker-compose.yml
+++ b/apps/discovery_streams/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:4.1.0
+    platform: linux/amd64
     ports:
       - 2181:2181
     environment:
@@ -12,6 +13,7 @@ services:
       - "moby:127.0.0.1"
   kafka:
     image: confluentinc/cp-kafka:4.1.0
+    platform: linux/amd64
     ports:
       - 9092:9092
       - 9093:9093
@@ -30,6 +32,7 @@ services:
     build:
       context: .
     image: consumer
+    platform: linux/amd64
     depends_on:
       - kafka
     ports:

--- a/apps/e2e/test/docker-compose.yml
+++ b/apps/e2e/test/docker-compose.yml
@@ -3,12 +3,14 @@ version: '3.4'
 services:
   init:
     image: alpine:3.16.0
+    platform: linux/amd64
     volumes:
       - ${PWD}/test:/workdir
       - minio:/minio
     entrypoint: /workdir/setup.sh
   metastore:
     image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+    platform: linux/amd64
     depends_on:
     - postgres
     - minio
@@ -27,9 +29,9 @@ services:
       POSTGRES_SQL_SERVICE_HOST: postgres
       POSTGRES_SQL_SERVICE_PORT: 5432
       DATABASE_NAME: metastore
-
   postgres:
     image: smartcitiesdata/postgres-testo:0.9.12
+    platform: linux/amd64
     ports:
       - "5455:5432"
   ecto-postgres:
@@ -42,6 +44,7 @@ services:
       - "5456:5432"
   minio:
     image: minio/minio:RELEASE.2022-10-15T19-57-03Z.fips
+    platform: linux/amd64
     command: server /data --console-address ":9001"
     volumes:
       - minio:/data
@@ -55,6 +58,7 @@ services:
     - metastore
     - minio
     image: trinodb/trino:389
+    platform: linux/amd64
     ports:
     - "8080:8080"
     healthcheck:
@@ -64,13 +68,14 @@ services:
       retries: 10
     volumes:
       - ${PWD}/test/hive.properties:/etc/trino/catalog/hive.properties
-
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
     - zookeeper
     ports:
@@ -87,14 +92,14 @@ services:
       interval: 10s
       timeout: 20s
       retries: 3
-
   redis:
     image: redis:latest
+    platform: linux/amd64
     ports:
       - "6379:6379"
-
   elasticsearch:
     image: elasticsearch:7.4.2
+    platform: linux/amd64
     ports:
     - "9200:9200"
     - "9300:9300"

--- a/apps/forklift/docker-compose.yml
+++ b/apps/forklift/docker-compose.yml
@@ -3,12 +3,14 @@ version: '3.4'
 services:
   init:
     image: alpine:3.16.0
+    platform: linux/amd64
     volumes:
       - ${PWD}/test/integration:/workdir
       - minio:/minio
     entrypoint: /workdir/setup.sh
   metastore:
     image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+    platform: linux/amd64
     depends_on:
     - postgres
     - minio
@@ -32,10 +34,12 @@ services:
     logging:
       driver: none
     image: smartcitiesdata/postgres-testo:development
+    platform: linux/amd64
     ports:
     - "5432:5432"
   minio:
     image: minio/minio:RELEASE.2022-10-15T19-57-03Z.fips
+    platform: linux/amd64
     command: server /data --console-address ":9001"
     volumes:
       - minio:/data
@@ -49,6 +53,7 @@ services:
     - metastore
     - minio
     image: trinodb/trino:389
+    platform: linux/amd64
     ports:
     - "8080:8080"
     healthcheck:
@@ -61,10 +66,12 @@ services:
 
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
     - zookeeper
     ports:
@@ -86,6 +93,7 @@ services:
 
   kafka-init:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
       - kafka
     entrypoint: ['/bin/bash', '-c']
@@ -102,6 +110,7 @@ services:
 
   redis:
     image: redis:latest
+    platform: linux/amd64
     ports:
       - "6379:6379"
 

--- a/apps/pipeline/docker-compose.yml
+++ b/apps/pipeline/docker-compose.yml
@@ -3,12 +3,14 @@ version: '3.4'
 services:
   init:
     image: alpine:3.16.0
+    platform: linux/amd64
     volumes:
       - ${PWD}/test/integration:/workdir
       - minio:/minio
     entrypoint: /workdir/setup.sh
   metastore:
     image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+    platform: linux/amd64
     depends_on:
     - postgres
     - minio
@@ -32,10 +34,12 @@ services:
     logging:
       driver: none
     image: smartcitiesdata/postgres-testo:development
+    platform: linux/amd64
     ports:
     - "5432:5432"
   minio:
     image: minio/minio:RELEASE.2022-10-15T19-57-03Z.fips
+    platform: linux/amd64
     command: server /data --console-address ":9001"
     volumes:
       - minio:/data
@@ -49,6 +53,7 @@ services:
     - metastore
     - minio
     image: trinodb/trino:389
+    platform: linux/amd64
     ports:
     - "8080:8080"
     healthcheck:
@@ -61,10 +66,12 @@ services:
 
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
     - zookeeper
     ports:
@@ -86,6 +93,7 @@ services:
 
   kafka-init:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
       - kafka
     entrypoint: ['/bin/bash', '-c']

--- a/apps/raptor/test/integration/docker-compose.yaml
+++ b/apps/raptor/test/integration/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3"
 services:
   redis:
     image: redis
+    platform: linux/amd64
     ports:
       - "6379:6379"
     healthcheck:
@@ -11,11 +12,13 @@ services:
       retries: 3
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     container_name: zookeeper
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     container_name: kafka
     depends_on:
     - zookeeper

--- a/apps/reaper/docker-compose.yml
+++ b/apps/reaper/docker-compose.yml
@@ -3,12 +3,14 @@ version: '3.4'
 services:
   init:
     image: alpine:3.16.0
+    platform: linux/amd64
     volumes:
       - ${PWD}/test/integration:/workdir
       - minio:/minio
     entrypoint: /workdir/setup.sh
   minio:
     image: minio/minio:RELEASE.2022-10-15T19-57-03Z.fips
+    platform: linux/amd64
     command: server /data --console-address ":9001"
     volumes:
       - minio:/data
@@ -19,10 +21,12 @@ services:
       - init
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
     - zookeeper
     ports:
@@ -44,6 +48,7 @@ services:
 
   kafka-init:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     depends_on:
       - kafka
     entrypoint: ['/bin/bash', '-c']
@@ -60,10 +65,12 @@ services:
 
   redis:
     image: redis:latest
+    platform: linux/amd64
     ports:
       - "6379:6379"
   sftp:
     image: atmoz/sftp:alpine
+    platform: linux/amd64
     ports: 
      - "2222:22"
     command: "sftp_user:sftp_password:1001::upload"

--- a/apps/template/test/integration/docker-compose.yaml
+++ b/apps/template/test/integration/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3"
 services:
   redis:
     image: redis
+    platform: linux/amd64
     ports:
       - "6379:6379"
     healthcheck:
@@ -11,11 +12,13 @@ services:
       retries: 3
   zookeeper:
     image: wurstmeister/zookeeper
+    platform: linux/amd64
     container_name: zookeeper
     ports:
     - "2181:2181"
   kafka:
     image: bitnami/kafka:3.1.2
+    platform: linux/amd64
     container_name: kafka
     depends_on:
     - zookeeper


### PR DESCRIPTION
## Description

- Adding platform tag so that m1 emulates containers

## Note:
Platform tags still might be needed in Alchemist, Valkyrie, Disc Streams, Dead Letter, Definition Kafka, and Flair since their integration suite doesn't use a docker-compose. It uses DivoKafka and DivoRedis packages. Need to learn more about how those are spin up but, 

## Reminders:
Don't think I need to do any of these because it's just docker file changes to aid in local development with integration tests only. No impact on built images.

- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
