### PR TITLE
933 spike regen api key

### DIFF
--- a/apps/discovery_api/config/config.exs
+++ b/apps/discovery_api/config/config.exs
@@ -14,7 +14,7 @@ config :discovery_api, DiscoveryApiWeb.Endpoint,
   pubsub_server: DiscoveryApi.PubSub,
   instrumenters: [DiscoveryApiWeb.Endpoint.Instrumenter],
   http: [
-    port: 4000,
+    port: 4001,
     stream_handlers: [Web.StreamHandlers.StripServerHeader, :cowboy_stream_h],
     protocol_options: [idle_timeout: idle_timeout]
   ]

--- a/apps/raptor/lib/raptor/services/auth0_management_service.ex
+++ b/apps/raptor/lib/raptor/services/auth0_management_service.ex
@@ -28,13 +28,14 @@ defmodule Raptor.Services.Auth0Management do
 
   def patch_api_key(userID, apiKey) do
     #TODO: Test
-    url = Keyword.fetch!(auth0(), :audience)
-    IO.puts("1")
+    audience = Keyword.fetch!(auth0(), :audience)
+    url = "#{audience}users/#{userID}"
+    IO.inspect(url, label: "URL")
     {:ok, access_token} = get_token()
     IO.puts("2")
     body = '{"app_metadata": {"apiKey": "#{apiKey}"}}'
-    headers = [{"Authorization", "Bearer #{access_token}"}]
-    {:ok, response} = HTTPoison.patch("#{url}users/#{userID}}", body, headers, [])
+    headers = [{"Authorization", "Bearer #{access_token}"}, {"Content-Type", "application/json"}]
+    {:ok, response} = HTTPoison.patch(url, body, headers, [])
     IO.puts("3")
     IO.inspect(response, label: "Patch Response")
 
@@ -67,11 +68,13 @@ defmodule Raptor.Services.Auth0Management do
 
     case post(url, req_body, headers: [{"content-type", "application/x-www-form-urlencoded"}]) do
       {:ok, response} ->
+        IO.inspect(response, label: "Auth response")
         access_token = response |> Map.get(:body) |> Jason.decode!() |> Map.get("access_token")
-        IO.inspect(access_token, label: "Auth response access token")
+        IO.inspect(access_token, label: "Auth access token")
         {:ok, access_token}
 
       {_, error} ->
+        IO.inspect(error, label: "Auth Error")
         {:error, error}
     end
   end

--- a/apps/raptor/lib/raptor/services/auth0_management_service.ex
+++ b/apps/raptor/lib/raptor/services/auth0_management_service.ex
@@ -26,6 +26,13 @@ defmodule Raptor.Services.Auth0Management do
     end
   end
 
+  def patch_api_key(apiKey) do
+    #TODO: Test
+    url = Keyword.fetch!(auth0(), :audience)
+
+    IO.inspect(url, label: "Auth0 URL")
+  end
+
   defp client_id() do
     ueberauth_config = Application.get_env(:ueberauth, Ueberauth.Strategy.Auth0.OAuth)
 

--- a/apps/raptor/lib/raptor/services/auth0_management_service.ex
+++ b/apps/raptor/lib/raptor/services/auth0_management_service.ex
@@ -26,11 +26,19 @@ defmodule Raptor.Services.Auth0Management do
     end
   end
 
-  def patch_api_key(apiKey) do
+  def patch_api_key(userID, apiKey) do
     #TODO: Test
     url = Keyword.fetch!(auth0(), :audience)
+    IO.puts("1")
+    {:ok, access_token} = get_token()
+    IO.puts("2")
+    body = '{"app_metadata": {"apiKey": "#{apiKey}"}}'
+    headers = [{"Authorization", "Bearer #{access_token}"}]
+    {:ok, response} = HTTPoison.patch("#{url}users/#{userID}}", body, headers, [])
+    IO.puts("3")
+    IO.inspect(response, label: "Patch Response")
 
-    IO.inspect(url, label: "Auth0 URL")
+
   end
 
   defp client_id() do
@@ -60,6 +68,7 @@ defmodule Raptor.Services.Auth0Management do
     case post(url, req_body, headers: [{"content-type", "application/x-www-form-urlencoded"}]) do
       {:ok, response} ->
         access_token = response |> Map.get(:body) |> Jason.decode!() |> Map.get("access_token")
+        IO.inspect(access_token, label: "Auth response access token")
         {:ok, access_token}
 
       {_, error} ->

--- a/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
@@ -2,23 +2,32 @@ defmodule RaptorWeb.ApiKeyController do
   use RaptorWeb, :controller
 
   alias Raptor.Services.Auth0Management
+  alias Raptor.Services.DatasetStore
+  alias Raptor.Services.UserOrgAssocStore
+  alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Services.DatasetAccessGroupRelationStore
   require Logger
 
   plug(:accepts, ["json"])
 
   def regenerateApiKey(conn, %{"auth0_user" => user}) do
+    #TODO: Test
     IO.inspect(user, label: "Auth0 User")
 
-    newApiKey = randomApiKey()
-    response = Auth0Management.patch_api_key(newApiKey)
-
+    new_api_key = randomApiKey(24)
+    response = Auth0Management.patch_api_key(new_api_key)
+    render(conn, %{apiKey: new_api_key})
   end
 
   def regenerateApiKey(conn, _) do
+    #TODO: Test
       render_error(conn, 400, "user_id is a required parameter")
     end
 
-  defp randomApiKey() do
-    "iliketuttles"
+  defp randomApiKey(length) do
+    #TODO: Test
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64()
+    |> binary_part(0, length)
   end
 end

--- a/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
@@ -1,0 +1,24 @@
+defmodule RaptorWeb.ApiKeyController do
+  use RaptorWeb, :controller
+
+  alias Raptor.Services.Auth0Management
+  require Logger
+
+  plug(:accepts, ["json"])
+
+  def regenerateApiKey(conn, %{"auth0_user" => user}) do
+    IO.inspect(user, label: "Auth0 User")
+
+    newApiKey = randomApiKey()
+    response = Auth0Management.patch_api_key(newApiKey)
+
+  end
+
+  def regenerateApiKey(conn, _) do
+      render_error(conn, 400, "user_id is a required parameter")
+    end
+
+  defp randomApiKey() do
+    "iliketuttles"
+  end
+end

--- a/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
@@ -10,12 +10,12 @@ defmodule RaptorWeb.ApiKeyController do
 
   plug(:accepts, ["json"])
 
-  def regenerateApiKey(conn, %{"auth0_user" => user}) do
+  def regenerateApiKey(conn, %{"user_id" => user_id}) do
     #TODO: Test
-    IO.inspect(user, label: "Auth0 User")
+    IO.inspect(user_id, label: "user_id")
 
     new_api_key = randomApiKey(24)
-    response = Auth0Management.patch_api_key(new_api_key)
+    response = Auth0Management.patch_api_key(user_id, new_api_key)
     render(conn, %{apiKey: new_api_key})
   end
 

--- a/apps/raptor/lib/raptor_web/router.ex
+++ b/apps/raptor/lib/raptor_web/router.ex
@@ -9,5 +9,6 @@ defmodule RaptorWeb.Router do
     pipe_through :api
     get("/authorize", AuthorizeController, :authorize)
     get("/listAccessGroups", ListAccessGroupsController, :list)
+    patch("/regenerateApiKey", ApiKeyController, :regenerateApiKey)
   end
 end

--- a/apps/raptor/lib/raptor_web/views/api_key_view.ex
+++ b/apps/raptor/lib/raptor_web/views/api_key_view.ex
@@ -1,0 +1,9 @@
+defmodule RaptorWeb.ApiKeyView do
+  use RaptorWeb, :view
+
+  def render("regenerateApiKey.json", %{apiKey: apiKey}) do
+    %{
+      apiKey: apiKey
+    }
+  end
+end

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -44,7 +44,8 @@ defmodule Raptor.MixProject do
       {:telemetry_event, in_umbrella: true},
       {:tesla, "~> 1.3"},
       {:ueberauth_auth0, "~> 0.8.1"},
-      {:distillery, "~> 2.1"}
+      {:distillery, "~> 2.1"},
+      {:httpoison, "~> 1.5"},
     ]
   end
 

--- a/apps/raptor_service/lib/raptor_service.ex
+++ b/apps/raptor_service/lib/raptor_service.ex
@@ -70,6 +70,22 @@ defmodule RaptorService do
     end
   end
 
+  def regenerate_api_key_for_user(raptor_url, user_id) do
+    case HTTPoison.patch(url_for_api_key_regeneration(raptor_url, user_id)) do
+      {:ok, %{body: body}} ->
+        {:ok, apiKey} = Jason.decode(body)
+        apiKey
+
+      error ->
+        Logger.error("Raptor failed to regenerate api key with error: #{inspect(error)}")
+        "Something went wrong"
+    end
+  end
+
+  defp url_for_api_key_regeneration(raptor_url, user_id) do
+    "#{raptor_url}/regenerateApiKey?user_id=#{user_id}"
+    end
+
   defp list_url_with_api_key_params(raptor_url, nil) do
     "#{raptor_url}/listAccessGroups"
   end

--- a/apps/raptor_service/lib/raptor_service.ex
+++ b/apps/raptor_service/lib/raptor_service.ex
@@ -71,7 +71,7 @@ defmodule RaptorService do
   end
 
   def regenerate_api_key_for_user(raptor_url, user_id) do
-    case HTTPoison.patch(url_for_api_key_regeneration(raptor_url, user_id)) do
+    case HTTPoison.patch(url_for_api_key_regeneration(raptor_url, user_id), body: %{"user_id" => user_id}) do
       {:ok, %{body: body}} ->
         {:ok, apiKey} = Jason.decode(body)
         apiKey


### PR DESCRIPTION
## [Ticket Link #933](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/933)

## Description

Spike code for API key regeneration through raptor

## Reminders:
- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
