### PR TITLE
fix immediate ingestion bug

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
@@ -243,7 +243,13 @@ defmodule AndiWeb.IngestionLiveView.FinalizeForm do
   defp complete_validation(changeset, socket) do
     new_changeset = Map.put(changeset, :action, :update)
     cadence = Ecto.Changeset.get_field(changeset, :cadence)
-    Ingestions.update_cadence(socket.assigns.ingestion_id, cadence)
+
+    # Call update_cadence here as there is a disconnect between the form validation in this file, and the Ingestions schema required field validation
+    # Only call update_cadence when it equals "once" for immedate cadence, as scheduled cadences call update_cadence on their own
+    if cadence == "once" do
+      Ingestions.update_cadence(socket.assigns.ingestion_id, cadence)
+    end
+
     repeat_ingestion? = cadence not in ["once", "never", nil]
     send(socket.parent_pid, :form_update)
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
@@ -243,6 +243,7 @@ defmodule AndiWeb.IngestionLiveView.FinalizeForm do
   defp complete_validation(changeset, socket) do
     new_changeset = Map.put(changeset, :action, :update)
     cadence = Ecto.Changeset.get_field(changeset, :cadence)
+    Ingestions.update_cadence(socket.assigns.ingestion_id, cadence)
     repeat_ingestion? = cadence not in ["once", "never", nil]
     send(socket.parent_pid, :form_update)
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/finalize_form.ex
@@ -244,8 +244,6 @@ defmodule AndiWeb.IngestionLiveView.FinalizeForm do
     new_changeset = Map.put(changeset, :action, :update)
     cadence = Ecto.Changeset.get_field(changeset, :cadence)
 
-    # Call update_cadence here as there is a disconnect between the form validation in this file, and the Ingestions schema required field validation
-    # Only call update_cadence when it equals "once" for immedate cadence, as scheduled cadences call update_cadence on their own
     if cadence == "once" do
       Ingestions.update_cadence(socket.assigns.ingestion_id, cadence)
     end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.24",
+      version: "2.4.25",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/finalize_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/finalize_form_test.exs
@@ -1,0 +1,49 @@
+defmodule AndiWeb.Unit.IngestionLiveView.FinalizeFormTest do
+  use ExUnit.Case
+  use Placebo
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  import SmartCity.TestHelper, only: [eventually: 1]
+
+  alias AndiWeb.IngestionLiveView.FinalizeForm
+
+  alias Andi.InputSchemas.Ingestions
+  alias AndiWeb.IngestionLiveView.FormUpdate
+  alias AndiWeb.IngestionLiveView.MetadataForm
+  alias Andi.InputSchemas.Datasets
+  alias AndiWeb.InputSchemas.FinalizeFormSchema
+  alias Phoenix.LiveView
+  alias SmartCity.TestDataGenerator, as: TDG
+
+  @endpoint AndiWeb.Endpoint
+
+  setup do
+    allow FormUpdate.send_value(any(), any()), return: {:ok}
+    :ok
+  end
+
+  describe "Immediate cadence selection" do
+    test "Fires update_cadence when complete_validation is called with cadence of 'once'", %{} do
+      conn = Phoenix.ConnTest.build_conn()
+
+      form_data = %{cadence: "once"}
+      ingestion_id = "foo"
+      socket = %Phoenix.LiveView.Socket{assigns: %{
+          ingestion_id: ingestion_id,
+          visibility: "hidden"
+        },
+        parent_pid: conn.owner
+      }
+
+      expect(FinalizeFormSchema.changeset_from_form_data(form_data), return: %Ecto.Changeset{
+          changes: form_data,
+          data: %FinalizeFormSchema{},
+          types: %{}
+        })
+      expect(Ingestions.update_cadence(ingestion_id, form_data.cadence), return: nil)
+
+      FinalizeForm.handle_event("validate", %{"form_data" => form_data}, socket)
+    end
+  end
+end

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/finalize_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/finalize_form_test.exs
@@ -2,35 +2,22 @@ defmodule AndiWeb.Unit.IngestionLiveView.FinalizeFormTest do
   use ExUnit.Case
   use Placebo
 
-  import Phoenix.ConnTest
+  import Phoenix.ConnTest, only: [build_conn: 0]
   import Phoenix.LiveViewTest
-  import SmartCity.TestHelper, only: [eventually: 1]
 
   alias AndiWeb.IngestionLiveView.FinalizeForm
-
   alias Andi.InputSchemas.Ingestions
-  alias AndiWeb.IngestionLiveView.FormUpdate
-  alias AndiWeb.IngestionLiveView.MetadataForm
-  alias Andi.InputSchemas.Datasets
   alias AndiWeb.InputSchemas.FinalizeFormSchema
   alias Phoenix.LiveView
-  alias SmartCity.TestDataGenerator, as: TDG
-
-  @endpoint AndiWeb.Endpoint
-
-  setup do
-    allow FormUpdate.send_value(any(), any()), return: {:ok}
-    :ok
-  end
 
   describe "Immediate cadence selection" do
     test "Fires update_cadence when complete_validation is called with cadence of 'once'", %{} do
-      conn = Phoenix.ConnTest.build_conn()
+      conn = build_conn()
 
       form_data = %{cadence: "once"}
       ingestion_id = "foo"
 
-      socket = %Phoenix.LiveView.Socket{
+      socket = %LiveView.Socket{
         assigns: %{
           ingestion_id: ingestion_id,
           visibility: "hidden"

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/finalize_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/finalize_form_test.exs
@@ -29,18 +29,23 @@ defmodule AndiWeb.Unit.IngestionLiveView.FinalizeFormTest do
 
       form_data = %{cadence: "once"}
       ingestion_id = "foo"
-      socket = %Phoenix.LiveView.Socket{assigns: %{
+
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{
           ingestion_id: ingestion_id,
           visibility: "hidden"
         },
         parent_pid: conn.owner
       }
 
-      expect(FinalizeFormSchema.changeset_from_form_data(form_data), return: %Ecto.Changeset{
+      expect(FinalizeFormSchema.changeset_from_form_data(form_data),
+        return: %Ecto.Changeset{
           changes: form_data,
           data: %FinalizeFormSchema{},
           types: %{}
-        })
+        }
+      )
+
       expect(Ingestions.update_cadence(ingestion_id, form_data.cadence), return: nil)
 
       FinalizeForm.handle_event("validate", %{"form_data" => form_data}, socket)


### PR DESCRIPTION
## [Ticket Link #955](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/955)

## Description

Fix the immediate ingestion bug

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [x] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [x] If altering an API endpoint, was the relevant postman collection updated?
  - [x] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
