### PR TITLE
964 Deny users blocked in Auth0

### DIFF
--- a/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
@@ -44,10 +44,10 @@ defmodule RaptorWeb.AuthorizeController do
       1 ->
         user = user_list |> Enum.at(0)
 
-        if(user["email_verified"]) do
+        if(user["email_verified"] and !user["blocked"]) do
           check_user_association(user, dataset)
         else
-          # Only users who have validated their email address may make API calls
+          # Only users who have validated their email address and aren't blocked may make API calls
           false
         end
 

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.2.11",
+      version: "1.2.12",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #964](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/964)

## Description

- Enforce that a user is not blocked in the Auth0 console

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] ~~If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
