### PR TITLE
Runtime for local development performs migrations

### DIFF
--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.3.6",
+      version: "1.3.7",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/runtime.exs
+++ b/apps/discovery_api/runtime.exs
@@ -233,3 +233,7 @@ config :telemetry_event,
 if System.get_env("RAPTOR_URL") do
   config :discovery_api, raptor_url: System.get_env("RAPTOR_URL")
 end
+
+if System.get_env("MIX_ENV") == "integration" do
+  DiscoveryApi.ReleaseTasks.migrate
+end

--- a/apps/e2e/test/docker-compose.yml
+++ b/apps/e2e/test/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - "5455:5432"
   ecto-postgres:
     image: postgres:14.4-alpine
+    platform: linux/amd64
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## Description

Discovery API was unable to be run locally because the migrations never ran - so the discovery postgres never was set up correctly.

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
