### PR TITLE
added REQUIRED_API_KEY logic to Discovery_Streams

### DIFF
--- a/apps/discovery_streams/config/integration.exs
+++ b/apps/discovery_streams/config/integration.exs
@@ -1,4 +1,5 @@
 use Mix.Config
+System.put_env("REQUIRE_API_KEY", "false")
 
 host = "127.0.0.1"
 endpoints = [{String.to_atom(host), 9092}]

--- a/apps/discovery_streams/config/test.exs
+++ b/apps/discovery_streams/config/test.exs
@@ -1,4 +1,5 @@
 use Mix.Config
+System.put_env("REQUIRE_API_KEY", "false")
 
 host = "127.0.0.1"
 endpoints = [{String.to_atom(host), 9092}]

--- a/apps/discovery_streams/lib/discovery_streams_web/channels/streaming_channel.ex
+++ b/apps/discovery_streams/lib/discovery_streams_web/channels/streaming_channel.ex
@@ -21,7 +21,9 @@ defmodule DiscoveryStreamsWeb.StreamingChannel do
   def join(channel, params, socket) do
     if System.get_env("REQUIRE_API_KEY") == "true" do
       case Map.get(params, "api_key") do
-        nil -> get_error_message(channel)
+        nil ->
+          get_error_message(channel)
+
         api_key ->
           case RaptorService.get_user_id_from_api_key(raptor_url(), api_key) do
             {:ok, _user_id} ->
@@ -40,7 +42,8 @@ defmodule DiscoveryStreamsWeb.StreamingChannel do
     system_name = determine_system_name(channel)
 
     case Brook.get(@instance_name, :streaming_datasets_by_system_name, system_name) do
-      {:ok, nil} -> get_error_message(channel)
+      {:ok, nil} ->
+        get_error_message(channel)
 
       {:ok, _dataset_id} ->
         api_key = params["api_key"]
@@ -52,13 +55,16 @@ defmodule DiscoveryStreamsWeb.StreamingChannel do
           get_error_message(channel)
         end
 
-      _ -> get_error_message(channel)
+      _ ->
+        get_error_message(channel)
     end
   end
 
-  defp get_error_message(channel), do: {:error, %{reason: "Channel #{channel} does not exist or you do not have access"}}
+  defp get_error_message(channel),
+    do: {:error, %{reason: "Channel #{channel} does not exist or you do not have access"}}
 
-  def get_error_status(channel, reason, status_code), do: {:error, %{reason: "Channel #{channel} gave error code #{status_code} with reason #{reason}"}}
+  def get_error_status(channel, reason, status_code),
+    do: {:error, %{reason: "Channel #{channel} gave error code #{status_code} with reason #{reason}"}}
 
   def handle_in(@filter_event, message, socket) do
     filter_rules = create_filter_rules(message)

--- a/apps/discovery_streams/lib/discovery_streams_web/channels/streaming_channel.ex
+++ b/apps/discovery_streams/lib/discovery_streams_web/channels/streaming_channel.ex
@@ -19,7 +19,7 @@ defmodule DiscoveryStreamsWeb.StreamingChannel do
   intercept([@update_event])
 
   def join(channel, params, socket) do
-    if String.downcase(System.get_env("REQUIRE_API_KEY")) == "true" do
+    if System.get_env("REQUIRE_API_KEY") == "true" do
       case Map.get(params, "api_key") do
         nil -> get_error_message(channel)
         api_key ->

--- a/apps/discovery_streams/mix.exs
+++ b/apps/discovery_streams/mix.exs
@@ -4,7 +4,7 @@ defmodule DiscoveryStreams.Mixfile do
   def project do
     [
       app: :discovery_streams,
-      version: "3.0.19",
+      version: "3.0.20",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_streams/test/unit/streaming_channel_test.exs
+++ b/apps/discovery_streams/test/unit/streaming_channel_test.exs
@@ -17,6 +17,7 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
     allow(RaptorService.is_authorized(any(), any(), any()),
       return: true
     )
+
     :ok
   end
 
@@ -149,11 +150,11 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
 
     test "joining a application with no api_key returns an error" do
       assert {:error, %{reason: "Channel streaming:shuttle-position does not exist or you do not have access"}} ==
-        subscribe_and_join(
-          socket(DiscoveryStreamsWeb.UserSocket),
-          DiscoveryStreamsWeb.StreamingChannel,
-          "streaming:shuttle-position"
-        )
+               subscribe_and_join(
+                 socket(DiscoveryStreamsWeb.UserSocket),
+                 DiscoveryStreamsWeb.StreamingChannel,
+                 "streaming:shuttle-position"
+               )
     end
 
     test "joining a application with api_key connects" do
@@ -178,12 +179,12 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
       )
 
       assert {:error, %{reason: "Channel streaming:shuttle-position gave error code 500 with reason reason"}} ==
-        subscribe_and_join(
-          socket(DiscoveryStreamsWeb.UserSocket),
-          DiscoveryStreamsWeb.StreamingChannel,
-          "streaming:shuttle-position",
-          %{"api_key" => "valid_api_key"}
-        )
+               subscribe_and_join(
+                 socket(DiscoveryStreamsWeb.UserSocket),
+                 DiscoveryStreamsWeb.StreamingChannel,
+                 "streaming:shuttle-position",
+                 %{"api_key" => "valid_api_key"}
+               )
     end
   end
 end

--- a/apps/discovery_streams/test/unit/streaming_channel_test.exs
+++ b/apps/discovery_streams/test/unit/streaming_channel_test.exs
@@ -17,7 +17,6 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
     allow(RaptorService.is_authorized(any(), any(), any()),
       return: true
     )
-
     :ok
   end
 
@@ -137,5 +136,54 @@ defmodule DiscoveryStreamsWeb.StreamingChannelTest do
     )
 
     assert_called(RaptorService.is_authorized("raptor.url", api_key, "shuttle-position"))
+  end
+
+  describe "REQUIRED_API_KEY" do
+    setup do
+      System.put_env("REQUIRE_API_KEY", "true")
+
+      on_exit(fn ->
+        System.put_env("REQUIRE_API_KEY", "false")
+      end)
+    end
+
+    test "joining a application with no api_key returns an error" do
+      assert {:error, %{reason: "Channel streaming:shuttle-position does not exist or you do not have access"}} ==
+        subscribe_and_join(
+          socket(DiscoveryStreamsWeb.UserSocket),
+          DiscoveryStreamsWeb.StreamingChannel,
+          "streaming:shuttle-position"
+        )
+    end
+
+    test "joining a application with api_key connects" do
+      allow(RaptorService.get_user_id_from_api_key(any(), any()),
+        return: {:ok, "user_id"}
+      )
+
+      {:ok, _, socket} =
+        subscribe_and_join(
+          socket(DiscoveryStreamsWeb.UserSocket),
+          DiscoveryStreamsWeb.StreamingChannel,
+          "streaming:shuttle-position",
+          %{"api_key" => "valid_api_key"}
+        )
+
+      leave(socket)
+    end
+
+    test "joining a application with invalid api_key returns an error" do
+      allow(RaptorService.get_user_id_from_api_key(any(), any()),
+        return: {:error, "reason", "500"}
+      )
+
+      assert {:error, %{reason: "Channel streaming:shuttle-position gave error code 500 with reason reason"}} ==
+        subscribe_and_join(
+          socket(DiscoveryStreamsWeb.UserSocket),
+          DiscoveryStreamsWeb.StreamingChannel,
+          "streaming:shuttle-position",
+          %{"api_key" => "valid_api_key"}
+        )
+    end
   end
 end


### PR DESCRIPTION
## [Ticket Link #936](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/936)

## Description

- This adds REQUIRED_API_KEY logic to Discovery_streams to block users that don't have valid API Keys from getting in

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  ~~- [ ] If updating Major or Minor versions , did you update the sauron chart configuration?~~ 
~~- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?~~
~~- [ ] If altering an API endpoint, was the relevant postman collection updated?~~
  ~~- [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
