### PR TITLE
Andi Select Labels ADA

### DIFF
--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_add_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_add_field_editor.ex
@@ -29,7 +29,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__name form-block">
                 <div class="form-input">
                   <%= label(form, :name, "Name", class: "label label--required") %>
-                  <%= text_input(form, :name, [id: id <> "_name", class: "input", required: true]) %>
+                  <%= text_input(form, :name, [class: "input", required: true]) %>
                 </div>
                 <%= error_tag(form, :name) %>
               </div>
@@ -37,7 +37,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__type form-block">
                 <div class="form-input">
                   <%= label(form, :type, "Type", class: "label label--required") %>
-                  <%= select(form, :type, get_item_types(), [id: id <> "_type", class: "select", required: true]) %>
+                  <%= select(form, :type, get_item_types(), [class: "select", required: true]) %>
                 </div>
                 <%= error_tag(form, :type) %>
               </div>
@@ -45,7 +45,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__parent-id form-block">
                 <div class="form-input">
                   <%= label(form, :parent_id, "Child Of", class: "label") %>
-                  <%= select(form, :parent_id, @eligible_parents, selected: @selected_field_id, id: id <> "_child-of", class: "select") %>
+                  <%= select(form, :parent_id, @eligible_parents, selected: @selected_field_id, class: "select") %>
                 </div>
               </div>
             </div>

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
@@ -35,7 +35,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
 
               <div class="user-form__organizations">
                 <%= label(:organization, :org_id, class: "label") %>
-                <%= select(:organiation, :org_id, MetadataFormHelpers.get_org_options(), [class: "select", readonly: true]) %>
+                <%= select(:organization, :org_id, MetadataFormHelpers.get_org_options(), [class: "select", readonly: true]) %>
                 <button type="submit" class="btn btn--add-organization btn--primary-outline">Add Organization</button>
               </div>
           </form>
@@ -134,11 +134,11 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
     end
   end
 
-  def handle_event("associate", %{"organiation" => %{"org_id" => ""}}, socket) do
+  def handle_event("associate", %{"organization" => %{"org_id" => ""}}, socket) do
     {:noreply, socket}
   end
 
-  def handle_event("associate", %{"organiation" => %{"org_id" => org_id}}, socket) do
+  def handle_event("associate", %{"organization" => %{"org_id" => org_id}}, socket) do
     user = socket.assigns.user
     send_event(org_id, user, socket.assigns.signed_in_user_id)
 

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
@@ -34,7 +34,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
               </div>
 
               <div class="user-form__organizations">
-                <%= label(:organization, :org_id, class: "label") %>
+                <%= label(:organization, :org_id, "Organization", class: "label") %>
                 <%= select(:organization, :org_id, MetadataFormHelpers.get_org_options(), [class: "select", readonly: true]) %>
                 <button type="submit" class="btn btn--add-organization btn--primary-outline">Add Organization</button>
               </div>

--- a/apps/andi/test/integration/andi_web/live/user_live_view/edit_user_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/user_live_view/edit_user_live_view_test.exs
@@ -117,12 +117,12 @@ defmodule AndiWeb.EditUserLiveViewTest do
 
       eventually(fn ->
         assert {:ok, view, html} = live(conn, @url_path <> user.id)
-        options = get_all_select_options(html, "#organiation_org_id")
+        options = get_all_select_options(html, "#organization_org_id")
         assert {"Please select an organization", ""} == List.first(options)
         assert {"Awesome Title", org_id} in options
       end)
 
-      render_change(view, "associate", %{"organiation" => %{"org_id" => org_id}})
+      render_change(view, "associate", %{"organization" => %{"org_id" => org_id}})
 
       eventually(fn ->
         user_subject_id = user.subject_id
@@ -147,8 +147,8 @@ defmodule AndiWeb.EditUserLiveViewTest do
       org2_id = org2.id
 
       # Associate to user
-      render_change(view, "associate", %{"organiation" => %{"org_id" => org_id}})
-      render_change(view, "associate", %{"organiation" => %{"org_id" => org2_id}})
+      render_change(view, "associate", %{"organization" => %{"org_id" => org_id}})
+      render_change(view, "associate", %{"organization" => %{"org_id" => org2_id}})
 
       eventually(fn ->
         user = User.get_by_subject_id(user.subject_id)


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/982)

## Description

Working on ADA requirements - specifically giving the selects in andi associated labels.
-----
<img width="659" alt="Screen Shot 2022-12-28 at 3 27 20 PM" src="https://user-images.githubusercontent.com/54278348/209873978-3f14c9ac-ae63-4be6-bff7-0cac5498113b.png">
-----
![image](https://user-images.githubusercontent.com/54278348/209874004-760eed25-a8aa-4fce-a06b-7fa6232b930e.png)


 

## Reminders:
- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
