### PR TITLE
Rework the main/header html positions for screen readers

### DIFF
--- a/apps/andi/lib/andi_web/live/access_group_live_view/access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/access_group_live_view.ex
@@ -11,7 +11,7 @@ defmodule AndiWeb.AccessGroupLiveView do
     ~L"""
     <div class="content">
       <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_access_groups_path()) %>
-      <div class="access-groups-view">
+      <main aria-label="Create and manage access groups"class="access-groups-view">
         <div class="access-groups-index">
           <div class="access-groups-index__header">
             <h1 class="access-groups-index__title">Access Groups</h1>
@@ -22,7 +22,7 @@ defmodule AndiWeb.AccessGroupLiveView do
           <hr class="access-groups-line">
           <%= live_component(@socket, Table, id: :access_groups_table, access_groups: @view_models, is_curator: @is_curator) %>
         </div>
-      </div>
+      </main>
       <%= footer_render(@is_curator) %>
     </div>
     """

--- a/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/edit_access_group_live_view.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_access_groups_path()) %>
-    <div class="edit-page" id="access-groups-edit-page">
+    <main aria-label="Edit Access Groups" class="edit-page" id="access-groups-edit-page">
       <div class="edit-access-group-title">
         <h1 class="component-title-text access-groups-component-title-text">Edit Access Group </h1>
       </div>
@@ -64,7 +64,7 @@ defmodule AndiWeb.AccessGroupLiveView.EditAccessGroupLiveView do
       </div>
 
       <%= live_component(@socket, AndiWeb.ConfirmDeleteModal, type: "Access Group", visibility: @delete_access_group_modal_visibility, id: @access_group.id) %>
-    </div>
+    </main>
     <%= footer_render(@is_curator) %>
     """
   end

--- a/apps/andi/lib/andi_web/live/common/footer_live_view.ex
+++ b/apps/andi/lib/andi_web/live/common/footer_live_view.ex
@@ -6,7 +6,7 @@ defmodule AndiWeb.FooterLiveView do
 
   def render(assigns) do
     ~L"""
-      <footer class="page-footer">
+      <footer class="page-footer" aria-label="Footer">
         <span class="left-side-text">
           <%= if get_left_side_link() do %>
             <a class="footer-link" href="<%= get_left_side_link() %>"><%= get_left_side_text() %></a>

--- a/apps/andi/lib/andi_web/live/common/header_live_view.ex
+++ b/apps/andi/lib/andi_web/live/common/header_live_view.ex
@@ -30,7 +30,7 @@ defmodule AndiWeb.HeaderLiveView do
 
   def render(assigns) do
     ~L"""
-    <header class="page-header">
+    <header role="banner" aria-label="Navigation and logout buttons" class="page-header">
       <span class="page-header__primary" phx-click="show-datasets">
         <img id="header-logo" src=<%= get_logo() %>></img>
         <span><%= get_header_text() %></span>

--- a/apps/andi/lib/andi_web/live/dataset_live_view/dataset_live_view.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/dataset_live_view.ex
@@ -23,7 +23,7 @@ defmodule AndiWeb.DatasetLiveView do
     ~L"""
     <div class="content">
       <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_datasets_path()) %>
-      <div class="datasets-view">
+      <main aria-label="Add and edit datasets" class="datasets-view">
         <div class="datasets-index">
           <div class="datasets-index__header">
             <h1 class="datasets-index__title"><%= title_text(@is_curator) %></h1>
@@ -66,7 +66,7 @@ defmodule AndiWeb.DatasetLiveView do
 
           <%= live_component(@socket, Table, id: :datasets_table, datasets: @view_models, order: @order, is_curator: @is_curator) %>
         </div>
-      </div>
+      </main>
       <%= footer_render(@is_curator) %>
     </div>
     """

--- a/apps/andi/lib/andi_web/live/dataset_live_view/edit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/edit_live_view.ex
@@ -17,7 +17,7 @@ defmodule AndiWeb.EditLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_datasets_path()) %>
-    <div class="edit-page" id="dataset-edit-page">
+    <main aria-label="Edit dataset" class="edit-page" id="dataset-edit-page">
       <div class="edit-dataset-title">
         <h1 class="component-title-text">Define Dataset</h1>
       </div>
@@ -89,8 +89,7 @@ defmodule AndiWeb.EditLiveView do
           <div id="snackbar" class="error-message">A page error occurred</div>
         <% end %>
       </div>
-
-    </div>
+    </main>
     <%= footer_render(@is_curator) %>
     """
   end

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_ingestions_path()) %>
-    <div class="edit-page" id="ingestions-edit-page">
+    <main aria-label="Edit Ingestion" class="edit-page" id="ingestions-edit-page">
       <%= f = form_for @changeset, "" %>
         <%= hidden_input(f, :sourceFormat) %>
         <div class="edit-ingestion-title">
@@ -77,7 +77,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
             <div id="snackbar" class="error-message">A page error occurred</div>
           <% end %>
       </div>
-    </div>
+    </main>
     <%= footer_render(@is_curator) %>
     """
   end

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/ingestion_live_view.ex
@@ -15,7 +15,7 @@ defmodule AndiWeb.IngestionLiveView do
     ~L"""
     <div class="content">
       <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_ingestions_path()) %>
-      <div class="ingestions-view">
+      <main aria-label="Add and Edit Ingestions" class="ingestions-view">
         <div class="ingestions-index">
           <div class="ingestions-index__header">
             <h1 class="ingestions-index__title">All Data Ingestions</h1>
@@ -26,7 +26,7 @@ defmodule AndiWeb.IngestionLiveView do
           <%= live_component(@socket, Table, id: :ingestions_table, ingestions: @view_models, is_curator: @is_curator) %>
 
         </div>
-      </div>
+      </main>
       <%= footer_render(@is_curator) %>
     </div>
     """

--- a/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
@@ -145,8 +145,7 @@ defmodule AndiWeb.EditOrganizationLiveView do
       |> AtomicMap.convert(safe: false, underscore: false)
       |> Organization.changeset()
 
-    {:noreply,
-     assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
+    {:noreply, assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
   end
 
   def handle_event("validate", %{"form_data" => form_data}, socket) do
@@ -155,8 +154,7 @@ defmodule AndiWeb.EditOrganizationLiveView do
       |> AtomicMap.convert(safe: false, underscore: false)
       |> Organization.changeset()
 
-    {:noreply,
-     assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
+    {:noreply, assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
   end
 
   def handle_event("validate_unique_org_name", _, socket) do

--- a/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
@@ -20,7 +20,7 @@ defmodule AndiWeb.EditOrganizationLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_organizations_path()) %>
-    <div id="edit-organization-live-view" class="organization-edit-page edit-page">
+    <main aria-label="Edit Organization" id="edit-organization-live-view" class="organization-edit-page edit-page">
       <div class="edit-organization-title">
         <h1 class="component-title-text">Edit Organization </h1>
       </div>
@@ -92,13 +92,16 @@ defmodule AndiWeb.EditOrganizationLiveView do
         <% end %>
 
       </div>
-
-    </div>
+    </main>
     <%= footer_render(@is_curator) %>
     """
   end
 
-  def mount(_params, %{"organization" => org, "is_curator" => is_curator, "user_id" => user_id}, socket) do
+  def mount(
+        _params,
+        %{"organization" => org, "is_curator" => is_curator, "user_id" => user_id},
+        socket
+      ) do
     changeset = Organization.changeset(org, %{}) |> Map.put(:errors, [])
 
     org_exists =
@@ -142,7 +145,8 @@ defmodule AndiWeb.EditOrganizationLiveView do
       |> AtomicMap.convert(safe: false, underscore: false)
       |> Organization.changeset()
 
-    {:noreply, assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
+    {:noreply,
+     assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
   end
 
   def handle_event("validate", %{"form_data" => form_data}, socket) do
@@ -151,7 +155,8 @@ defmodule AndiWeb.EditOrganizationLiveView do
       |> AtomicMap.convert(safe: false, underscore: false)
       |> Organization.changeset()
 
-    {:noreply, assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
+    {:noreply,
+     assign(socket, changeset: new_changeset, unsaved_changes: true, has_validation_errors: false)}
   end
 
   def handle_event("validate_unique_org_name", _, socket) do
@@ -164,7 +169,11 @@ defmodule AndiWeb.EditOrganizationLiveView do
   end
 
   def handle_event("cancel-edit", _, %{assigns: %{unsaved_changes: true}} = socket) do
-    {:noreply, assign(socket, unsaved_changes_modal_visibility: "visible", unsaved_changes_link: header_organizations_path())}
+    {:noreply,
+     assign(socket,
+       unsaved_changes_modal_visibility: "visible",
+       unsaved_changes_link: header_organizations_path()
+     )}
   end
 
   def handle_event("cancel-edit", _, socket) do
@@ -186,7 +195,11 @@ defmodule AndiWeb.EditOrganizationLiveView do
         |> Ecto.Changeset.apply_changes()
         |> InputConverter.andi_org_to_smrt_org()
 
-      Andi.Schemas.AuditEvents.log_audit_event(socket.assigns.user_id, organization_update(), smrt_org)
+      Andi.Schemas.AuditEvents.log_audit_event(
+        socket.assigns.user_id,
+        organization_update(),
+        smrt_org
+      )
 
       case Brook.Event.send(@instance_name, organization_update(), __MODULE__, smrt_org) do
         :ok ->

--- a/apps/andi/lib/andi_web/live/organization_live_view/organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view/organization_live_view.ex
@@ -16,7 +16,7 @@ defmodule AndiWeb.OrganizationLiveView do
     ~L"""
     <div class="content">
       <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_organizations_path()) %>
-      <div class="organizations-view">
+      <main aria-label="Add and manage organizations" class="organizations-view">
         <div class="organizations-index">
           <div class="organizations-index__header">
             <h1 class="organizations-index__title">All Organizations</h1>
@@ -45,7 +45,7 @@ defmodule AndiWeb.OrganizationLiveView do
 
           <%= live_component(@socket, Table, id: :organizations_table, organizations: @organizations, order: @order) %>
         </div>
-      </div>
+      </main>
       <%= footer_render(@is_curator) %>
       </div>
     """

--- a/apps/andi/lib/andi_web/live/public_submissions_live_view/submit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/public_submissions_live_view/submit_live_view.ex
@@ -11,7 +11,7 @@ defmodule AndiWeb.SubmitLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_datasets_path()) %>
-    <div class="edit-page" id="dataset-edit-page">
+    <main aria-label="Submit Dataset" class="edit-page" id="dataset-edit-page">
       <div class="preamble">
       <p>You are about to submit a dataset to the Smart Columbus Operating System for review. If approved, your dataset will be made available to the public for download and consumption. The Smart Columbus Operating System currently does not allow any datasets that contain:</p>
       <ul>
@@ -84,7 +84,7 @@ defmodule AndiWeb.SubmitLiveView do
           <div id="snackbar" class="error-message">A page error occurred</div>
         <% end %>
       </div>
-    </div>
+    </main>
     <%= footer_render(@is_curator) %>
     """
   end

--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view.ex
@@ -17,7 +17,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
   def render(assigns) do
     ~L"""
     <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_users_path()) %>
-      <div id="edit-user-live-view" class="user-edit-page edit-page">
+      <main aria-label="Edit User" id="edit-user-live-view" class="user-edit-page edit-page">
           <div class="edit-user-title">
               <h1 class="component-title-text">Edit User </h1>
           </div>
@@ -56,7 +56,7 @@ defmodule AndiWeb.UserLiveView.EditUserLiveView do
             <h3>Organizations Associated With This User</h3>
             <%= live_component(@socket, AndiWeb.EditUserLiveView.EditUserLiveViewTable, organizations: @organizations, id: :edit_user_organizations) %>
           </div>
-      </div>
+      </main>
       <%= footer_render(@is_curator) %>
     """
   end

--- a/apps/andi/lib/andi_web/live/user_live_view/user_live_view.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/user_live_view.ex
@@ -15,7 +15,7 @@ defmodule AndiWeb.UserLiveView do
     ~L"""
     <div class="content">
       <%= header_render(@is_curator, AndiWeb.HeaderLiveView.header_users_path()) %>
-      <div class="users-view">
+      <main aria-label="Add and edit users" class="users-view">
         <div class="users-index">
           <div class="users-index__header">
             <h1 class="users-index__title">All Users</h1>
@@ -42,7 +42,7 @@ defmodule AndiWeb.UserLiveView do
           </div>
           <%= live_component(@socket, Table, id: :users_table, users: @users, order: @order) %>
         </div>
-      </div>
+      </main>
       <%= footer_render(@is_curator) %>
     </div>
     """

--- a/apps/andi/lib/andi_web/templates/layout/app.html.eex
+++ b/apps/andi/lib/andi_web/templates/layout/app.html.eex
@@ -12,9 +12,9 @@
   </head>
   <body>
     <div class="root">
-      <main role="main" class="root__main">
+      <div class="root__main">
         <%= @inner_content %>
-      </main>
+      </div>
     </div>
   </body>
 </html>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.31",
+      version: "2.4.32",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #981](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/981)

## Description

No visual changes happened, just switched around the elements and added aria-labels. Was careful to make sure that the footer popping-up didn't return

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/54278348/211093596-97d049e9-9602-47be-9706-8541899e661a.png">


## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
- - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
