### PR TITLE
Remove field selector from form when not xml source

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,10 @@
 - ...
 
 ## Reminders:
+
 - [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
-- - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
-  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration? 
+  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
+  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
 - [ ] If changing elixir code in an "app", did you update the relevant version
       in `mix.exs`?
 - [ ] If altering an API endpoint, was the relevant postman collection updated?

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/metadata/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/metadata/metadata_form.ex
@@ -47,7 +47,7 @@ defmodule AndiWeb.IngestionLiveView.MetadataForm do
       </div>
 
       <div class="metadata-form__top-level-selector">
-        <%= if input_value(f, :sourceFormat) not in ["xml", "json", "text/xml", "application/json"] do %>
+        <%= if input_value(f, :sourceFormat) not in ["text/xml", "application/json", "application/geo+json"] do %>
           <%= label(f, :emptyValue, DisplayNames.get(:topLevelSelector), class: MetadataFormHelpers.top_level_selector_label_class(input_value(f, :sourceFormat))) %>
           <%= text_input(f, :emptyValue, [class: "input--text input disable-focus", readonly: true]) %>
         <% else %>

--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_field_editor.ex
@@ -32,16 +32,12 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
 
-        <%= if editing_ingestion? do %>
-        <div class="data-dictionary-field-editor__selector">
-          <%= if DataDictionaryHelpers.is_source_format_xml(@source_format) do %>
+        <%= if editing_ingestion? and DataDictionaryHelpers.is_source_format_xml(@source_format) do %>
+          <div class="data-dictionary-field-editor__selector">
             <%= label(@form, :selector, "Selector", class: "label label--required", for: id <> "_selector") %>
-          <% else %>
-            <%= label(@form, :selector, "Selector", class: "label", for: id <> "_selector") %>
-          <% end %>
-          <%= text_input(@form, :selector, [id: id <> "_selector", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
-          <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
-        </div>
+            <%= text_input(@form, :selector, [id: id <> "_selector", class: "data-dictionary-field-editor__selector input", disabled: !DataDictionaryHelpers.is_source_format_xml(@source_format), required: true]) %>
+            <%= ErrorHelpers.error_tag(form_with_errors, :selector) %>
+          </div>
         <% end %>
 
         <div class="data-dictionary-field-editor__type">

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.33",
+      version: "2.4.34",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## Description

- Remove field selector from showing on non XML schema attributes. 
  - Selector can be used at the top level for Json or XML, but for individual attributes, selector is only utilized for XML data, not json. 
  - Reflecting this in the UI continues to clarify its functionality, and smartcitiesdata wiki docs have also been updated.
- Allow top level selector for GeoJSON ingestions, it was mistakenly left out in prior releases

## Reminders:
- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
  - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] ~~If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
