### PR TITLE
unique IDs and unique labels everywhere

### DIFF
--- a/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
+++ b/apps/andi/lib/andi_web/live/access_group_live_view/dataset_table.ex
@@ -12,14 +12,14 @@ defmodule AndiWeb.AccessGroupLiveView.DatasetTable do
       <div class="access-groups-sub-table-container">
         <table class="access-groups-sub-table" title="Datasets Assigned to This Access Group">
           <thead>
-            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Dataset</th>
+            <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column" id="dataset">Dataset</th>
             <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Organization</th>
             <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Keywords</th>
             <th class="access-groups-sub-table__th access-groups-sub-table__cell wide-column">Action</th>
           </thead>
 
           <%= if @selected_datasets == [] do %>
-            <tr><td class="access-groups-sub-table__cell" colspan="100%">No Associated Datasets</td></tr>
+            <tr><td class="access-groups-sub-table__cell" colspan="100%" headers="dataset">No Associated Datasets</td></tr>
           <% else %>
             <%= for dataset <- datasets_to_display(@selected_datasets) do %>
             <tr class="access-groups-sub-table__tr">

--- a/apps/andi/lib/andi_web/live/dataset_live_view/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/data_dictionary_form.ex
@@ -118,7 +118,7 @@ defmodule AndiWeb.EditLiveView.DataDictionaryForm do
                 </div>
 
                 <div class="data-dictionary-form__tree-footer data-dictionary-form-tree-footer" >
-                  <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
+                  <button id="add-button" name="add-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
                   <button id="remove-button" name="remove-button" class="data-dictionary-form__remove-field-button material-icons" type="button" phx-click="remove_data_dictionary_field">delete_outline</button>
                 </div>
               </div>

--- a/apps/andi/lib/andi_web/live/dataset_live_view/key_value_editor.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/key_value_editor.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.EditLiveView.KeyValueEditor do
     ~L"""
     <div id="<%= @id %>" class="url-form__<%= @css_label %> url-form-table">
       <div class="url-form-table__title"><%= DisplayNames.get(@field) %></div>
-      <table class="url-form-table__table" title='<%= DisplayNames.get(@field) %>'>
+      <table class="url-form-table__table" title='<%= DisplayNames.get(@field) %>' aria-label="<%= @id %>">
       <tr class="url-form-table__row url-form-table__row--bordered">
         <th class="url-form-table__cell url-form-table__cell--bordered url-form-table__cell--header">KEY</th>
         <th class="url-form-table__cell url-form-table__cell--bordered url-form-table__cell--header" colspan="2" >VALUE</th>

--- a/apps/andi/lib/andi_web/live/dataset_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/metadata_form.ex
@@ -62,8 +62,11 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
       <div class="form-section">
         <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :save, as: :form_data] %>
           <%= hidden_input(f, :orgName) %>
+          <%= hidden_input(f, :orgTitle) %>
           <%= hidden_input(f, :orgId) %>
+          <%= hidden_input(f, :dataName) %>
           <%= hidden_input(f, :systemName) %>
+          <%= hidden_input(f, :sourceType) %>
           <%= hidden_input(f, :datasetId) %>
 
           <div class="component-edit-section--<%= @visibility %>">
@@ -75,8 +78,8 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
               </div>
 
               <div class="metadata-form__data-name">
-                <%= label(f, :dataName, DisplayNames.get(:dataName), class: "label label--required") %>
-                <%= text_input(f, :dataName, [class: "input input--text", readonly: true, required: true]) %>
+                <%= label(f, :dataName, DisplayNames.get(:dataName), class: "label label--required", for: "metadata_#{@socket.id}__data-name") %>
+                <%= text_input(f, :dataName, [id: "metadata_#{@socket.id}__data-name", class: "input input--text", readonly: true, required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :dataName, bind_to_input: false) %>
               </div>
 
@@ -156,15 +159,15 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
               </div>
 
               <div class="metadata-form__type">
-                <%= label(f, :sourceType, DisplayNames.get(:sourceType), class: "label label--required") %>
-                <%= select(f, :sourceType, MetadataFormHelpers.get_source_type_options(), [class: "select", disabled: @dataset_published?, required: true]) %>
+                <%= label(f, :sourceType, DisplayNames.get(:sourceType), class: "label label--required", for: "metadata_#{@socket.id}__source-type") %>
+                <%= select(f, :sourceType, MetadataFormHelpers.get_source_type_options(), [id: "metadata_#{@socket.id}__source-type", class: "select", disabled: @dataset_published?, required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :sourceType, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__organization">
-                <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required") %>
-                <%= select(f, :orgTitle, MetadataFormHelpers.get_org_options(), [class: "select", disabled: @dataset_published?, selected: "", required: true]) %>
-                <%= ErrorHelpers.error_tag(f, :orgTitle, bind_to_input: false) %>
+                <%= label(f, :orgId, DisplayNames.get(:orgTitle), class: "label label--required", for: "metadata_#{@socket.id}__org-title") %>
+                <%= select(f, :orgId, MetadataFormHelpers.get_org_options(), [id: "metadata_#{@socket.id}__org-title", class: "select", disabled: @dataset_published?, selected: "", required: true]) %>
+                <%= ErrorHelpers.error_tag(f, :orgId, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__level-of-access">

--- a/apps/andi/lib/andi_web/live/dataset_live_view/metadata_form.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/metadata_form.ex
@@ -62,11 +62,8 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
       <div class="form-section">
         <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :save, as: :form_data] %>
           <%= hidden_input(f, :orgName) %>
-          <%= hidden_input(f, :orgTitle) %>
           <%= hidden_input(f, :orgId) %>
-          <%= hidden_input(f, :dataName) %>
           <%= hidden_input(f, :systemName) %>
-          <%= hidden_input(f, :sourceType) %>
           <%= hidden_input(f, :datasetId) %>
 
           <div class="component-edit-section--<%= @visibility %>">
@@ -165,9 +162,9 @@ defmodule AndiWeb.EditLiveView.MetadataForm do
               </div>
 
               <div class="metadata-form__organization">
-                <%= label(f, :orgId, DisplayNames.get(:orgTitle), class: "label label--required") %>
-                <%= select(f, :orgId, MetadataFormHelpers.get_org_options(), [class: "select", disabled: @dataset_published?, selected: "", required: true]) %>
-                <%= ErrorHelpers.error_tag(f, :orgId, bind_to_input: false) %>
+                <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required") %>
+                <%= select(f, :orgTitle, MetadataFormHelpers.get_org_options(), [class: "select", disabled: @dataset_published?, selected: "", required: true]) %>
+                <%= ErrorHelpers.error_tag(f, :orgTitle, bind_to_input: false) %>
               </div>
 
               <div class="metadata-form__level-of-access">

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary/data_dictionary_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/data_dictionary/data_dictionary_form.ex
@@ -113,7 +113,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryForm do
                 </div>
 
                 <div class="data-dictionary-form__tree-footer data-dictionary-form-tree-footer" >
-                  <button id="save-button" name="save-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
+                  <button id="add-button" name="add-button" class="btn btn--primary-outline btn--save" type="button" phx-click="add_data_dictionary_field">Add</button>
                   <button id="remove-button" name="remove-button" class="data-dictionary-form__remove-field-button material-icons" type="button" phx-click="remove_data_dictionary_field">delete_outline</button>
                 </div>
               </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_auth_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_auth_step_form.ex
@@ -35,37 +35,37 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
           <div class="extract-auth-step-form-edit-section form-grid">
 
             <div class="extract-auth-step-form__destination">
-              <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step_#{@id}__auth_destination") %>
-              <%= text_input(f, :destination, [id: "step_#{@id}__auth_destination", aria_label: "step_#{@id}__auth_destination", class: "input", required: true]) %>
+              <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step_#{@extract_step.sequence}__auth_destination") %>
+              <%= text_input(f, :destination, [id: "step_#{@extract_step.sequence}__auth_destination", aria_label: "step_#{@extract_step.sequence}__auth_destination", class: "input", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :destination, bind_to_input: false) %>
             </div>
 
             <div class="extract-auth-step-form__url">
-              <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@id}__auth_url") %>
-              <%= text_input(f, :url, [id: "step_#{@id}__auth_url", aria_label: "step_#{@id}__auth_url", class: "input full-width", required: true]) %>
+              <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@extract_step.sequence}__auth_url") %>
+              <%= text_input(f, :url, [id: "step_#{@extract_step.sequence}__auth_url", aria_label: "step_#{@extract_step.sequence}__auth_url", class: "input full-width", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 
             <%= live_component(@socket, KeyValueEditor, id: "step_#{@id}__key_value_editor_headers" <> @extract_step.id, css_label: "source-headers", form: f, field: :headers, target: "step-" <> @id) %>
 
             <div class="extract-auth-step-form__body">
-              <%= label(f, :body, DisplayNames.get(:body),  class: "label", for: "step_#{@id}__auth_body") %>
-              <%= textarea(f, :body, id: "step_#{@id}__auth_body", aria_label: "step_#{@id}__auth_body", class: "input full-width", phx_hook: "prettify") %>
+              <%= label(f, :body, DisplayNames.get(:body),  class: "label", for: "step_#{@extract_step.sequence}__auth_body") %>
+              <%= textarea(f, :body, id: "step_#{@extract_step.sequence}__auth_body", aria_label: "step_#{@extract_step.sequence}__auth_body", class: "input full-width", phx_hook: "prettify") %>
               <%= ErrorHelpers.error_tag(f, :body, bind_to_input: false) %>
             </div>
 
             <div class="extract-auth-step-form__path">
-              <%= label(f, :path, DisplayNames.get(:path), class: "label label--required", for: "step_#{@id}__auth_path") %>
+              <%= label(f, :path, DisplayNames.get(:path), class: "label label--required", for: "step_#{@extract_step.sequence}__auth_path") %>
               <% form_path = input_value(f, :path) %>
-              <%= text_input(f, :path, [id: "step_#{@id}__auth_path", aria_label: "step_#{@id}__auth_path", class: "input", value: path_to_string(form_path), required: true]) %>
+              <%= text_input(f, :path, [id: "step_#{@extract_step.sequence}__auth_path", aria_label: "step_#{@extract_step.sequence}__auth_path", class: "input", value: path_to_string(form_path), required: true]) %>
               <span class="input__help-text">Separate response path keys with a period (.) (e.g. 'data.token' for response {"data": {"token": "abc123"}}) </span>
               <%= ErrorHelpers.error_tag(f, :path, bind_to_input: false) %>
             </div>
 
             <div class="extract-auth-step-form__cacheTtl">
-              <%= label(f, :cacheTtl, DisplayNames.get(:cacheTtl), class: "label label--required", for: "step_#{@id}__auth_cache_ttl") %>
+              <%= label(f, :cacheTtl, DisplayNames.get(:cacheTtl), class: "label label--required", for: "step_#{@extract_step.sequence}__auth_cache_ttl") %>
               <% form_ttl = input_value(f, :cacheTtl) %>
-              <%= text_input(f, :cacheTtl, [id: "step_#{@id}__auth_cache_ttl", aria_label: "step_#{@id}__auth_cache_ttl", class: "input", value: milliseconds_to_minutes(form_ttl), required: true]) %>
+              <%= text_input(f, :cacheTtl, [id: "step_#{@extract_step.sequence}__auth_cache_ttl", aria_label: "step_#{@extract_step.sequence}__auth_cache_ttl", class: "input", value: milliseconds_to_minutes(form_ttl), required: true]) %>
               <span class="input__help-text">Time in minutes that credentials are stored (defaults to 15 minutes)</span>
               <%= ErrorHelpers.error_tag(f, :cacheTtl, bind_to_input: false) %>
             </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_auth_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_auth_step_form.ex
@@ -36,13 +36,13 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
 
             <div class="extract-auth-step-form__destination">
               <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step_#{@id}__auth_destination") %>
-              <%= text_input(f, :destination, [id: "step_#{@id}__auth_destination", class: "input", required: true]) %>
+              <%= text_input(f, :destination, [id: "step_#{@id}__auth_destination", aria_label: "step_#{@id}__auth_destination", class: "input", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :destination, bind_to_input: false) %>
             </div>
 
             <div class="extract-auth-step-form__url">
               <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@id}__auth_url") %>
-              <%= text_input(f, :url, [id: "step_#{@id}__auth_url", class: "input full-width", required: true]) %>
+              <%= text_input(f, :url, [id: "step_#{@id}__auth_url", aria_label: "step_#{@id}__auth_url", class: "input full-width", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 
@@ -50,14 +50,14 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
 
             <div class="extract-auth-step-form__body">
               <%= label(f, :body, DisplayNames.get(:body),  class: "label", for: "step_#{@id}__auth_body") %>
-              <%= textarea(f, :body, id: "step_#{@id}__auth_body", class: "input full-width", phx_hook: "prettify") %>
+              <%= textarea(f, :body, id: "step_#{@id}__auth_body", aria_label: "step_#{@id}__auth_body", class: "input full-width", phx_hook: "prettify") %>
               <%= ErrorHelpers.error_tag(f, :body, bind_to_input: false) %>
             </div>
 
             <div class="extract-auth-step-form__path">
               <%= label(f, :path, DisplayNames.get(:path), class: "label label--required", for: "step_#{@id}__auth_path") %>
               <% form_path = input_value(f, :path) %>
-              <%= text_input(f, :path, [id: "step_#{@id}__auth_path", class: "input", value: path_to_string(form_path), required: true]) %>
+              <%= text_input(f, :path, [id: "step_#{@id}__auth_path", aria_label: "step_#{@id}__auth_path", class: "input", value: path_to_string(form_path), required: true]) %>
               <span class="input__help-text">Separate response path keys with a period (.) (e.g. 'data.token' for response {"data": {"token": "abc123"}}) </span>
               <%= ErrorHelpers.error_tag(f, :path, bind_to_input: false) %>
             </div>
@@ -65,7 +65,7 @@ defmodule AndiWeb.ExtractSteps.ExtractAuthStepForm do
             <div class="extract-auth-step-form__cacheTtl">
               <%= label(f, :cacheTtl, DisplayNames.get(:cacheTtl), class: "label label--required", for: "step_#{@id}__auth_cache_ttl") %>
               <% form_ttl = input_value(f, :cacheTtl) %>
-              <%= text_input(f, :cacheTtl, [id: "step_#{@id}__auth_cache_ttl", class: "input", value: milliseconds_to_minutes(form_ttl), required: true]) %>
+              <%= text_input(f, :cacheTtl, [id: "step_#{@id}__auth_cache_ttl", aria_label: "step_#{@id}__auth_cache_ttl", class: "input", value: milliseconds_to_minutes(form_ttl), required: true]) %>
               <span class="input__help-text">Time in minutes that credentials are stored (defaults to 15 minutes)</span>
               <%= ErrorHelpers.error_tag(f, :cacheTtl, bind_to_input: false) %>
             </div>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_date_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_date_step_form.ex
@@ -34,19 +34,19 @@ defmodule AndiWeb.ExtractSteps.ExtractDateStepForm do
             <div class="extract-date-step-form-edit-section form-grid">
               <div class="extract-date-step-form__destination">
                 <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step-#{@id}__date-destination") %>
-                <%= text_input(f, :destination, [id: "step-#{@id}__date-destination", class: "extract-date-step-form__destination input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
+                <%= text_input(f, :destination, [id: "step-#{@id}__date-destination", aria_label: "step_#{@id}__date-destination", class: "extract-date-step-form__destination input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :destination) %>
               </div>
 
               <div class="extract-date-step-form__deltaTimeUnit">
                 <%= label(f, :deltaTimeUnit, DisplayNames.get(:deltaTimeUnit), class: "label", for: "step_#{@id}__date_delta_time_unit") %>
-                <%= select(f, :deltaTimeUnit, get_time_units(), id: "step_#{@id}__date_delta_time_unit", class: "extract-date-step-form__delta_time_unit select", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
+                <%= select(f, :deltaTimeUnit, get_time_units(), id: "step_#{@id}__date_delta_time_unit", aria_label: "step_#{@id}__date_delta_time_unit", class: "extract-date-step-form__delta_time_unit select", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
                 <%= ErrorHelpers.error_tag(f, :deltaTimeUnit) %>
               </div>
 
               <div class="extract-date-step-form__deltaTimeValue">
                 <%= label(f, :deltaTimeValue, DisplayNames.get(:deltaTimeValue), class: "label", for: "step_#{@id}__date_delta_time_value") %>
-                <%= text_input(f, :deltaTimeValue, id: "step_#{@id}__date_delta_time_value", class: "extract-date-step-form__delta_time_value input", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
+                <%= text_input(f, :deltaTimeValue, id: "step_#{@id}__date_delta_time_value", aria_label: "step_#{@id}__date_delta_time_value", class: "extract-date-step-form__delta_time_value input", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
                 <%= ErrorHelpers.error_tag(f, :deltaTimeValue) %>
               </div>
 
@@ -55,7 +55,7 @@ defmodule AndiWeb.ExtractSteps.ExtractDateStepForm do
                   <%= label(f, :format, "Format", class: "label label--required", for: "step_#{@id}__date_format") %>
                   <a href="https://hexdocs.pm/timex/Timex.Format.DateTime.Formatters.Default.html" target="_blank">Help</a>
                 </div>
-                <%= text_input(f, :format, [id: "step_#{@id}__date_format", class: "extract-date-step-form__format input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
+                <%= text_input(f, :format, [id: "step_#{@id}__date_format", aria_label: "step_#{@id}__date_format", class: "extract-date-step-form__format input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :format) %>
               </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_date_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_date_step_form.ex
@@ -33,29 +33,29 @@ defmodule AndiWeb.ExtractSteps.ExtractDateStepForm do
           <div class="component-edit-section--<%= @visibility %>">
             <div class="extract-date-step-form-edit-section form-grid">
               <div class="extract-date-step-form__destination">
-                <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step-#{@id}__date-destination") %>
-                <%= text_input(f, :destination, [id: "step-#{@id}__date-destination", aria_label: "step_#{@id}__date-destination", class: "extract-date-step-form__destination input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
+                <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step-#{@extract_step.sequence}__date-destination") %>
+                <%= text_input(f, :destination, [id: "step-#{@extract_step.sequence}__date-destination", aria_label: "step_#{@extract_step.sequence}__date-destination", class: "extract-date-step-form__destination input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :destination) %>
               </div>
 
               <div class="extract-date-step-form__deltaTimeUnit">
-                <%= label(f, :deltaTimeUnit, DisplayNames.get(:deltaTimeUnit), class: "label", for: "step_#{@id}__date_delta_time_unit") %>
-                <%= select(f, :deltaTimeUnit, get_time_units(), id: "step_#{@id}__date_delta_time_unit", aria_label: "step_#{@id}__date_delta_time_unit", class: "extract-date-step-form__delta_time_unit select", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
+                <%= label(f, :deltaTimeUnit, DisplayNames.get(:deltaTimeUnit), class: "label", for: "step_#{@extract_step.sequence}__date_delta_time_unit") %>
+                <%= select(f, :deltaTimeUnit, get_time_units(), id: "step_#{@extract_step.sequence}__date_delta_time_unit", aria_label: "step_#{@extract_step.sequence}__date_delta_time_unit", class: "extract-date-step-form__delta_time_unit select", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
                 <%= ErrorHelpers.error_tag(f, :deltaTimeUnit) %>
               </div>
 
               <div class="extract-date-step-form__deltaTimeValue">
-                <%= label(f, :deltaTimeValue, DisplayNames.get(:deltaTimeValue), class: "label", for: "step_#{@id}__date_delta_time_value") %>
-                <%= text_input(f, :deltaTimeValue, id: "step_#{@id}__date_delta_time_value", aria_label: "step_#{@id}__date_delta_time_value", class: "extract-date-step-form__delta_time_value input", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
+                <%= label(f, :deltaTimeValue, DisplayNames.get(:deltaTimeValue), class: "label", for: "step_#{@extract_step.sequence}__date_delta_time_value") %>
+                <%= text_input(f, :deltaTimeValue, id: "step_#{@extract_step.sequence}__date_delta_time_value", aria_label: "step_#{@extract_step.sequence}__date_delta_time_value", class: "extract-date-step-form__delta_time_value input", phx_focus: :get_example_output, phx_target: "#step-#{@id}") %>
                 <%= ErrorHelpers.error_tag(f, :deltaTimeValue) %>
               </div>
 
               <div class="extract-date-step-form__format">
                 <div class="help-text-label">
-                  <%= label(f, :format, "Format", class: "label label--required", for: "step_#{@id}__date_format") %>
+                  <%= label(f, :format, "Format", class: "label label--required", for: "step_#{@extract_step.sequence}__date_format") %>
                   <a href="https://hexdocs.pm/timex/Timex.Format.DateTime.Formatters.Default.html" target="_blank">Help</a>
                 </div>
-                <%= text_input(f, :format, [id: "step_#{@id}__date_format", aria_label: "step_#{@id}__date_format", class: "extract-date-step-form__format input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
+                <%= text_input(f, :format, [id: "step_#{@extract_step.sequence}__date_format", aria_label: "step_#{@extract_step.sequence}__date_format", class: "extract-date-step-form__format input", phx_focus: :get_example_output, phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :format) %>
               </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
@@ -46,13 +46,13 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
 
                 <div class="extract-http-step-form__method">
                   <%= label(f, :action, DisplayNames.get(:method), class: "label label--required", for: "step_#{@id}__http_method") %>
-                  <%= select(f, :action, get_http_methods(), [id: "step_#{@id}__http_method", class: "extract-http-step-form__method select", required: true]) %>
+                  <%= select(f, :action, get_http_methods(), [id: "step_#{@id}__http_method", aria_label: "step_#{@id}__http_method", class: "extract-http-step-form__method select", required: true]) %>
                   <%= ErrorHelpers.error_tag(f, :action) %>
                 </div>
 
                 <div class="extract-http-step-form__url">
                   <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@id}__url") %>
-                  <%= url_input(f, :url, [id: "step_#{@id}__url", class: "input full-width", disabled: @testing, required: true]) %>
+                  <%= url_input(f, :url, [id: "step_#{@id}__url", aria_label: "step_#{@id}__url", class: "input full-width", disabled: @testing, required: true]) %>
                   <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
                 </div>
 
@@ -63,7 +63,7 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
                 <%= if input_value(f, :action) == "POST" do %>
                   <div class="extract-http-step-form__body">
                     <%= label(f, :body, DisplayNames.get(:body),  class: "label", for: "step_#{@id}__body") %>
-                    <%= textarea(f, :body, id: "step_#{@id}__body", class: "input full-width", phx_hook: "prettify", disabled: @testing) %>
+                    <%= textarea(f, :body, id: "step_#{@id}__body", aria_label: "step_#{@id}__body", class: "input full-width", phx_hook: "prettify", disabled: @testing) %>
                     <%= ErrorHelpers.error_tag(f, :body, bind_to_input: false) %>
                   </div>
                 <% end %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
@@ -45,14 +45,14 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
               <div class="extract-http-step-form-edit-section form-grid">
 
                 <div class="extract-http-step-form__method">
-                  <%= label(f, :action, DisplayNames.get(:method), class: "label label--required", for: "step_#{@id}__http_method") %>
-                  <%= select(f, :action, get_http_methods(), [id: "step_#{@id}__http_method", aria_label: "step_#{@id}__http_method", class: "extract-http-step-form__method select", required: true]) %>
+                  <%= label(f, :action, DisplayNames.get(:method), class: "label label--required", for: "step_#{@extract_step.sequence}__http_method") %>
+                  <%= select(f, :action, get_http_methods(), [id: "step_#{@extract_step.sequence}__http_method", aria_label: "step_#{@extract_step.sequence}__http_method", class: "extract-http-step-form__method select", required: true]) %>
                   <%= ErrorHelpers.error_tag(f, :action) %>
                 </div>
 
                 <div class="extract-http-step-form__url">
-                  <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@id}__url") %>
-                  <%= url_input(f, :url, [id: "step_#{@id}__url", aria_label: "step_#{@id}__url", class: "input full-width", disabled: @testing, required: true]) %>
+                  <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@extract_step.sequence}__url") %>
+                  <%= url_input(f, :url, [id: "step_#{@extract_step.sequence}__url", aria_label: "step_#{@extract_step.sequence}__url", class: "input full-width", disabled: @testing, required: true]) %>
                   <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
                 </div>
 
@@ -62,8 +62,8 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
 
                 <%= if input_value(f, :action) == "POST" do %>
                   <div class="extract-http-step-form__body">
-                    <%= label(f, :body, DisplayNames.get(:body),  class: "label", for: "step_#{@id}__body") %>
-                    <%= textarea(f, :body, id: "step_#{@id}__body", aria_label: "step_#{@id}__body", class: "input full-width", phx_hook: "prettify", disabled: @testing) %>
+                    <%= label(f, :body, DisplayNames.get(:body),  class: "label", for: "step_#{@extract_step.sequence}__body") %>
+                    <%= textarea(f, :body, id: "step_#{@extract_step.sequence}__body", aria_label: "step_#{@extract_step.sequence}__body", class: "input full-width", phx_hook: "prettify", disabled: @testing) %>
                     <%= ErrorHelpers.error_tag(f, :body, bind_to_input: false) %>
                   </div>
                 <% end %>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_s3_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_s3_step_form.ex
@@ -34,7 +34,7 @@ defmodule AndiWeb.ExtractSteps.ExtractS3StepForm do
 
             <div class="extract-s3-step-form__url">
               <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@id}__s3_url") %>
-              <%= text_input(f, :url, [id: "step_#{@id}__s3_url", class: "input full-width", required: true]) %>
+              <%= text_input(f, :url, [id: "step_#{@id}__s3_url", aria_label: "step_#{@id}__s3_url", class: "input full-width", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_s3_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_s3_step_form.ex
@@ -33,8 +33,8 @@ defmodule AndiWeb.ExtractSteps.ExtractS3StepForm do
           <div class="extract-s3-step-form-edit-section form-grid">
 
             <div class="extract-s3-step-form__url">
-              <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@id}__s3_url") %>
-              <%= text_input(f, :url, [id: "step_#{@id}__s3_url", aria_label: "step_#{@id}__s3_url", class: "input full-width", required: true]) %>
+              <%= label(f, :url, DisplayNames.get(:url), class: "label label--required", for: "step_#{@extract_step.sequence}__s3_url") %>
+              <%= text_input(f, :url, [id: "step_#{@extract_step.sequence}__s3_url", aria_label: "step_#{@extract_step.sequence}__s3_url", class: "input full-width", required: true]) %>
               <%= ErrorHelpers.error_tag(f, :url, bind_to_input: false) %>
             </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_secret_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_secret_step_form.ex
@@ -36,8 +36,8 @@ defmodule AndiWeb.ExtractSteps.ExtractSecretStepForm do
             <div class="extract-secret-step-form-edit-section form-grid">
 
               <div class="extract-secret-step-form__destination">
-                <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step_#{@id}__secret_destination") %>
-                <%= text_input(f, :destination, [id: "step_#{@id}__secret_destination", aria_label: "step_#{@id}__secret_destination", class: "extract-secret-step-form__destination input", phx_target: "#step-#{@id}", required: true]) %>
+                <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step_#{@extract_step.sequence}__secret_destination") %>
+                <%= text_input(f, :destination, [id: "step_#{@extract_step.sequence}__secret_destination", aria_label: "step_#{@extract_step.sequence}__secret_destination", class: "extract-secret-step-form__destination input", phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :destination) %>
               </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_secret_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_secret_step_form.ex
@@ -37,7 +37,7 @@ defmodule AndiWeb.ExtractSteps.ExtractSecretStepForm do
 
               <div class="extract-secret-step-form__destination">
                 <%= label(f, :destination, DisplayNames.get(:destination), class: "label label--required", for: "step_#{@id}__secret_destination") %>
-                <%= text_input(f, :destination, [id: "step_#{@id}__secret_destination", class: "extract-secret-step-form__destination input", phx_target: "#step-#{@id}", required: true]) %>
+                <%= text_input(f, :destination, [id: "step_#{@id}__secret_destination", aria_label: "step_#{@id}__secret_destination", class: "extract-secret-step-form__destination input", phx_target: "#step-#{@id}", required: true]) %>
                 <%= ErrorHelpers.error_tag(f, :destination) %>
               </div>
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_secret_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_secret_step_form.ex
@@ -42,9 +42,9 @@ defmodule AndiWeb.ExtractSteps.ExtractSecretStepForm do
               </div>
 
               <div class="extract-secret-step-form__value">
-                <%= label(f, :secret_value, DisplayNames.get(:secret_value), class: "label label--required", for: "step_#{@id}__secret_value") %>
+                <%= label(f, :secret_value, DisplayNames.get(:secret_value), class: "label label--required", for: "step_#{@extract_step.sequence}__secret_value") %>
                 <div class="secret_value_add">
-                  <%= text_input(f, :secret_value, [id: "step_#{@id}__secret_value", type: "password", class: "extract-secret-step-form__secret-value input", phx_target: "#step-#{@id}", placeholder: "Secrets are not displayed after being saved", required: true]) %>
+                  <%= text_input(f, :secret_value, [id: "step_#{@extract_step.sequence}__secret_value", type: "password", class: "extract-secret-step-form__secret-value input", phx_target: "#step-#{@id}", placeholder: "Secrets are not displayed after being saved", required: true]) %>
                   <% secret_value = FormData.input_value(nil, f, :secret_value) %>
                   <button type="button" class="btn btn--action" phx-click="save_secret" <%= disable_add_button(@changeset, secret_value) %> phx-target='<%="#step-#{@id}"%>' phx-value-secret="<%= secret_value %>">Add</button>
                   <span class="secret__status-msg <%= save_success_class(@save_success) %>"><%= @save_secret_message %></span>

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -45,14 +45,14 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
         <%= hidden_input(f, :id, value: @transformation_changeset.changes.id) %>
         <div class="transformation-form transformation-edit-form--<%= @visibility %>">
           <div class="transformation-form__name">
-            <%= label(f, :name, "Name", class: "label label--required") %>
-            <%= text_input(f, :name, [class: "transformation-name input transformation-form-fields", phx_debounce: "1000", required: true]) %>
+            <%= label(f, :name, "Name", class: "label label--required", for: "transformation_#{@socket.id}__name") %>
+            <%= text_input(f, :name, [id: "transformation_#{@socket.id}__name", aria_label: "transformation_#{@socket.id}__name", class: "transformation-name input transformation-form-fields", phx_debounce: "1000", required: true]) %>
             <%= ErrorHelpers.error_tag(f.source, :name, bind_to_input: false) %>
           </div>
 
           <div class="transformation-form__type">
-            <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required") %>
-            <%= select(f, :type, get_transformation_types(), [phx_click: "transformation-type-selected", class: "select transformation-type", required: true]) %>
+            <%= label(f, :type, DisplayNames.get(:transformationType), class: "label label--required", for: "transformation_#{@socket.id}__type") %>
+            <%= select(f, :type, get_transformation_types(), [id: "transformation_#{@socket.id}__type", aria_label: "transformation_#{@socket.id}__type", phx_click: "transformation-type-selected", class: "select transformation-type", required: true]) %>
             <%= ErrorHelpers.error_tag(f.source, :type, bind_to_input: false) %>
           </div>
           <div class="transformation-form__fields">

--- a/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
@@ -34,20 +34,20 @@ defmodule AndiWeb.EditOrganizationLiveView do
 
         <div class="organization-form-edit-section form-grid">
           <div class="organization-form__title">
-            <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required") %>
-            <%= text_input(f, :orgTitle, [class: "input", phx_blur: "validate_unique_org_name", required: true]) %>
+            <%= label(f, :orgTitle, DisplayNames.get(:orgTitle), class: "label label--required", for: "organization-form__title") %>
+            <%= text_input(f, :orgTitle, [id: "organization-form__title", class: "input", phx_blur: "validate_unique_org_name", required: true]) %>
             <%= ErrorHelpers.error_tag(f, :orgTitle, bind_to_input: false) %>
           </div>
 
           <div class="organization-form__name">
-            <%= label(f, :orgName, DisplayNames.get(:orgName), class: "label label--required") %>
-            <%= text_input(f, :orgName, [class: "input input--text", readonly: true, required: true]) %>
+            <%= label(f, :orgName, DisplayNames.get(:orgName), class: "label label--required", for: "organization-form__name") %>
+            <%= text_input(f, :orgName, [id: "organization-form__name", class: "input input--text", readonly: true, required: true]) %>
             <%= ErrorHelpers.error_tag(f, :orgName, bind_to_input: false) %>
           </div>
 
           <div class="organization-form__description">
-            <%= label(f, :description, DisplayNames.get(:description), class: "label label--required") %>
-            <%= textarea(f, :description, class: "input textarea", required: true) %>
+            <%= label(f, :description, DisplayNames.get(:description), class: "label label--required", for: "organization-form__description") %>
+            <%= textarea(f, :description, id: "organization-form__description", class: "input textarea", required: true) %>
             <%= ErrorHelpers.error_tag(f, :description, bind_to_input: false) %>
           </div>
 

--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_add_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_add_field_editor.ex
@@ -29,7 +29,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__name form-block">
                 <div class="form-input">
                   <%= label(form, :name, "Name", class: "label label--required", for: id <> "_name") %>
-                  <%= text_input(form, :name, [id: id <> "_name", class: "input", required: true]) %>
+                  <%= text_input(form, :name, [id: id <> "_name", aria_label: id <> "_name", class: "input", required: true]) %>
                 </div>
                 <%= error_tag(form, :name) %>
               </div>
@@ -37,7 +37,7 @@ defmodule AndiWeb.DataDictionary.AddFieldEditor do
               <div class="data-dictionary-add-field-editor__type form-block">
                 <div class="form-input">
                   <%= label(form, :type, "Type", class: "label label--required", for: id <> "_type") %>
-                  <%= select(form, :type, get_item_types(), [id: id <> "_type", class: "select", required: true]) %>
+                  <%= select(form, :type, get_item_types(), [id: id <> "_type", aria_label: id <> "_type", class: "select", required: true]) %>
                 </div>
                 <%= error_tag(form, :type) %>
               </div>

--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_field_editor.ex
@@ -28,7 +28,7 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
 
         <div class="data-dictionary-field-editor__name">
           <%= label(@form, :name, "Name", class: "label label--required", for: id <> "_name") %>
-          <%= text_input(@form, :name, [id: id <> "_name", aria_labelledby: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000", required: true]) %>
+          <%= text_input(@form, :name, [id: id <> "_name", aria_label: id <> "_name", class: "data-dictionary-field-editor__name input", "phx-debounce": "1000", required: true]) %>
           <%= ErrorHelpers.error_tag(form_with_errors, :name) %>
         </div>
 
@@ -83,7 +83,7 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
 
         <div class="data-dictionary-field-editor__description">
           <%= label(@form, :description, "Description", class: "label", for: id <> "_description") %>
-          <%= textarea(@form, :description, id: id <> "_description", aria_labelledby: id <> "_description", class: "data-dictionary-field-editor__description input textarea", "phx-debounce": "blur") %>
+          <%= textarea(@form, :description, id: id <> "_description", aria_label: id <> "_description", class: "data-dictionary-field-editor__description input textarea", "phx-debounce": "blur") %>
         </div>
         <div class="data-dictionary-field-editor__pii">
           <%= label(@form, :pii, "P.I.I.", class: "label", for: id <> "_pii") %>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.39",
+      version: "2.4.40",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.4.37",
+      version: "2.4.38",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/dataset_live_view/metadata/metadata_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/dataset_live_view/metadata/metadata_form_test.exs
@@ -155,14 +155,14 @@ defmodule AndiWeb.MetadataFormTest do
       assert {:ok, view, html} = live(conn, @url_path <> dataset.id)
       metadata_view = find_live_child(view, "metadata_form_editor")
 
-      assert {"", ["Please select an organization"]} == get_select_first_option(html, "#form_data_orgId")
+      assert {"", ["Please select an organization"]} == get_select_first_option(html, "#metadata_metadata_form_editor__org-title")
 
       form_data = %{"dataName" => "data_title", "orgId" => org2.id}
 
       html = render_change(metadata_view, "validate", %{"form_data" => form_data, "_target" => ["form_data", "orgId"]})
 
       assert "very_readable__data_title" == get_value(html, "#form_data_systemName")
-      assert {org2.id, "Very Readable"} == get_select(html, "#form_data_orgId")
+      assert {org2.id, "Very Readable"} == get_select(html, "#metadata_metadata_form_editor__org-title")
     end
 
     test "updating data title allows common data name across different orgs", %{conn: conn} do

--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -135,7 +135,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
 
   defp select_type(type, view) do
     click_value = %{"value" => type}
-    element(view, "#form_data_type") |> render_click(click_value)
+    element(view, ".transformation-type") |> render_click(click_value)
   end
 
   defp build_field_id(field_name) do


### PR DESCRIPTION
## [Ticket Link #978](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/978)

## Description

Add unique IDs and labels to allow screen readers to differentiate between components and labels with the same text content

## Reminders:

- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
  - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
