### PR TITLE
Errors dont revert to previous data

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -44,8 +44,11 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
   end
 
   def render(assigns) do
+    current_data = assigns.changeset
+                   |> Changeset.apply_changes()
+
     metadata_changeset =
-      assigns.changeset
+      Ingestion.changeset(current_data, %{})
       |> Ingestion.validate()
       |> IngestionMetadataFormSchema.extract_from_ingestion_changeset()
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -44,8 +44,9 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
   end
 
   def render(assigns) do
-    current_data = assigns.changeset
-                   |> Changeset.apply_changes()
+    current_data =
+      assigns.changeset
+      |> Changeset.apply_changes()
 
     metadata_changeset =
       Ingestion.changeset(current_data, %{})

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.42",
+      version: "2.5.43",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #968](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/968)

## Description

Slight modification to allow the UI to have empty values and still show errors

## Reminders:

- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
