### PR TITLE
Fix toast and publish

### DIFF
--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -50,9 +50,10 @@ defmodule Andi.Event.EventHandler do
     ingestion_update()
     |> add_event_count(author, data.id)
 
-    Ingestions.update_ingested_time(data.id, DateTime.utc_now())
+    data
+    |> Map.put(:ingestionTime, %{ingestionTime: DateTime.to_iso8601(DateTime.utc_now())})
+    |> Ingestions.update()
 
-    Ingestions.update(data)
     IngestionStore.update(data)
   end
 

--- a/apps/andi/lib/andi/input_schemas/ingestions.ex
+++ b/apps/andi/lib/andi/input_schemas/ingestions.ex
@@ -138,13 +138,6 @@ defmodule Andi.InputSchemas.Ingestions do
     Ingestion.changeset(schema, changes)
   end
 
-  def update_ingested_time(ingestion_id, ingested_time) do
-    from_ingestion = get(ingestion_id) || %Ingestion{id: ingestion_id}
-    iso_ingested_time = DateTime.to_iso8601(ingested_time)
-
-    update(from_ingestion, %{ingestedTime: iso_ingested_time})
-  end
-
   def update_submission_status(ingestion_id, status) do
     from_ingestion = get(ingestion_id)
 

--- a/apps/andi/lib/andi/input_schemas/input_converter.ex
+++ b/apps/andi/lib/andi/input_schemas/input_converter.ex
@@ -270,15 +270,20 @@ defmodule Andi.InputSchemas.InputConverter do
   defp encode_extract_step_body_as_json(%{body: body} = smrt_extract_step) when body not in ["", nil] do
     case body do
       _ when is_binary(body) ->
-        Map.put(smrt_extract_step, :body, Jason.decode!(body))
+        raise_error_if_invalid_json(body)
+        Map.put(smrt_extract_step, :body, body)
 
       _ when is_map(body) ->
-        Map.put(smrt_extract_step, :body, body)
+        Map.put(smrt_extract_step, :body, Jason.encode!(body))
 
       _ ->
         Logger.error("Received an extract step body that is not a string or a map. Received body: #{body}}")
         smrt_extract_step
     end
+  end
+
+  defp raise_error_if_invalid_json(payload) do
+    Jason.decode!(payload)
   end
 
   defp encode_extract_step_body_as_json(smrt_extract_step), do: smrt_extract_step
@@ -340,7 +345,6 @@ defmodule Andi.InputSchemas.InputConverter do
     andi_extract_steps
     |> Enum.map(fn step ->
       step
-      |> Map.delete(:id)
       |> Map.delete(:technical_id)
       |> Map.update(:context, nil, fn context -> update_context_from_andi_step(context, step.type) end)
       |> Map.put(:assigns, %{})
@@ -349,12 +353,49 @@ defmodule Andi.InputSchemas.InputConverter do
 
   defp update_context_from_andi_step(context, "http") do
     context
+    |> cast_keys_to_atom_in_map_recursively()
     |> decode_andi_extract_step_body()
     |> Map.put_new(:body, %{})
     |> Map.put_new(:protocol, nil)
     |> Map.update(:queryParams, nil, &convert_key_value_to_map/1)
     |> Map.update(:headers, nil, &convert_key_value_to_map/1)
     |> Map.update(:url, nil, &remove_query_params_from_url/1)
+  end
+
+  defp cast_keys_to_atom_in_map_recursively(map) do
+    map
+    |> Enum.map(fn
+      {key, value} when is_binary(key) ->
+        {String.to_atom(key), value}
+
+      {key, value} ->
+        {key, value}
+    end)
+    |> Enum.map(fn
+      {key, value} when is_map(value) ->
+        {key, cast_keys_to_atom_in_map_recursively(value)}
+
+      {key, value} when is_list(value) ->
+        {key, cast_keys_to_atoms_in_list_recursively(value)}
+
+      {key, value} ->
+        {key, value}
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp cast_keys_to_atoms_in_list_recursively(list) do
+    list
+    |> Enum.map(fn
+      element when is_map(element) ->
+        cast_keys_to_atom_in_map_recursively(element)
+
+      element when is_list(element) ->
+        cast_keys_to_atoms_in_list_recursively(element)
+
+      element ->
+        element
+    end)
   end
 
   defp update_context_from_andi_step(context, "s3") do

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -374,7 +374,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
            |> Ingestion.validate(),
          true <- ingestion_changeset.valid? do
       ingestion_for_publish = ingestion_changeset.data
-      smrt_ingestion = InputConverter.andi_ingestion_to_smrt_ingestion(ingestion_for_publish) |> IO.inspect(label: "RYAN - Message")
+      smrt_ingestion = InputConverter.andi_ingestion_to_smrt_ingestion(ingestion_for_publish)
 
       case Brook.Event.send(@instance_name, ingestion_update(), :andi, smrt_ingestion) do
         :ok ->

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/edit_ingestion_live_view.ex
@@ -353,7 +353,7 @@ defmodule AndiWeb.IngestionLiveView.EditIngestionLiveView do
   defp publish_message(true = _valid?), do: "Published successfully."
 
   defp publish_message(false = _valid?),
-       do: "Saved successfully, but could not publish. You may need to fix errors before publishing."
+    do: "Saved successfully, but could not publish. You may need to fix errors before publishing."
 
   defp update_publish_message(socket, status) do
     message = publish_message(status == "valid" && socket.assigns.changeset.valid?)

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.43",
+      version: "2.5.44",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/edit_ingestion_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/edit_ingestion_live_view_test.exs
@@ -167,7 +167,7 @@ defmodule AndiWeb.EditIngestionLiveViewTest do
       new_name = "new_name"
 
       form_data = %{
-        "name" => new_name,
+        "name" => new_name
       }
 
       view
@@ -190,7 +190,7 @@ defmodule AndiWeb.EditIngestionLiveViewTest do
 
       form_data = %{
         "name" => new_name,
-        "sourceFormat" => nil,
+        "sourceFormat" => nil
       }
 
       view
@@ -212,7 +212,7 @@ defmodule AndiWeb.EditIngestionLiveViewTest do
       new_name = "new_name"
 
       form_data = %{
-        "name" => new_name,
+        "name" => new_name
       }
 
       view

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/edit_ingestion_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/edit_ingestion_live_view_test.exs
@@ -136,7 +136,7 @@ defmodule AndiWeb.EditIngestionLiveViewTest do
       assert_redirected(view, @url_path)
     end
 
-    test "success message is displayed when form data is saved", %{curator_conn: conn, ingestion: ingestion} do
+    test "Partial success message is displayed when invalid form data is saved", %{curator_conn: conn, ingestion: ingestion} do
       assert {:ok, view, html} = live(conn, "#{@url_path}/#{ingestion.id}")
 
       assert get_text(html, "#snackbar") == ""
@@ -157,6 +157,73 @@ defmodule AndiWeb.EditIngestionLiveViewTest do
 
       refute Enum.empty?(find_elements(html, "#snackbar.success-message"))
       assert get_text(html, "#snackbar") == "Saved successfully. You may need to fix errors before publishing."
+    end
+
+    test "Success message is displayed when form data is saved", %{curator_conn: conn, ingestion: ingestion} do
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{ingestion.id}")
+
+      assert get_text(html, "#snackbar") == ""
+
+      new_name = "new_name"
+
+      form_data = %{
+        "name" => new_name,
+      }
+
+      view
+      |> form("#ingestion_metadata_form", form_data: form_data)
+      |> render_change()
+
+      render_change(view, :save, %{})
+      html = render(view)
+
+      refute Enum.empty?(find_elements(html, "#snackbar.success-message"))
+      assert get_text(html, "#snackbar") == "Saved successfully."
+    end
+
+    test "Error message is displayed when invalid form data attempts to be published", %{curator_conn: conn, ingestion: ingestion} do
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{ingestion.id}")
+
+      assert get_text(html, "#snackbar") == ""
+
+      new_name = "new_name"
+
+      form_data = %{
+        "name" => new_name,
+        "sourceFormat" => nil,
+      }
+
+      view
+      |> form("#ingestion_metadata_form", form_data: form_data)
+      |> render_change()
+
+      render_change(view, :publish, %{})
+      html = render(view)
+
+      refute Enum.empty?(find_elements(html, "#snackbar.success-message"))
+      assert get_text(html, "#snackbar") == "Saved successfully, but could not publish. You may need to fix errors before publishing."
+    end
+
+    test "Success publish message is displayed when valid form data is published", %{curator_conn: conn, ingestion: ingestion} do
+      assert {:ok, view, html} = live(conn, "#{@url_path}/#{ingestion.id}")
+
+      assert get_text(html, "#snackbar") == ""
+
+      new_name = "new_name"
+
+      form_data = %{
+        "name" => new_name,
+      }
+
+      view
+      |> form("#ingestion_metadata_form", form_data: form_data)
+      |> render_change()
+
+      render_change(view, :publish, %{})
+      html = render(view)
+
+      refute Enum.empty?(find_elements(html, "#snackbar.success-message"))
+      assert get_text(html, "#snackbar") == "Published successfully."
     end
 
     test "saving form as draft does not send brook event", %{curator_conn: conn} do

--- a/apps/andi/test/unit/andi/event/event_handler_test.exs
+++ b/apps/andi/test/unit/andi/event/event_handler_test.exs
@@ -33,18 +33,18 @@ defmodule Andi.Event.EventHandlerTest do
   end
 
   test "should update the view state and the postgres entry when ingestion update event is called" do
-    ingestion = TDG.create_ingestion(%{id: Faker.UUID.v4()})
-    allow(IngestionStore.update(any()), return: :ok)
-    allow(Ingestions.update(any()), return: {:ok, "good"})
-    allow(Ingestions.update_ingested_time(any(), any()), return: :ok)
     current_time = DateTime.utc_now()
+    ingestion = TDG.create_ingestion(%{id: Faker.UUID.v4()})
+                |> Map.put(:ingestedTime, DateTime.to_iso8601(current_time))
+
+    allow(IngestionStore.update(any()), return: :ok)
+    allow(Ingestions.update(ingestion), return: {:ok, "good"})
     allow(DateTime.utc_now(), return: current_time)
     expect(TelemetryEvent.add_event_metrics(any(), [:events_handled]), return: :ok)
 
     Brook.Event.new(type: ingestion_update(), data: ingestion, author: :author)
     |> EventHandler.handle_event()
 
-    assert_called Ingestions.update_ingested_time(ingestion.id, DateTime.utc_now())
     assert_called Ingestions.update(ingestion)
     assert_called IngestionStore.update(ingestion)
   end

--- a/apps/andi/test/unit/andi/event/event_handler_test.exs
+++ b/apps/andi/test/unit/andi/event/event_handler_test.exs
@@ -34,8 +34,10 @@ defmodule Andi.Event.EventHandlerTest do
 
   test "should update the view state and the postgres entry when ingestion update event is called" do
     current_time = DateTime.utc_now()
-    ingestion = TDG.create_ingestion(%{id: Faker.UUID.v4()})
-                |> Map.put(:ingestedTime, DateTime.to_iso8601(current_time))
+
+    ingestion =
+      TDG.create_ingestion(%{id: Faker.UUID.v4()})
+      |> Map.put(:ingestedTime, DateTime.to_iso8601(current_time))
 
     allow(IngestionStore.update(any()), return: :ok)
     allow(Ingestions.update(ingestion), return: {:ok, "good"})

--- a/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
@@ -9,6 +9,89 @@ defmodule Andi.InputSchemas.InputConverterTest do
   alias SmartCity.TestDataGenerator, as: TDG
 
   use Placebo
+  describe "ingestion conversions" do
+
+    test "prepare_smrt_ingestion_for_casting/1 decodes the extract step body if it is json encoded" do
+      smrt_ingestion =
+        TDG.create_ingestion(%{
+          extractSteps: [
+            %{
+              type: "s3",
+              context: %{
+                url: "123.com",
+                body: "{\"foo\": 123}",
+                headers: %{"api-key" => "to-my-heart"}
+              }
+            }
+          ]
+        })
+
+      result = InputConverter.prepare_smrt_ingestion_for_casting(smrt_ingestion)
+
+      assert result.extractSteps == [
+               %{
+                 context: %{
+                   body: %{"foo" => 123},
+                   headers: [%{key: "api-key", value: "to-my-heart"}],
+                   url: "123.com"
+                 },
+                 type: "s3"
+               }
+             ]
+    end
+
+    test "prepare_smrt_ingestion_for_casting does not transform the extract step body if already a map" do
+      smrt_ingestion =
+        TDG.create_ingestion(%{
+          extractSteps: [
+            %{
+              type: "s3",
+              context: %{
+                url: "123.com",
+                body: %{foo: 123},
+                headers: %{"api-key" => "to-my-heart"}
+              }
+            }
+          ]
+        })
+
+      result = InputConverter.prepare_smrt_ingestion_for_casting(smrt_ingestion)
+
+      assert result.extractSteps == [
+               %{
+                 context: %{
+                   body: %{foo: 123},
+                   headers: [%{key: "api-key", value: "to-my-heart"}],
+                   url: "123.com"
+                 },
+                 type: "s3"
+               }
+             ]
+    end
+
+    test "prepare_smrt_ingestion_for_casting throws an error if a body cannot be json decoded" do
+      smrt_ingestion =
+        TDG.create_ingestion(%{
+          extractSteps: [
+            %{
+              type: "s3",
+              context: %{
+                url: "123.com",
+                body: "{foo:123}",
+                headers: %{"api-key" => "to-my-heart"}
+              }
+            }
+          ]
+        })
+
+      try do
+        result = InputConverter.prepare_smrt_ingestion_for_casting(smrt_ingestion)
+        flunk("Expected incorrectly formatted body to raise an error")
+      rescue e in Jason.DecodeError ->
+        :ok
+      end
+    end
+  end
 
   describe "main conversions" do
     setup do

--- a/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
@@ -9,9 +9,9 @@ defmodule Andi.InputSchemas.InputConverterTest do
   alias SmartCity.TestDataGenerator, as: TDG
 
   use Placebo
-  describe "ingestion conversions" do
 
-    test "prepare_smrt_ingestion_for_casting/1 decodes the extract step body if it is json encoded" do
+  describe "ingestion conversions" do
+    test "prepare_smrt_ingestion_for_casting/1 passes through the extract step body if it is json encoded" do
       smrt_ingestion =
         TDG.create_ingestion(%{
           extractSteps: [
@@ -31,7 +31,7 @@ defmodule Andi.InputSchemas.InputConverterTest do
       assert result.extractSteps == [
                %{
                  context: %{
-                   body: %{"foo" => 123},
+                   body: "{\"foo\": 123}",
                    headers: [%{key: "api-key", value: "to-my-heart"}],
                    url: "123.com"
                  },
@@ -40,7 +40,7 @@ defmodule Andi.InputSchemas.InputConverterTest do
              ]
     end
 
-    test "prepare_smrt_ingestion_for_casting does not transform the extract step body if already a map" do
+    test "prepare_smrt_ingestion_for_casting json encodes the extract step body if it is a map" do
       smrt_ingestion =
         TDG.create_ingestion(%{
           extractSteps: [
@@ -60,7 +60,7 @@ defmodule Andi.InputSchemas.InputConverterTest do
       assert result.extractSteps == [
                %{
                  context: %{
-                   body: %{foo: 123},
+                   body: "{\"foo\":123}",
                    headers: [%{key: "api-key", value: "to-my-heart"}],
                    url: "123.com"
                  },
@@ -69,7 +69,7 @@ defmodule Andi.InputSchemas.InputConverterTest do
              ]
     end
 
-    test "prepare_smrt_ingestion_for_casting throws an error if a body cannot be json decoded" do
+    test "prepare_smrt_ingestion_for_casting throws an error if a body is not valid json" do
       smrt_ingestion =
         TDG.create_ingestion(%{
           extractSteps: [
@@ -87,8 +87,9 @@ defmodule Andi.InputSchemas.InputConverterTest do
       try do
         result = InputConverter.prepare_smrt_ingestion_for_casting(smrt_ingestion)
         flunk("Expected incorrectly formatted body to raise an error")
-      rescue e in Jason.DecodeError ->
-        :ok
+      rescue
+        e in Jason.DecodeError ->
+          :ok
       end
     end
   end


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Added a publish specific toast
- Fixed Brook message encoding/decoding for extract steps body

## Reminders:

- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
