### PR TITLE
add regex_replace transformation

### DIFF
--- a/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/unit/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -100,6 +100,43 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
       assert element(view, "##{field_id}") |> has_element?()
     end
 
+    test "after selecting regex replace, regex extract fields appear" do
+      transformation_changeset = Transformation.changeset_for_draft(%{})
+      assert {:ok, view, html} = render_transformation_form(transformation_changeset)
+
+      select_type("regex_replace", view)
+
+      source_field_id = build_field_id("sourceField")
+      replacement_field_id = build_field_id("replacement")
+      regex_field_id = build_field_id("regex")
+
+      assert has_element?(view, ".transformation-field")
+      assert element(view, "label[for=#{source_field_id}]", "Source Field") |> has_element?()
+      assert element(view, "label[for=#{regex_field_id}]", "Regex") |> has_element?()
+      assert element(view, "label[for=#{replacement_field_id}]", "Replacement") |> has_element?()
+      assert element(view, "##{source_field_id}") |> has_element?()
+      assert element(view, "##{replacement_field_id}") |> has_element?()
+      assert element(view, "##{regex_field_id}") |> has_element?()
+    end
+
+    test "if regex replace is selected show fields on load" do
+      transformation_changeset = Transformation.changeset_for_draft(%{type: "regex_replace"})
+
+      assert {:ok, view, html} = render_transformation_form(transformation_changeset)
+
+      source_field_id = build_field_id("sourceField")
+      replacement_field_id = build_field_id("replacement")
+      regex_field_id = build_field_id("regex")
+
+      assert has_element?(view, ".transformation-field")
+      assert element(view, "label[for=#{source_field_id}]", "Source Field") |> has_element?()
+      assert element(view, "label[for=#{regex_field_id}]", "Regex") |> has_element?()
+      assert element(view, "label[for=#{replacement_field_id}]", "Replacement") |> has_element?()
+      assert element(view, "##{source_field_id}") |> has_element?()
+      assert element(view, "##{replacement_field_id}") |> has_element?()
+      assert element(view, "##{regex_field_id}") |> has_element?()
+    end
+
     test "shows error message if field missing" do
       transformation_changeset = Transformation.changeset_for_draft(%{type: "remove"})
       assert {:ok, view, html} = render_transformation_form(transformation_changeset)

--- a/apps/transformers/lib/transformation_fields.ex
+++ b/apps/transformers/lib/transformation_fields.ex
@@ -21,6 +21,10 @@ defmodule Transformers.TransformationFields do
     Transformers.Division.fields()
   end
 
+  def fields_for("regex_replace") do
+    Transformers.RegexReplace.fields()
+  end
+
   def fields_for(_unsupported) do
     []
   end

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -40,4 +40,27 @@ defmodule Transformers.RegexReplace do
       {:error, "Value of field #{field_name} is not a string: #{value}"}
     end
   end
+
+  def fields() do
+    [
+      %{
+        field_name: @source_field,
+        field_type: "string",
+        field_label: "Source Field",
+        options: nil
+      },
+      %{
+        field_name: @regex,
+        field_type: "string",
+        field_label: "Regex",
+        options: nil
+      },
+      %{
+        field_name: @replacement,
+        field_type: "string",
+        field_label: "Replacement",
+        options: nil
+      },
+    ]
+  end
 end

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -60,7 +60,7 @@ defmodule Transformers.RegexReplace do
         field_type: "string",
         field_label: "Replacement",
         options: nil
-      },
+      }
     ]
   end
 end

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.8",
+      version: "1.0.9",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #695](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/695)

## Description

Add regex replace fields to take advantage of the existing regex replace logic

## Reminders:

- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
