### PR TITLE
Add Error Handling to Org.dataJsonUrl Harvest

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 
 ## Reminders:
 
-- [ ] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
+- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
   - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
   - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
 - [ ] If changing elixir code in an "app", did you update the relevant version

--- a/apps/andi/lib/andi/harvest/harvester.ex
+++ b/apps/andi/lib/andi/harvest/harvester.ex
@@ -45,6 +45,10 @@ defmodule Andi.Harvest.Harvester do
     end
   end
 
+  def get_data_json("") do
+    {:error, "Unable to fetch data json from empty dataJsonUrl"}
+  end
+
   def get_data_json(url) do
     case get(url) do
       {:ok, response} ->
@@ -54,6 +58,10 @@ defmodule Andi.Harvest.Harvester do
         Logger.error("Failed to get data json from #{url}: #{inspect(error)}")
         {:error, error}
     end
+  rescue
+    _e ->
+      Logger.error("Hackney failed to get data json from org url: \"#{url}\"")
+      {:error, "Hackney failed to get data json from org url: \"#{url}\""}
   end
 
   def map_data_json_to_dataset(data_json, org) do

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.53",
+      version: "2.5.54",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -64,7 +64,7 @@ defmodule Andi.MixProject do
       {:gettext, "~> 0.17"},
       {:guardian, "~> 2.0"},
       {:guardian_db, "~> 2.0.3"},
-      {:hackney, "~> 1.17"},
+      {:hackney, "~> 1.18"},
       {:httpoison, "~> 1.5"},
       {:poison, "~> 3.1", override: true},
       {:jason, "~> 1.2"},

--- a/apps/andi/test/unit/andi/harvest/harvester_test.exs
+++ b/apps/andi/test/unit/andi/harvest/harvester_test.exs
@@ -63,6 +63,10 @@ defmodule Andi.Harvest.HarvesterTest do
       assert resp == actual
     end
 
+    test "get_data_json/1 handles non existent urls" do
+      assert {:error, _err_text} = Harvester.get_data_json("")
+    end
+
     test "map_data_json_to_dataset/2", %{data_json: data_json, org: org} do
       {:ok, data_json} = Jason.decode(data_json)
       datasets = Harvester.map_data_json_to_dataset(data_json, org)

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.3.8",
+      version: "1.3.9",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -58,7 +58,7 @@ defmodule DiscoveryApi.Mixfile do
       {:guardian, "~> 2.0"},
       {:guardian_db, "~> 2.0.3"},
       {:gettext, "~> 0.17"},
-      {:hackney, "~> 1.17"},
+      {:hackney, "~> 1.18"},
       {:httpoison, "~> 1.5"},
       {:faker, "~> 0.13"},
       {:jason, "~> 1.2"},

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.19.5",
+      version: "0.19.6",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
@@ -37,7 +37,7 @@ defmodule Forklift.MixProject do
       {:divo, "~> 1.3", only: [:dev, :test, :integration]},
       {:elsa, "~> 0.12"},
       {:ex_doc, "~> 0.21"},
-      {:hackney, "~> 1.17"},
+      {:hackney, "~> 1.18"},
       {:jason, "~> 1.2", override: true},
       {:libcluster, "~> 3.1"},
       {:libvault, "~> 0.2"},

--- a/apps/reaper/lib/reaper/event/event_handler.ex
+++ b/apps/reaper/lib/reaper/event/event_handler.ex
@@ -106,7 +106,9 @@ defmodule Reaper.Event.EventHandler do
     Enum.each(
       extractions_to_delete,
       fn {_id, extraction} ->
-        IngestionDelete.handle(extraction["ingestion"])
+        if extraction["ingestion"] do
+          IngestionDelete.handle(extraction["ingestion"])
+        end
       end
     )
 

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.18",
+      version: "2.0.19",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
@@ -54,7 +54,7 @@ defmodule Reaper.MixProject do
       {:ex_aws_s3, "~> 2.0",
        [env: :prod, git: "https://github.com/ex-aws/ex_aws_s3", ref: "6b9fdac73b62dee14bffb939965742f2576f2a7b"]},
       {:gen_stage, "~> 1.0", override: true},
-      {:hackney, "~> 1.17"},
+      {:hackney, "~> 1.18"},
       {:horde, "~> 0.7.0"},
       {:httpoison, "~> 1.6"},
       {:poison, "~> 3.1", override: true},


### PR DESCRIPTION
## Description

- Add a case to catch Hackney errors
- Explicitly upgrade Hackney to .18 to reduce errors - [link](https://github.com/benoitc/hackney/issues/685)
- Add a test asserting that nil dataJsonUrls for an org doesn't throw an error, which previously was blocking event handling

## Reminders:

- [x] Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app
  - [ ] ~~If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.~~
  - [ ] ~~If updating Major or Minor versions , did you update the sauron chart configuration?~~
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] ~~If altering an API endpoint, was the relevant postman collection updated?~~
  - [ ] ~~If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?~~
