### PR TITLE
User store for api cache

### DIFF
--- a/apps/raptor/lib/raptor/schemas/auth0_user_data.ex
+++ b/apps/raptor/lib/raptor/schemas/auth0_user_data.ex
@@ -22,8 +22,10 @@ defmodule Raptor.Schemas.Auth0UserData do
   use Accessible
 
   def from_map(%{} = map_data) do
-    normalized_data = map_data
+    normalized_data =
+      map_data
       |> AtomicMap.convert(safe: false, underscore: false)
+
     struct(%__MODULE__{}, normalized_data)
   end
 end

--- a/apps/raptor/lib/raptor/schemas/auth0_user_data.ex
+++ b/apps/raptor/lib/raptor/schemas/auth0_user_data.ex
@@ -1,0 +1,29 @@
+defmodule Raptor.Schemas.Auth0UserData do
+  @moduledoc """
+  This module defines the structure for a user stored in Auth0
+  """
+
+  @derive Jason.Encoder
+
+  @type t :: %__MODULE__{
+          user_id: String.t(),
+          app_metadata: Map.t(),
+          blocked: boolean(),
+          email_verified: boolean()
+        }
+
+  defstruct [
+    :user_id,
+    :app_metadata,
+    :blocked,
+    :email_verified
+  ]
+
+  use Accessible
+
+  def from_map(%{} = map_data) do
+    normalized_data = map_data
+      |> AtomicMap.convert(safe: false, underscore: false)
+    struct(%__MODULE__{}, normalized_data)
+  end
+end

--- a/apps/raptor/lib/raptor/services/auth0_management_service.ex
+++ b/apps/raptor/lib/raptor/services/auth0_management_service.ex
@@ -26,6 +26,7 @@ defmodule Raptor.Services.Auth0Management do
         |> Map.get(:body)
         |> Jason.decode!()
         |> Enum.map(&Auth0UserData.from_map/1)
+        |> IO.inspect(label: "Ryan - post map")
 
       {:ok, users}
     else

--- a/apps/raptor/lib/raptor/services/auth0_management_service.ex
+++ b/apps/raptor/lib/raptor/services/auth0_management_service.ex
@@ -13,8 +13,6 @@ defmodule Raptor.Services.Auth0Management do
 
   @instance_name Raptor.instance_name()
 
-  @api_key_collection :api_keys
-
   def get_users_by_api_key(apiKey) do
     url = Keyword.fetch!(auth0(), :audience)
 

--- a/apps/raptor/lib/raptor/services/auth0_management_service.ex
+++ b/apps/raptor/lib/raptor/services/auth0_management_service.ex
@@ -21,10 +21,12 @@ defmodule Raptor.Services.Auth0Management do
            Tesla.get("#{url}users?q=app_metadata.apiKey:\"#{apiKey}\"&search_engine=v3",
              headers: [{"Authorization", "Bearer #{access_token}"}]
            ) do
-      users = response
-              |> Map.get(:body)
-              |> Jason.decode!()
-              |> Enum.map(&Auth0UserData.from_map/1)
+      users =
+        response
+        |> Map.get(:body)
+        |> Jason.decode!()
+        |> Enum.map(&Auth0UserData.from_map/1)
+
       {:ok, users}
     else
       {:error, reason} ->
@@ -76,7 +78,9 @@ defmodule Raptor.Services.Auth0Management do
         audience: audience
       })
 
-    case Tesla.post(url, req_body, headers: [{"content-type", "application/x-www-form-urlencoded"}]) do
+    case Tesla.post(url, req_body,
+           headers: [{"content-type", "application/x-www-form-urlencoded"}]
+         ) do
       {:ok, response} ->
         access_token = response |> Map.get(:body) |> Jason.decode!() |> Map.get("access_token")
         {:ok, access_token}

--- a/apps/raptor/lib/raptor/services/auth0_user_data_store.ex
+++ b/apps/raptor/lib/raptor/services/auth0_user_data_store.ex
@@ -1,0 +1,58 @@
+defmodule Raptor.Services.Auth0UserDataStore do
+  @moduledoc """
+  This module provides functionality for interacting with Redis
+  """
+  require Logger
+  alias Raptor.Schemas.Auth0UserData
+
+  @namespace "raptor:auth0_user_data:"
+  @redix Raptor.Application.redis_client()
+
+  @doc """
+  Get Auth0 user data from Redis for a specific user
+  """
+  @spec get_user_by_api_key(String.t()) :: list(map())
+  def get_user_by_api_key(api_key) do
+    case Redix.command!(@redix, ["KEYS", @namespace <> api_key]) do
+      [] ->
+        []
+
+      keys ->
+        keys
+        |> (fn keys -> Redix.command!(@redix, ["MGET" | keys]) end).()
+        |> Enum.map(&from_json/1)
+    end
+  end
+
+  @doc """
+  Save a `Raptor.Schemas.Auth0UserData` to Redis
+  """
+  @spec persist(Raptor.Schemas.Auth0UserData.t()) ::
+          Redix.Protocol.redis_value() | no_return()
+  def persist(%Auth0UserData{} = auth0_user_data) do
+    key = auth0_user_data.app_metadata.apiKey
+
+    auth0_user_data
+    |> Map.from_struct()
+    |> Jason.encode!()
+    |> (fn assoc_json ->
+          Redix.command!(@redix, ["SET", @namespace <> key, assoc_json, "EX", "3600"])
+        end).()
+  end
+
+  @doc """
+  Remove a `Raptor.Schemas.Auth0UserData` from Redis
+  """
+  @spec delete_by_api_key(String.t()) ::
+          Redix.Protocol.redis_value() | no_return()
+  def delete_by_api_key(api_key) do
+    key = "#{api_key}"
+    Redix.command!(@redix, ["DEL", @namespace <> key])
+  end
+
+  defp from_json(json_string) do
+    json_string
+    |> Jason.decode!(keys: :atoms)
+    |> (fn map -> struct(%Auth0UserData{}, map) end).()
+  end
+end

--- a/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
@@ -30,15 +30,7 @@ defmodule RaptorWeb.ApiKeyController do
   end
 
   def getUserIdFromApiKey(conn, %{"api_key" => api_key}) do
-    user_list_results =
-      case Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key) do
-        [] -> Auth0Management.get_users_by_api_key(api_key)
-        user_list -> {:ok, user_list}
-      end
-
-    persist_user_list(user_list_results)
-
-    case user_list_results do
+    case Auth0Management.get_users_by_api_key(api_key) do
       {:ok, user_list} ->
         case get_valid_user_id(user_list) do
           {:ok, user_id} ->
@@ -80,19 +72,6 @@ defmodule RaptorWeb.ApiKeyController do
       _ ->
         Logger.warn("Multiple users cannot have the same API Key.")
         {:error, "Multiple users cannot have the same API Key."}
-    end
-  end
-
-  defp persist_user_list(user_list_results) do
-    case user_list_results do
-      {:ok, user_list} ->
-        user_list
-        |> Enum.each(fn
-          user_data -> Raptor.Services.Auth0UserDataStore.persist(user_data)
-        end)
-
-      {:error, reason} ->
-        :error
     end
   end
 end

--- a/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/api_key_controller.ex
@@ -30,10 +30,11 @@ defmodule RaptorWeb.ApiKeyController do
   end
 
   def getUserIdFromApiKey(conn, %{"api_key" => api_key}) do
-    user_list_results = case Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key) do
-      [] -> Auth0Management.get_users_by_api_key(api_key)
-      user_list -> {:ok, user_list}
-    end
+    user_list_results =
+      case Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key) do
+        [] -> Auth0Management.get_users_by_api_key(api_key)
+        user_list -> {:ok, user_list}
+      end
 
     persist_user_list(user_list_results)
 
@@ -86,12 +87,12 @@ defmodule RaptorWeb.ApiKeyController do
     case user_list_results do
       {:ok, user_list} ->
         user_list
-          |> Enum.each(fn
-            user_data -> Raptor.Services.Auth0UserDataStore.persist(user_data)
-          end)
-      {:error, reason} -> :error
+        |> Enum.each(fn
+          user_data -> Raptor.Services.Auth0UserDataStore.persist(user_data)
+        end)
+
+      {:error, reason} ->
+        :error
     end
   end
-
-
 end

--- a/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/authorize_controller.ex
@@ -3,6 +3,7 @@ defmodule RaptorWeb.AuthorizeController do
 
   alias Raptor.Services.Auth0Management
   alias Raptor.Services.DatasetStore
+  alias Raptor.Schemas.Auth0UserData
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Services.UserAccessGroupRelationStore
   alias Raptor.Services.DatasetAccessGroupRelationStore
@@ -28,11 +29,11 @@ defmodule RaptorWeb.AuthorizeController do
     dataset != %{}
   end
 
-  def check_user_association(user, dataset) do
+  def check_user_association(%Auth0UserData{} = user, dataset) do
     org_id_of_dataset = dataset.org_id
 
-    is_user_in_org?(user["user_id"], org_id_of_dataset) or
-      is_user_in_access_group?(user["user_id"], dataset.dataset_id)
+    is_user_in_org?(user.user_id, org_id_of_dataset) or
+      is_user_in_access_group?(user.user_id, dataset.dataset_id)
   end
 
   def validate_user_list(user_list, dataset) do

--- a/apps/raptor/lib/raptor_web/controllers/list_access_groups_controller.ex
+++ b/apps/raptor/lib/raptor_web/controllers/list_access_groups_controller.ex
@@ -31,11 +31,11 @@ defmodule RaptorWeb.ListAccessGroupsController do
       1 ->
         access_groups =
           List.first(users)
-          |> Map.get("user_id")
+          |> Map.get(:user_id)
           |> UserAccessGroupRelationStore.get_all_by_user()
 
         organizations =
-          List.first(users) |> Map.get("user_id") |> UserOrgAssocStore.get_all_by_user()
+          List.first(users) |> Map.get(:user_id) |> UserOrgAssocStore.get_all_by_user()
 
         render(conn, %{access_groups: access_groups, organizations: organizations})
 

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -28,6 +28,7 @@ defmodule Raptor.MixProject do
 
   defp deps do
     [
+      {:atomic_map, "~> 0.9"},
       {:brook, "== 0.4.9"},
       {:cowlib, "== 2.9.1", override: true},
       {:divo, "~> 1.3", only: [:dev, :test, :integration]},

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.2.13",
+      version: "1.2.14",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/raptor/test/integration/raptor_web/controllers/api_key_controller_test.exs
+++ b/apps/raptor/test/integration/raptor_web/controllers/api_key_controller_test.exs
@@ -83,8 +83,8 @@ defmodule Raptor.ApiKeyControllerTest do
       Raptor.Services.Auth0UserDataStore.persist(auth0_user_data)
 
       # Do not allow Auth0 calls
-      allow(Auth0Management.get_users_by_api_key(any()),
-        return: {:error, "error"}
+      allow(Tesla.get(any(), any()),
+        return: {:error, nil}
       )
 
       {:ok, response} =

--- a/apps/raptor/test/integration/raptor_web/controllers/api_key_controller_test.exs
+++ b/apps/raptor/test/integration/raptor_web/controllers/api_key_controller_test.exs
@@ -101,12 +101,20 @@ defmodule Raptor.ApiKeyControllerTest do
       api_key = "nonCachedApiKey"
 
       Raptor.Services.Auth0UserDataStore.delete_by_api_key(api_key)
+
       allow(Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key),
         return: []
       )
 
       allow(Tesla.get(any(), any()),
-        return: {:ok, %{body: "[{\"app_metadata\": {\"apiKey\": \"#{api_key}\"}, \"email_verified\": true, \"user_id\": \"#{user_id}\", \"blocked\": false}]"}}
+        return:
+          {:ok,
+           %{
+             body:
+               "[{\"app_metadata\": {\"apiKey\": \"#{api_key}\"}, \"email_verified\": true, \"user_id\": \"#{
+                 user_id
+               }\", \"blocked\": false}]"
+           }}
       )
 
       allow(Tesla.post(any(), any(), any()),
@@ -130,8 +138,16 @@ defmodule Raptor.ApiKeyControllerTest do
       assert Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key) == []
 
       allow(Tesla.get(any(), any()),
-        return: {:ok, %{body: "[{\"app_metadata\": {\"apiKey\": \"#{api_key}\"}, \"email_verified\": true, \"user_id\": \"#{user_id}\", \"blocked\": false}]"}}
+        return:
+          {:ok,
+           %{
+             body:
+               "[{\"app_metadata\": {\"apiKey\": \"#{api_key}\"}, \"email_verified\": true, \"user_id\": \"#{
+                 user_id
+               }\", \"blocked\": false}]"
+           }}
       )
+
       allow(Tesla.post(any(), any(), any()),
         return: {:ok, %{body: "{\"access_token\": \"foo\"}"}}
       )
@@ -140,14 +156,16 @@ defmodule Raptor.ApiKeyControllerTest do
         HTTPoison.get("http://localhost:4002/api/getUserIdFromApiKey?api_key=#{api_key}")
 
       expected_redis_data = [
-      %Raptor.Schemas.Auth0UserData{
-        app_metadata: %{apiKey: api_key},
-        user_id: user_id,
-        email_verified: true,
-        blocked: false
-      }
+        %Raptor.Schemas.Auth0UserData{
+          app_metadata: %{apiKey: api_key},
+          user_id: user_id,
+          email_verified: true,
+          blocked: false
+        }
       ]
-      assert Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key) == expected_redis_data
+
+      assert Raptor.Services.Auth0UserDataStore.get_user_by_api_key(api_key) ==
+               expected_redis_data
 
       body = Jason.decode!(response.body)
 
@@ -159,6 +177,7 @@ defmodule Raptor.ApiKeyControllerTest do
       allow(Auth0Management.get_users_by_api_key(any()),
         return: {:error, "error"}
       )
+
       allow(Raptor.Services.Auth0UserDataStore.get_user_by_api_key(any()),
         return: []
       )

--- a/apps/raptor/test/integration/raptor_web/controllers/authorize_controller_test.exs
+++ b/apps/raptor/test/integration/raptor_web/controllers/authorize_controller_test.exs
@@ -12,6 +12,7 @@ defmodule Raptor.AuthorizeControllerTest do
   alias Raptor.Schemas.Dataset
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Schemas.UserOrgAssoc
+  alias Raptor.Schemas.Auth0UserData
   alias Raptor.Services.Auth0Management
   alias Raptor.Services.UserAccessGroupRelationStore
   alias Raptor.Schemas.UserAccessGroupRelation
@@ -26,7 +27,7 @@ defmodule Raptor.AuthorizeControllerTest do
   describe "authorize" do
     setup do
       allow(Auth0Management.get_users_by_api_key("fakeApiKey"),
-        return: {:ok, [%{"email_verified" => true, "user_id" => "123"}]}
+        return: {:ok, [%Auth0UserData{user_id: "123", email_verified: true, blocked: false}]}
       )
 
       :ok

--- a/apps/raptor/test/integration/raptor_web/controllers/list_access_groups_controller_test.exs
+++ b/apps/raptor/test/integration/raptor_web/controllers/list_access_groups_controller_test.exs
@@ -14,6 +14,7 @@ defmodule Raptor.ListAccessGroupsControllerTest do
   alias Raptor.Schemas.UserOrgAssoc
   alias Raptor.Services.Auth0Management
   alias Raptor.Services.UserAccessGroupRelationStore
+  alias Raptor.Schemas.Auth0UserData
   alias Raptor.Schemas.UserAccessGroupRelation
   alias Raptor.Services.DatasetAccessGroupRelationStore
   alias Raptor.Schemas.DatasetAccessGroupRelation
@@ -26,7 +27,7 @@ defmodule Raptor.ListAccessGroupsControllerTest do
   describe "listAccessGroups" do
     test "returns an empty list of access groups when there are no valid access groups for the given apiKey" do
       allow(Auth0Management.get_users_by_api_key("fakeApiKey"),
-        return: {:ok, [%{"email_verified" => true, "user_id" => "1701"}]}
+        return: {:ok, [%Auth0UserData{user_id: "1701", email_verified: true}]}
       )
 
       {:ok, %Tesla.Env{body: body}} =
@@ -39,7 +40,7 @@ defmodule Raptor.ListAccessGroupsControllerTest do
 
     test "returns a list of access groups when there are access group authorized for the given apiKey" do
       allow(Auth0Management.get_users_by_api_key("fakeApiKey"),
-        return: {:ok, [%{"email_verified" => true, "user_id" => "1702"}]}
+        return: {:ok, [%Auth0UserData{user_id: "1702", email_verified: true}]}
       )
 
       relation = send_user_access_group_associate_event("access_group_id", "1702")

--- a/apps/raptor/test/unit/raptor_web/authorize_controller_test.exs
+++ b/apps/raptor/test/unit/raptor_web/authorize_controller_test.exs
@@ -2,6 +2,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
   use RaptorWeb.ConnCase
   use Placebo
   alias Raptor.Services.Auth0Management
+  alias Raptor.Schemas.Auth0UserData
   alias Raptor.Services.DatasetStore
   alias Raptor.Services.UserOrgAssocStore
   alias Raptor.Services.DatasetAccessGroupRelationStore
@@ -10,33 +11,35 @@ defmodule RaptorWeb.AuthorizeControllerTest do
   # these simulate "raw json" attributes of an auth0 user
   #   available in the "Raw JSON" tab of a user's page
   @authorized_call [
-    %{
-      "email_verified" => true,
-      "user_id" => "penny"
+    %Auth0UserData{
+      email_verified: true,
+      user_id: "penny",
+      app_metadata: %{apiKey: "fakeApiKey"},
+      blocked: false
     }
   ]
 
   @multiple_users_call [
-    %{
-      "email_verified" => true
+    %Auth0UserData{
+      email_verified: true
     },
-    %{
-      "email_verified" => true
+    %Auth0UserData{
+      email_verified: true
     }
   ]
 
   @unverified_email_call [
-    %{
-      "email_verified" => false
+    %Auth0UserData{
+      email_verified: false
     }
   ]
 
   @unauthorized_call []
 
   @blocked_user [
-    %{
-      "email_verified" => true,
-      "blocked" => true
+    %Auth0UserData{
+      email_verified: true,
+      blocked: true
     }
   ]
 
@@ -47,7 +50,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       system_name = "system__name"
       org_id = "dog_stats"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => true}
 
       expect(DatasetStore.get(system_name),
@@ -73,7 +76,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       dataset_org_id = "dataset_org"
       dataset_id = "wags"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => true}
 
       expect(DatasetStore.get(system_name),
@@ -123,7 +126,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       system_name = "system__name"
       dataset_org_id = "dataset_org"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => false}
 
       expect(DatasetStore.get(system_name),
@@ -162,7 +165,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       system_name = "system__name"
       org_id = "dog_stats"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => true}
       expect(Auth0Management.get_users_by_api_key(api_key), return: {:ok, @authorized_call})
 
@@ -189,7 +192,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       system_name = "system__name"
       dataset_org_id = "dataset_org"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => false}
       expect(Auth0Management.get_users_by_api_key(api_key), return: {:ok, @authorized_call})
 
@@ -229,7 +232,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       dataset_org_id = "dataset_org"
       dataset_id = "wags"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => true}
       expect(Auth0Management.get_users_by_api_key(api_key), return: {:ok, @authorized_call})
 
@@ -269,7 +272,7 @@ defmodule RaptorWeb.AuthorizeControllerTest do
       dataset_org_id = "dataset_org"
       dataset_id = "wags"
       user = @authorized_call |> List.first()
-      user_id = user["user_id"]
+      user_id = user.user_id
       expected = %{"is_authorized" => false}
       expect(Auth0Management.get_users_by_api_key(api_key), return: {:ok, @authorized_call})
 

--- a/apps/raptor/test/unit/raptor_web/list_access_groups_controller_test.exs
+++ b/apps/raptor/test/unit/raptor_web/list_access_groups_controller_test.exs
@@ -6,6 +6,7 @@ defmodule RaptorWeb.ListAccessGroupsControllerTest do
   alias Raptor.Services.DatasetAccessGroupRelationStore
   alias Raptor.Services.UserAccessGroupRelationStore
   alias Raptor.Services.Auth0Management
+  alias Raptor.Schemas.Auth0UserData
 
   describe "retrieves access groups by api_key" do
     test "returns an empty list when there are no access groups for the given apiKey", %{
@@ -15,7 +16,7 @@ defmodule RaptorWeb.ListAccessGroupsControllerTest do
       user_id = "auth0_user"
 
       allow(Auth0Management.get_users_by_api_key(api_key),
-        return: {:ok, [%{"user_id" => user_id}]}
+        return: {:ok, [%Auth0UserData{user_id: user_id}]}
       )
 
       allow(UserOrgAssocStore.get_all_by_user("auth0_user"), return: [])
@@ -41,7 +42,7 @@ defmodule RaptorWeb.ListAccessGroupsControllerTest do
       user_id = "auth0_user"
 
       allow(Auth0Management.get_users_by_api_key(api_key),
-        return: {:ok, [%{"user_id" => user_id}]}
+        return: {:ok, [%Auth0UserData{user_id: user_id}]}
       )
 
       allow(UserOrgAssocStore.get_all_by_user("auth0_user"), return: [])


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Any API calls that include an APIKey will first check Redis for any cached user data based on that APIKey
- If it cannot find Redis cache data, then it will attempt an Auth0 call and persist the response in Redis cache for next time.
- Redis cache expires every 60 minutes per key.

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
