### PR TITLE
Handling lists in extract step body conversions

### DIFF
--- a/apps/andi/lib/andi/input_schemas/input_converter.ex
+++ b/apps/andi/lib/andi/input_schemas/input_converter.ex
@@ -276,8 +276,11 @@ defmodule Andi.InputSchemas.InputConverter do
       _ when is_map(body) ->
         Map.put(smrt_extract_step, :body, Jason.encode!(body))
 
+      _ when is_list(body) ->
+        Map.put(smrt_extract_step, :body, Jason.encode!(body))
+
       _ ->
-        Logger.error("Received an extract step body that is not a string or a map. Received body: #{body}}")
+        Logger.error("Received an extract step body that is not a string or a map. Received body: #{inspect(body)}")
         smrt_extract_step
     end
   end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.55",
+      version: "2.5.56",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
@@ -69,6 +69,35 @@ defmodule Andi.InputSchemas.InputConverterTest do
              ]
     end
 
+    test "prepare_smrt_ingestion_for_casting json encodes the extract step body if it is a list" do
+      smrt_ingestion =
+        TDG.create_ingestion(%{
+          extractSteps: [
+            %{
+              type: "s3",
+              context: %{
+                url: "123.com",
+                body: [%{foo: 123}],
+                headers: %{"api-key" => "to-my-heart"}
+              }
+            }
+          ]
+        })
+
+      result = InputConverter.prepare_smrt_ingestion_for_casting(smrt_ingestion)
+
+      assert result.extractSteps == [
+               %{
+                 context: %{
+                   body: "[{\"foo\":123}]",
+                   headers: [%{key: "api-key", value: "to-my-heart"}],
+                   url: "123.com"
+                 },
+                 type: "s3"
+               }
+             ]
+    end
+
     test "prepare_smrt_ingestion_for_casting throws an error if a body is not valid json" do
       smrt_ingestion =
         TDG.create_ingestion(%{


### PR DESCRIPTION
## [Ticket Link #1049 ](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1049)

## Description

Passing a list into the body of an http extract step causes Andi to error out. This PR allows for the body of an extract http step to be a list as well.

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
