### PR TITLE
1056 fix extract body bug

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
@@ -192,7 +192,7 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
 
   defp concat_steps(ingestion_id, steps) do
     Enum.reduce(steps, %{}, fn step, acc ->
-      step = AtomicMap.convert(step, understore: false)
+      step = AtomicMap.convert(step, underscore: true, safe: false)
       concat_steps(ingestion_id, step, acc)
     end)
   end
@@ -206,7 +206,7 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
   end
 
   defp process_extract_step(_ingestion_id, %{type: "http"} = step, bindings) do
-    {_body, headers} = evaluate_body_and_headers(step, bindings)
+    headers = evaluate_headers(step, bindings)
 
     url = UrlBuilder.decode_http_extract_step(step, bindings)
 
@@ -250,6 +250,8 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
     Map.put(bindings, step.context.destination |> String.to_atom(), response)
   end
 
+  defp evaluate_headers(step, bindings), do: UrlBuilder.safe_evaluate_parameters(step.context.headers, bindings)
+
   defp evaluate_body_and_headers(step, bindings) do
     body =
       case Map.fetch(step.context, :body) do
@@ -261,6 +263,7 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
 
     {body, headers}
   end
+
 
   defp process_body(body, _assigns) when body in ["", nil], do: ""
 

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form.ex
@@ -264,7 +264,6 @@ defmodule AndiWeb.ExtractSteps.ExtractHttpStepForm do
     {body, headers}
   end
 
-
   defp process_body(body, _assigns) when body in ["", nil], do: ""
 
   defp process_body(body, assigns) do

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.54",
+      version: "2.5.57",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/extract_steps/extract_http_step_form_test.exs
@@ -184,10 +184,11 @@ defmodule AndiWeb.ExtractHttpStepFormTest do
     test "test uses provided query params and headers", %{conn: conn} do
       {:ok, ingestion} =
         IngestionHelpers.create_with_http_extract_step(%{
-          action: "GET",
+          action: "POST",
           url: "https://123.com",
           queryParams: %{"x" => "y"},
-          headers: %{"api-key" => "to-my-heart"}
+          headers: %{"api-key" => "to-my-heart"},
+          body: "{}"
         })
         |> IngestionHelpers.save_ingestion()
 


### PR DESCRIPTION
## [Ticket Link #1056 ](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1056)

## Description

- Added function in the extract_http_step_form that only processes headers when body isn't necessary.
- Updated integration test.

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
