### PR TITLE
Set telemetry_event port to the standard prometheus port

### DIFF
--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.57",
+      version: "2.5.58",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/runtime.exs
+++ b/apps/andi/runtime.exs
@@ -101,7 +101,7 @@ config :andi, :auth0,
   audience: "https://#{System.get_env("AUTH0_DOMAIN")}/api/v2/"
 
 config :telemetry_event,
-  metrics_port: System.get_env("METRICS_PORT") |> String.to_integer(),
+  metrics_port: 9090,
   add_poller: true,
   add_metrics: [:phoenix_endpoint_stop_duration, :dataset_total_count],
   metrics_options: [


### PR DESCRIPTION
## Description

For some reason we were overwriting the port for 

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
