### PR TITLE
No longer dead lettering unknown messages.

### DIFF
--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -224,12 +224,6 @@ defmodule Andi.Event.EventHandler do
       :discard
   end
 
-  def handle_event(%Brook.Event{type: type, data: data, author: author}) do
-    Logger.error("Unknown message failed to process with type: #{type}, author: #{inspect(author)}, data: #{inspect(data)}")
-    DeadLetter.process(nil, nil, data, Atom.to_string(@instance_name), reason: "Unknown event type in Andi")
-    :discard
-  end
-
   defp create_user_if_not_exists(subject_id, email, name) do
     case User.get_by_subject_id(subject_id) do
       nil ->

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.5.63",
+      version: "2.5.64",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -162,21 +162,6 @@ defmodule Forklift.Event.EventHandler do
       :discard
   end
 
-  def handle_event(%Brook.Event{type: type, data: data, author: author}) do
-    Logger.error(
-      "Event Handler received an unknown message with type: #{inspect(type)}, data: #{inspect(data)}, author: #{
-        inspect(author)
-      }"
-    )
-
-    DeadLetter.process(nil, nil, data, Atom.to_string(@instance_name),
-      reason:
-        "Unknown message receieved with type: #{inspect(type)}, data: #{inspect(data)}, author: #{inspect(author)}"
-    )
-
-    :discard
-  end
-
   defp delete_dataset(dataset) do
     Forklift.DataReaderHelper.terminate(dataset)
     Forklift.DataWriter.delete(dataset)

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.19.7",
+      version: "0.19.8",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- No longer considering unknown messages as errors. Apparently our services receive a decent bit of known messages.

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
