### PR TITLE
add ftp ingestion capability

### DIFF
--- a/apps/reaper/lib/reaper/data_slurper.ex
+++ b/apps/reaper/lib/reaper/data_slurper.ex
@@ -16,7 +16,8 @@ defmodule Reaper.DataSlurper do
   @implementations [
     Reaper.DataSlurper.Http,
     Reaper.DataSlurper.Sftp,
-    Reaper.DataSlurper.S3
+    Reaper.DataSlurper.S3,
+    Reaper.DataSlurper.Ftp
   ]
 
   getter(:download_dir, generic: true, default: "")

--- a/apps/reaper/lib/reaper/data_slurper/ftp.ex
+++ b/apps/reaper/lib/reaper/data_slurper/ftp.ex
@@ -24,7 +24,7 @@ defmodule Reaper.DataSlurper.Ftp do
     %{host: host, path: path, port: port} = URI.parse(url)
 
     with {:ok, pid} <- connect(host, port, ingestion_id),
-      {:file, filename} <- stream_file(pid, path, filename) do
+         {:file, filename} <- stream_file(pid, path, filename) do
       {:file, filename}
     else
       {:error, reason} ->
@@ -34,7 +34,9 @@ defmodule Reaper.DataSlurper.Ftp do
 
   defp stream_file(pid, path, filename) do
     case :ftp.recv(pid, ~c(#{path}), filename) do
-      :ok -> {:file, filename}
+      :ok ->
+        {:file, filename}
+
       {:error, reason} ->
         {:error, map_ftp_errors(reason)}
     end
@@ -51,7 +53,8 @@ defmodule Reaper.DataSlurper.Ftp do
             {:error, "Unable to establish FTP connection: #{map_ftp_errors(reason)}"}
         end
 
-      {:ok, _} -> {:error, "Ingestion credentials are not of the correct type"}
+      {:ok, _} ->
+        {:error, "Ingestion credentials are not of the correct type"}
 
       error ->
         error

--- a/apps/reaper/lib/reaper/data_slurper/ftp.ex
+++ b/apps/reaper/lib/reaper/data_slurper/ftp.ex
@@ -1,0 +1,64 @@
+defmodule Reaper.DataSlurper.Ftp do
+  @moduledoc """
+  Downloads sftp files as stream to local filesystem
+  """
+  @behaviour Reaper.DataSlurper
+  alias Reaper.DataSlurper
+
+  @ftp_errors %{
+    eclosed: "The session is closed",
+    econn: "Connection to the remote server is prematurely closed",
+    ehost: "Host is not found, FTP server is not found, or connection is rejected by FTP server",
+    epath: "No such file or directory, or directory already exists, or permission denied",
+    euser: "Invalid username or password"
+  }
+
+  @impl DataSlurper
+  def handle?(url) do
+    String.starts_with?(url, "ftp")
+  end
+
+  @impl DataSlurper
+  def slurp(url, ingestion_id, _headers \\ [], _protocol \\ nil, _action \\ nil, _body \\ "") do
+    filename = DataSlurper.determine_filename(ingestion_id)
+    %{host: host, path: path, port: port} = URI.parse(url)
+
+    with {:ok, pid} <- connect(host, port, ingestion_id),
+      {:file, filename} <- stream_file(pid, path, filename) do
+      {:file, filename}
+    else
+      {:error, reason} ->
+        raise "Failed calling '" <> url <> "': " <> inspect(reason)
+    end
+  end
+
+  defp stream_file(pid, path, filename) do
+    case :ftp.recv(pid, ~c(#{path}), filename) do
+      :ok -> {:file, filename}
+      {:error, reason} ->
+        {:error, map_ftp_errors(reason)}
+    end
+  end
+
+  defp connect(host, port, ingestion_id) do
+    case Reaper.SecretRetriever.retrieve_ingestion_credentials(ingestion_id) do
+      {:ok, %{"username" => username, "password" => password}} ->
+        with {:ok, pid} <- :ftp.open(to_charlist(host)),
+             :ok <- :ftp.user(pid, to_charlist(username), to_charlist(password)) do
+          {:ok, pid}
+        else
+          {:error, reason} ->
+            {:error, "Unable to establish FTP connection: #{map_ftp_errors(reason)}"}
+        end
+
+      {:ok, _} -> {:error, "Ingestion credentials are not of the correct type"}
+
+      error ->
+        error
+    end
+  end
+
+  defp map_ftp_errors(reason) do
+    Map.get(@ftp_errors, reason, reason)
+  end
+end

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.20",
+      version: "2.0.21",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/test/unit/reaper/data_slurper/ftp_test.exs
+++ b/apps/reaper/test/unit/reaper/data_slurper/ftp_test.exs
@@ -19,7 +19,7 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles incorrectly configured ingestion credentials", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{api_key: "q4587435o43759o47597"}}
+        return: {:ok, %{api_key: "q4587435o43759o47597"}}
 
       message = "Ingestion credentials are not of the correct type"
 
@@ -32,11 +32,13 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles invalid ingestion credentials", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+        return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+
       allow :ftp.open(any()),
-            return: {:ok, "pid"}
+        return: {:ok, "pid"}
+
       allow :ftp.user(any(), any(), any()),
-            return: {:error, :euser}
+        return: {:error, :euser}
 
       message = "Unable to establish FTP connection: Invalid username or password"
 
@@ -49,9 +51,10 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles closed session", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+        return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+
       allow :ftp.open(any()),
-            return: {:error, :eclosed}
+        return: {:error, :eclosed}
 
       message = "Unable to establish FTP connection: The session is closed"
 
@@ -64,11 +67,13 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles bad connection", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+        return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+
       allow :ftp.open(any()),
-            return: {:ok, "pid"}
+        return: {:ok, "pid"}
+
       allow :ftp.user(any(), any(), any()),
-            return: {:error, :econn}
+        return: {:error, :econn}
 
       message = "Unable to establish FTP connection: Connection to the remote server is prematurely closed"
 
@@ -81,11 +86,13 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles bad host", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
-      allow :ftp.open(any()),
-            return: {:error, :ehost}
+        return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
 
-      message = "Unable to establish FTP connection: Host is not found, FTP server is not found, or connection is rejected by FTP server"
+      allow :ftp.open(any()),
+        return: {:error, :ehost}
+
+      message =
+        "Unable to establish FTP connection: Host is not found, FTP server is not found, or connection is rejected by FTP server"
 
       assert_raise RuntimeError,
                    ~s|Failed calling '#{map.source_url}': "#{message}"|,
@@ -96,13 +103,16 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles bad file path", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+        return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+
       allow :ftp.open(any()),
-            return: {:ok, "pid"}
+        return: {:ok, "pid"}
+
       allow :ftp.user(any(), any(), any()),
-            return: :ok
+        return: :ok
+
       allow :ftp.recv(any(), any(), any()),
-            return: {:error, :epath}
+        return: {:error, :epath}
 
       message = "No such file or directory, or directory already exists, or permission denied"
 
@@ -115,13 +125,16 @@ defmodule Reaper.DataSlurper.FtpTest do
 
     test "handles successful file retrieval", map do
       allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
-            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+        return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+
       allow :ftp.open(any()),
-            return: {:ok, "pid"}
+        return: {:ok, "pid"}
+
       allow :ftp.user(any(), any(), any()),
-            return: :ok
+        return: :ok
+
       allow :ftp.recv(any(), any(), map.ingestion_id),
-            return: :ok
+        return: :ok
 
       message = "No such file or directory, or directory already exists, or permission denied"
 

--- a/apps/reaper/test/unit/reaper/data_slurper/ftp_test.exs
+++ b/apps/reaper/test/unit/reaper/data_slurper/ftp_test.exs
@@ -1,0 +1,131 @@
+defmodule Reaper.DataSlurper.FtpTest do
+  use ExUnit.Case
+  use Placebo
+
+  describe "DataSlurper.Ftp.slurp/2" do
+    setup do
+      %{source_url: "ftp://localhost:222/does/not/matter.csv", ingestion_id: "12345-6789"}
+    end
+
+    test "handles failure to retrieve any ingestion credentials", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()), return: {:error, :retrieve_credential_failed}
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': :retrieve_credential_failed|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles incorrectly configured ingestion credentials", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{api_key: "q4587435o43759o47597"}}
+
+      message = "Ingestion credentials are not of the correct type"
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': "#{message}"|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles invalid ingestion credentials", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+      allow :ftp.open(any()),
+            return: {:ok, "pid"}
+      allow :ftp.user(any(), any(), any()),
+            return: {:error, :euser}
+
+      message = "Unable to establish FTP connection: Invalid username or password"
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': "#{message}"|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles closed session", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+      allow :ftp.open(any()),
+            return: {:error, :eclosed}
+
+      message = "Unable to establish FTP connection: The session is closed"
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': "#{message}"|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles bad connection", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+      allow :ftp.open(any()),
+            return: {:ok, "pid"}
+      allow :ftp.user(any(), any(), any()),
+            return: {:error, :econn}
+
+      message = "Unable to establish FTP connection: Connection to the remote server is prematurely closed"
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': "#{message}"|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles bad host", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+      allow :ftp.open(any()),
+            return: {:error, :ehost}
+
+      message = "Unable to establish FTP connection: Host is not found, FTP server is not found, or connection is rejected by FTP server"
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': "#{message}"|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles bad file path", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+      allow :ftp.open(any()),
+            return: {:ok, "pid"}
+      allow :ftp.user(any(), any(), any()),
+            return: :ok
+      allow :ftp.recv(any(), any(), any()),
+            return: {:error, :epath}
+
+      message = "No such file or directory, or directory already exists, or permission denied"
+
+      assert_raise RuntimeError,
+                   ~s|Failed calling '#{map.source_url}': "#{message}"|,
+                   fn ->
+                     Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+                   end
+    end
+
+    test "handles successful file retrieval", map do
+      allow Reaper.SecretRetriever.retrieve_ingestion_credentials(any()),
+            return: {:ok, %{"username" => "validUser", "password" => "validPassword"}}
+      allow :ftp.open(any()),
+            return: {:ok, "pid"}
+      allow :ftp.user(any(), any(), any()),
+            return: :ok
+      allow :ftp.recv(any(), any(), map.ingestion_id),
+            return: :ok
+
+      message = "No such file or directory, or directory already exists, or permission denied"
+
+      assert {:file, map.ingestion_id} == Reaper.DataSlurper.Ftp.slurp(map.source_url, map.ingestion_id)
+    end
+  end
+end


### PR DESCRIPTION
## [Ticket Link #1084](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1084)

## Description

Add support for FTP ingestions in a similar manner to how SFTP is supported

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
