### PR TITLE
enable XML body in HTTP post

### DIFF
--- a/apps/andi/lib/andi/input_schemas/input_converter.ex
+++ b/apps/andi/lib/andi/input_schemas/input_converter.ex
@@ -254,42 +254,48 @@ defmodule Andi.InputSchemas.InputConverter do
 
   defp update_context_from_smrt_step(context, "http") do
     context
-    |> encode_extract_step_body_as_json()
+    |> validate_extract_step_body()
     |> Map.update(:queryParams, [], &to_key_value_list/1)
     |> Map.update(:headers, [], &to_key_value_list/1)
   end
 
   defp update_context_from_smrt_step(context, type) when type in ["s3", "auth"] do
     context
-    |> encode_extract_step_body_as_json()
+    |> validate_extract_step_body()
     |> Map.update(:headers, [], &to_key_value_list/1)
   end
 
   defp update_context_from_smrt_step(context, _), do: context
 
-  defp encode_extract_step_body_as_json(%{body: body} = smrt_extract_step) when body not in ["", nil] do
+  defp validate_extract_step_body(%{body: body} = smrt_extract_step) when body not in ["", nil] do
     case body do
       _ when is_binary(body) ->
-        raise_error_if_invalid_json(body)
+        raise_error_if_invalid_body(body)
         Map.put(smrt_extract_step, :body, body)
 
-      _ when is_map(body) ->
-        Map.put(smrt_extract_step, :body, Jason.encode!(body))
-
-      _ when is_list(body) ->
-        Map.put(smrt_extract_step, :body, Jason.encode!(body))
-
       _ ->
-        Logger.error("Received an extract step body that is not a string or a map. Received body: #{inspect(body)}")
+        Logger.error("Received an extract step body that is not able to be encoded as json or xml. Received body: #{inspect(body)}")
         smrt_extract_step
     end
   end
 
-  defp raise_error_if_invalid_json(payload) do
-    Jason.decode!(payload)
+  defp raise_error_if_invalid_body(body) do
+    case Jason.decode(body) do
+      {:ok, _} ->
+        body
+
+      {:error, _} ->
+        try do
+          SweetXml.parse(body)
+          body
+        catch
+          :exit, _ ->
+            raise ArgumentError, message: "could not parse json or xml: #{inspect(body)}"
+        end
+    end
   end
 
-  defp encode_extract_step_body_as_json(smrt_extract_step), do: smrt_extract_step
+  defp validate_extract_step_body(smrt_extract_step), do: smrt_extract_step
 
   defp add_dataset_id(schema, dataset_id, parent_bread_crumb \\ "") do
     bread_crumb = parent_bread_crumb <> schema.name
@@ -357,7 +363,6 @@ defmodule Andi.InputSchemas.InputConverter do
   defp update_context_from_andi_step(context, "http") do
     context
     |> cast_keys_to_atom_in_map_recursively()
-    |> decode_andi_extract_step_body()
     |> Map.put_new(:body, %{})
     |> Map.put_new(:protocol, nil)
     |> Map.update(:queryParams, nil, &convert_key_value_to_map/1)
@@ -403,7 +408,6 @@ defmodule Andi.InputSchemas.InputConverter do
 
   defp update_context_from_andi_step(context, "s3") do
     context
-    |> decode_andi_extract_step_body()
     |> Map.update(:headers, nil, &convert_key_value_to_map/1)
   end
 
@@ -415,7 +419,6 @@ defmodule Andi.InputSchemas.InputConverter do
 
   defp update_context_from_andi_step(context, "auth") do
     context
-    |> decode_andi_extract_step_body()
     |> Map.put_new(:body, %{})
     |> Map.put_new(:encodeMethod, "json")
     |> Map.update(:headers, nil, &convert_key_value_to_map/1)
@@ -425,12 +428,6 @@ defmodule Andi.InputSchemas.InputConverter do
 
   defp ensure_nil_unit(""), do: nil
   defp ensure_nil_unit(unit), do: unit
-
-  defp decode_andi_extract_step_body(%{body: body} = http_extract_step) when body not in ["", nil] do
-    Map.put(http_extract_step, :body, Jason.decode!(body))
-  end
-
-  defp decode_andi_extract_step_body(andi_extract_step), do: andi_extract_step
 
   defp populate_schema_field_default(field) do
     {use_default, updated_field} = Map.pop(field, :use_default)

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.3",
+      version: "2.6.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/reaper/lib/reaper/data_extract/extract_step.ex
+++ b/apps/reaper/lib/reaper/data_extract/extract_step.ex
@@ -100,9 +100,6 @@ defmodule Reaper.DataExtract.ExtractStep do
   defp process_body(body, _assigns) when body in ["", nil], do: ""
 
   defp process_body(body, assigns) do
-    body
-    |> UrlBuilder.safe_evaluate_parameters(assigns)
-    |> Enum.into(%{})
-    |> Jason.encode!()
+    body |> UrlBuilder.safe_evaluate_body(assigns)
   end
 end

--- a/apps/reaper/lib/reaper/url_builder.ex
+++ b/apps/reaper/lib/reaper/url_builder.ex
@@ -29,6 +29,22 @@ defmodule Reaper.UrlBuilder do
     end)
   end
 
+  def safe_evaluate_body(body, bindings) when is_binary(body) do
+    regex = ~r"{{(.+?)}}"
+    replacements = Regex.scan(regex, body)
+
+    value =
+      Enum.reduce(replacements, body, fn replacement, new_body ->
+        Regex.replace(
+          ~r"#{List.first(replacement)}",
+          new_body,
+          bindings[String.to_atom(List.last(replacement))]
+        )
+      end)
+
+    value
+  end
+
   def safe_evaluate_parameters(parameters, bindings) do
     Enum.map(
       parameters,

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.24",
+      version: "2.0.25",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/test/unit/reaper/data_extract/extract_step_test.exs
+++ b/apps/reaper/test/unit/reaper/data_extract/extract_step_test.exs
@@ -76,7 +76,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}",
             encodeMethod: "json",
-            body: %{Key: "AuthToken"},
+            body: "{\"Key\": \"AuthToken\"}",
             headers: %{},
             cacheTtl: nil
           },
@@ -113,7 +113,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}",
             encodeMethod: "json",
-            body: %{Key: "AuthToken"},
+            body: "{\"Key\": \"AuthToken\"}",
             headers: %{},
             cacheTtl: nil
           },
@@ -150,7 +150,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}",
             encodeMethod: "json",
-            body: %{Key: "AuthToken"},
+            body: "{\"Key\": \"AuthToken\"}",
             headers: %{},
             cacheTtl: nil
           },
@@ -182,7 +182,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}",
             encodeMethod: "json",
-            body: %{Key: "{{key}}"},
+            body: "{\"Key\": \"{{key}}\"}",
             headers: %{},
             cacheTtl: nil
           },
@@ -247,7 +247,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}/headers",
             encodeMethod: "json",
-            body: %{},
+            body: "",
             headers: %{Header: "{{header}}"},
             cacheTtl: nil
           },
@@ -275,7 +275,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}/{{path}}",
             encodeMethod: "json",
-            body: %{},
+            body: "",
             headers: %{},
             cacheTtl: nil
           },
@@ -303,7 +303,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
             destination: "token",
             url: "http://localhost:#{bypass.port}",
             encodeMethod: "json",
-            body: %{Key: "AuthToken"},
+            body: "{\"Key\": \"AuthToken\"}",
             headers: %{},
             cacheTtl: nil
           },
@@ -424,7 +424,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
           context: %{
             action: "GET",
             protocol: nil,
-            body: %{},
+            body: "",
             url: "#{sourceUrl}",
             queryParams: %{},
             headers: %{}
@@ -460,7 +460,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
           context: %{
             action: "GET",
             protocol: nil,
-            body: %{},
+            body: "",
             url: "#{sourceUrl}/query",
             queryParams: %{
               token: "{{token}}"
@@ -492,7 +492,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
           context: %{
             action: "GET",
             protocol: nil,
-            body: %{},
+            body: "",
             url: "#{sourceUrl}/headers",
             queryParams: %{},
             headers: %{Bearer: "{{token}}"}
@@ -518,7 +518,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
           context: %{
             action: "GET",
             protocol: nil,
-            body: %{},
+            body: "",
             url: "#{sourceUrl}/{{path}}",
             queryParams: %{},
             headers: %{}
@@ -550,11 +550,11 @@ defmodule Reaper.DataExtract.ExtractStepTest do
           context: %{
             action: "POST",
             protocol: nil,
-            body: %{
-              soap_request: %{
-                date: "{{date}}"
+            body: "{
+              \"soap_request\": {
+                \"date\": \"{{date}}\"
               }
-            },
+            }",
             url: "#{sourceUrl}/post",
             queryParams: %{},
             headers: %{}
@@ -582,7 +582,7 @@ defmodule Reaper.DataExtract.ExtractStepTest do
           context: %{
             action: "GET",
             protocol: ["http1"],
-            body: %{},
+            body: "",
             url: "#{sourceUrl}",
             queryParams: %{},
             headers: %{}

--- a/apps/reaper/test/unit/reaper/url_builder_test.exs
+++ b/apps/reaper/test/unit/reaper/url_builder_test.exs
@@ -72,4 +72,44 @@ defmodule Reaper.UrlBuilderTest do
       ]
     ])
   end
+
+  test "safe evaluate xml body with bindings replaces bindings successfully" do
+    body =
+      "<soap12:Envelope>\n  <soap12:Body>\n    <{{date}} xmlns=\"{{key}}\">\n    </{{date}}>\n  </soap12:Body>\n</soap12:Envelope>"
+
+    bindings = %{
+      date: "19700101",
+      key: "SECRET"
+    }
+
+    expected =
+      "<soap12:Envelope>\n  <soap12:Body>\n    <19700101 xmlns=\"SECRET\">\n    </19700101>\n  </soap12:Body>\n</soap12:Envelope>"
+
+    assert UrlBuilder.safe_evaluate_body(body, bindings) == expected
+  end
+
+  test "safe evaluate json body with bindings replaces bindings successfully" do
+    body = "{\"{{date}}\": \"{{key}}\"}"
+
+    bindings = %{
+      date: "19700101",
+      key: "SECRET"
+    }
+
+    expected = "{\"19700101\": \"SECRET\"}"
+
+    assert UrlBuilder.safe_evaluate_body(body, bindings) == expected
+  end
+
+  test "safe evaluate body without bindings returns existing body with no changes" do
+    body =
+      "<soap12:Envelope>\n  <soap12:Body>\n    <Test>\n    </Test>\n  </soap12:Body>\n</soap12:Envelope>"
+
+    bindings = %{}
+
+    expected =
+      "<soap12:Envelope>\n  <soap12:Body>\n    <Test>\n    </Test>\n  </soap12:Body>\n</soap12:Envelope>"
+
+    assert UrlBuilder.safe_evaluate_body(body, bindings) == expected
+  end
 end


### PR DESCRIPTION
## [Ticket Link #1111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1111)

## Description

Enable XML bodies in HTTP POST

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
