### PR TITLE
665 - Conditional Transformation UI Part 2

### DIFF
--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.24",
+      version: "0.2.25",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
@@ -27,7 +27,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
       </div>
       <div>
         <%= label(form, :conditionOperation, "Comparison", class: "label label--required", for: "transformation_condition_#{@id}__comparison") %>
-        <%= select(form, :conditionOperation, ["", "Is Equal To", "Is Greater Than", "Is Less Than"], [value: get_in(form.source.changes, [:parameters, :conditionOperation]), id: "transformation_condition_#{@id}__comparison", class: "select transformation-type", required: true]) %>
+        <%= select(form, :conditionOperation, ["", "Is Equal To", "Is Not Equal To", "Is Greater Than", "Is Less Than"], [value: get_in(form.source.changes, [:parameters, :conditionOperation]), id: "transformation_condition_#{@id}__comparison", class: "select transformation-type", required: true]) %>
         <%= ErrorHelpers.error_tag(form.source, :conditionOperation, bind_to_input: false, id: "#{@id}_transformation_condition_comparison_error") %>
       </div>
       <div>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.5",
+      version: "2.6.51",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/lib/transformation_conditions.ex
+++ b/apps/transformers/lib/transformation_conditions.ex
@@ -128,7 +128,7 @@ defmodule Transformers.Conditions do
           do: try_parse(Map.fetch!(payload, target_field), data_type, target_format),
           else: try_parse(target_value, data_type, target_format)
 
-      case operation do
+      case map_operation(operation) do
         "=" -> {:ok, left_value == right_value}
         "!=" -> {:ok, left_value != right_value}
         ">" -> {:ok, left_value > right_value}
@@ -158,6 +158,16 @@ defmodule Transformers.Conditions do
 
       _ ->
         raise "unsupported parse type"
+    end
+  end
+
+  def map_operation(value) do
+    case value do
+      "Is Equal To" -> "="
+      "Is Not Equal To" -> "!="
+      "Is Greater Than" -> ">"
+      "Is Less Than" -> "<"
+      _ -> value
     end
   end
 end

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.19",
+      version: "1.0.20",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/conditions_test.exs
+++ b/apps/transformers/test/unit/conditions_test.exs
@@ -145,6 +145,29 @@ defmodule Transformers.ConditionsTest do
       result = Conditions.check(payload, parameters)
       assert result == {:ok, false}
     end
+
+    test "maps operation string 'Is Equal To'" do
+      parameters = %{
+        "targetField" => "testField",
+        "newValue" => "new value",
+        "valueType" => "string",
+        "condition" => "true",
+        "conditionCompareTo" => "Target Field",
+        "conditionDataType" => "string",
+        "sourceConditionField" => "testField",
+        "conditionOperation" => "Is Equal To",
+        "targetConditionField" => "compareField",
+        "targetConditionValue" => nil
+      }
+
+      payload = %{
+        "testField" => "value",
+        "compareField" => "value"
+      }
+
+      result = Conditions.check(payload, parameters)
+      assert result == {:ok, true}
+    end
   end
 
   describe "not equals" do
@@ -236,6 +259,28 @@ defmodule Transformers.ConditionsTest do
 
       result = Conditions.check(payload, parameters)
       assert result == {:ok, false}
+    end
+
+    test "maps operation string 'Is Not Equal To'" do
+      parameters = %{
+        "targetField" => "testField",
+        "newValue" => "new value",
+        "valueType" => "string",
+        "condition" => "true",
+        "conditionCompareTo" => "Static Value",
+        "conditionDataType" => "string",
+        "sourceConditionField" => "testField",
+        "conditionOperation" => "Is Not Equal To",
+        "targetConditionField" => nil,
+        "targetConditionValue" => "othervalue"
+      }
+
+      payload = %{
+        "testField" => "value"
+      }
+
+      result = Conditions.check(payload, parameters)
+      assert result == {:ok, true}
     end
   end
 
@@ -329,6 +374,28 @@ defmodule Transformers.ConditionsTest do
       result = Conditions.check(payload, parameters)
       assert result == {:ok, false}
     end
+
+    test "maps operation string 'Is Greater Than'" do
+      parameters = %{
+        "targetField" => "testField",
+        "newValue" => "new value",
+        "valueType" => "string",
+        "condition" => "true",
+        "conditionCompareTo" => "Static Value",
+        "conditionDataType" => "number",
+        "sourceConditionField" => "testField",
+        "conditionOperation" => "Is Greater Than",
+        "targetConditionField" => nil,
+        "targetConditionValue" => "1"
+      }
+
+      payload = %{
+        "testField" => 2
+      }
+
+      result = Conditions.check(payload, parameters)
+      assert result == {:ok, true}
+    end
   end
 
   describe "less than" do
@@ -420,6 +487,28 @@ defmodule Transformers.ConditionsTest do
 
       result = Conditions.check(payload, parameters)
       assert result == {:ok, false}
+    end
+
+    test "maps operation string 'Is Less Than'" do
+      parameters = %{
+        "targetField" => "testField",
+        "newValue" => "new value",
+        "valueType" => "string",
+        "condition" => "true",
+        "conditionCompareTo" => "Static Value",
+        "conditionDataType" => "number",
+        "sourceConditionField" => "testField",
+        "conditionOperation" => "Is Less Than",
+        "targetConditionField" => nil,
+        "targetConditionValue" => "3"
+      }
+
+      payload = %{
+        "testField" => 2
+      }
+
+      result = Conditions.check(payload, parameters)
+      assert result == {:ok, true}
     end
   end
 


### PR DESCRIPTION

## [Ticket Link #665](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/665)

## Description
Right after I merged changes I noticed a couple intended changes were missing from the previous PR due to a nasty cleanup step that I performed. They are as follows:
- add not equals option
- add conditional operation string mapper

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
