### PR TITLE
Display org title instead of org name on user page

### DIFF
--- a/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_table.ex
+++ b/apps/andi/lib/andi_web/live/user_live_view/edit_user_live_view_table.ex
@@ -20,7 +20,7 @@ defmodule AndiWeb.EditUserLiveView.EditUserLiveViewTable do
         <% else %>
           <%= for organization <- @organizations do %>
             <tr class="organizations-table__tr">
-              <td class="organizations-table__cell organizations-table__cell--break"><%= Map.get(organization, :orgName, "") %></td>
+              <td class="organizations-table__cell organizations-table__cell--break"><%= Map.get(organization, :orgTitle, "") %></td>
               <td class="organizations-table__cell organizations-table__cell primary-color-link" style="width: 10%;">
                 <%= Link.link("Edit", to: "/organizations/#{Map.get(organization, :id)}", class: "btn") %>
                 <button phx-click="remove_org" phx-value-org-id="<%= organization.id %>" phx-target="<%= @myself %>" class="btn btn--remove-organization">Remove</button>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.52",
+      version: "2.6.53",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #1108](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1108)

## Description

Before: 

![image](https://user-images.githubusercontent.com/54278348/230129763-6a6af531-aff3-436b-bf52-4829bfeb7009.png)



-------------------
After:

![Screen Shot 2023-04-05 at 10 29 12 AM](https://user-images.githubusercontent.com/54278348/230129561-324fef58-c957-4c4a-8cf7-1735a3b518ae.png)


## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
