### PR TITLE
1132 - Parse epoch strings in datetime transform

### DIFF
--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.27",
+      version: "0.2.28",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.22",
+      version: "1.0.23",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -20,6 +20,54 @@ defmodule Transformers.DateTimeTest do
     assert actual_transformed_field == "February 28, 2022 4:53 PM"
   end
 
+  test "parses time since epoch" do
+    params = %{
+      "sourceField" => "date1",
+      "targetField" => "date2",
+      "sourceFormat" => "{s-epoch}",
+      "targetFormat" => "{ISOdate}"
+    }
+
+    message_payload = %{"date1" => "1681232228"}
+
+    {:ok, transformed_payload} = Transformers.DateTime.transform(message_payload, params)
+
+    {:ok, actual_transformed_field} = Map.fetch(transformed_payload, params["targetField"])
+    assert actual_transformed_field == "2023-04-11"
+  end
+
+  test "parses epoch time and truncates decimal values" do
+    params = %{
+      "sourceField" => "date1",
+      "targetField" => "date2",
+      "sourceFormat" => "{s-epoch}",
+      "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
+    }
+
+    message_payload = %{"date1" => "1681232228.33823"}
+
+    {:ok, transformed_payload} = Transformers.DateTime.transform(message_payload, params)
+
+    {:ok, actual_transformed_field} = Map.fetch(transformed_payload, params["targetField"])
+    assert actual_transformed_field == "April 11, 2023 4:57 PM"
+  end
+
+  test "converts to epoch" do
+    params = %{
+      "sourceField" => "date1",
+      "targetField" => "date2",
+      "sourceFormat" => "{YYYY}-{0M}-{D} {h24}:{m}",
+      "targetFormat" => "{s-epoch}"
+    }
+
+    message_payload = %{"date1" => "2022-02-28 16:53"}
+
+    {:ok, transformed_payload} = Transformers.DateTime.transform(message_payload, params)
+
+    {:ok, actual_transformed_field} = Map.fetch(transformed_payload, params["targetField"])
+    assert actual_transformed_field == "1646067180"
+  end
+
   test "when source and target are the same field, source is overwritten" do
     params = %{
       "sourceField" => "date1",
@@ -124,6 +172,22 @@ defmodule Transformers.DateTimeTest do
                "Unable to parse datetime from \"date1\" in format \"{YYYY}-{0M}-{D} {h24}:{m}\": Expected `2 digit month` at line 1, column 4."
     end
 
+    test "returns error when epoch is incorrect" do
+      params = %{
+        "sourceField" => "date1",
+        "targetField" => "date2",
+        "sourceFormat" => "{s-epoch}",
+        "targetFormat" => "{ISOdate}"
+      }
+
+      message_payload = %{"date1" => "epoch"}
+
+      {:error, reason} = Transformers.DateTime.transform(message_payload, params)
+
+      assert reason ==
+               "Unable to parse datetime from \"date1\" in format \"{s-epoch}\": argument error"
+    end
+
     test "performs transform as normal when condition evaluates to true" do
       params = %{
         "sourceField" => "date1",
@@ -177,7 +241,7 @@ defmodule Transformers.DateTimeTest do
       parameters = %{
         "sourceField" => "date1",
         "targetField" => "date2",
-        "sourceFormat" => "{YYYY}-{0M}-{D} {h24}:{m}",
+        "sourceFormat" => "{s-epoch}",
         "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
       }
 


### PR DESCRIPTION
## [Ticket Link #1132](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1132)

## Description

- Added logic for parsing epoch strings to datetimes
- Added tests for conversions

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
