### PR TITLE
1125 nested transformations

### DIFF
--- a/apps/transformers/lib/parse_utils.ex
+++ b/apps/transformers/lib/parse_utils.ex
@@ -70,13 +70,16 @@ defmodule Transformers.ParseUtils do
   defp parseList(prospectiveList, payload) do
     if Regex.match?(~r/\[\*\]/, prospectiveList) do
       [base_parent_key, child_key] = String.split(prospectiveList, "[*].")
-      list = Enum.reduce(payload, [], fn {key, value}, acc ->
-        if String.starts_with?(key, base_parent_key) and String.ends_with?(key, child_key) do
-          acc ++ [value]
-        else
-          acc
-        end
-      end)
+
+      list =
+        Enum.reduce(payload, [], fn {key, value}, acc ->
+          if String.starts_with?(key, base_parent_key) and String.ends_with?(key, child_key) do
+            acc ++ [value]
+          else
+            acc
+          end
+        end)
+
       {:ok, list}
     else
       {:error, nil}

--- a/apps/transformers/lib/transform_actions.ex
+++ b/apps/transformers/lib/transform_actions.ex
@@ -98,22 +98,23 @@ defmodule Transformers do
 
         hierarchy ->
           {parent_key, child_hierarchy} = List.pop_at(hierarchy, 0)
-            |> IO.inspect(label: "Nicholas - {parent_key, child_hierarchy}")
 
           if Regex.match?(~r/\[.\]/, parent_key) do
+            base_parent_key = Regex.replace(~r/\[.\]/, parent_key, "")
             index = Regex.scan(~r/\[.\]/, parent_key)
               |> hd() |> hd()
               |> String.replace("[", "")
               |> String.replace("]", "")
+              |> String.to_integer()
+              |> IO.inspect(label: "index")
 
-            case index do
-              index when index == "*" ->
-                IO.inspect("Nicholas - wild card")
-              index ->
-                numeric_index = String.to_integer(index)
-                  |> IO.inspect(label: "Nicholas - numeric_index")
-            end
+            current_acc = Map.get(acc, base_parent_key, [])
 
+            updated_map = create_child_map(child_hierarchy, value)
+
+            updated_acc = List.insert_at(current_acc, index, updated_map)
+
+            Map.put(acc, base_parent_key, updated_acc)
           else
             map_child(parent_key, child_hierarchy, value, acc)
           end

--- a/apps/transformers/lib/transform_actions.ex
+++ b/apps/transformers/lib/transform_actions.ex
@@ -32,8 +32,19 @@ defmodule Transformers do
     end)
   end
 
+  def perform(operations, initial_payload) do
+    if(OperationUtils.allOperationsItemsAreFunctions(operations)) do
+      executeOperations(operations, initial_payload)
+    else
+      IO.inspect(operations, label: "Error occurred executing these ops")
+      {:error, "Invalid list of functions passed to performTransformations"}
+    end
+  end
+
   defp executeOperations(operations, initial_payload) do
-    Enum.reduce_while(operations, {:ok, initial_payload}, fn op, {:ok, acc_payload} ->
+    flatten_payload = flatten_payload(initial_payload)
+
+    result_payload = Enum.reduce_while(operations, {:ok, flatten_payload}, fn op, {:ok, acc_payload} ->
       case op.(acc_payload) do
         {:ok, result} ->
           {:cont, {:ok, result}}
@@ -42,14 +53,56 @@ defmodule Transformers do
           {:halt, {:error, reason}}
       end
     end)
+
+    case result_payload do
+      {:ok, payload} -> {:ok, split_payload(payload)}
+      error -> error
+    end
+
   end
 
-  def perform(operations, initial_payload) do
-    if(OperationUtils.allOperationsItemsAreFunctions(operations)) do
-      executeOperations(operations, initial_payload)
-    else
-      IO.inspect(operations, label: "Error occurred executing these ops")
-      {:error, "Invalid list of functions passed to performTransformations"}
+  defp flatten_payload(payload, parent_key \\ "") do
+    Enum.reduce(payload, %{}, fn {key, value}, acc ->
+      case value do
+        value when is_map(value) ->
+          child_payload = flatten_payload(value, concat_key(key, parent_key))
+          Map.merge(acc, child_payload)
+        value when is_list(value) ->
+          IO.inspect("Nicholas - list")
+          acc
+        value -> Map.put(acc, concat_key(key, parent_key), value)
+      end
+    end)
+  end
+
+  defp concat_key(key, parent_key) do
+    case parent_key do
+      "" -> key
+      _ -> "#{parent_key}.#{key}"
+    end
+  end
+
+  defp split_payload(payload) do
+    Enum.reduce(payload, %{}, fn {key, value}, acc ->
+      case String.split(key, ".") do
+        hierarchy when length(hierarchy) == 1 -> Map.put(acc, hd(hierarchy), value)
+        hierarchy ->
+          {parent_key, child_hierarchy} = List.pop_at(hierarchy, 0)
+          parent_map = Map.get(acc, parent_key, %{})
+
+          updated_parent_map = create_child_map(child_hierarchy, value)
+            |> Map.merge(parent_map)
+
+          Map.put(acc, parent_key, updated_parent_map)
+      end
+    end)
+  end
+
+  defp create_child_map(hierarchy, value) do
+    {parent_key, child_hierarchy} = List.pop_at(hierarchy, 0)
+    case hierarchy do
+      hierarchy when length(hierarchy) == 1 -> Map.new([{hd(hierarchy), value}])
+      _ -> Map.new([{parent_key, create_child_map(child_hierarchy, value)}])
     end
   end
 end

--- a/apps/transformers/lib/transform_actions.ex
+++ b/apps/transformers/lib/transform_actions.ex
@@ -109,7 +109,6 @@ defmodule Transformers do
               |> String.replace("[", "")
               |> String.replace("]", "")
               |> String.to_integer()
-              |> IO.inspect(label: "index")
 
             current_acc = Map.get(acc, base_parent_key, [])
 

--- a/apps/transformers/lib/transform_actions.ex
+++ b/apps/transformers/lib/transform_actions.ex
@@ -70,12 +70,12 @@ defmodule Transformers do
 
         value when is_list(value) ->
           value
-            |> Enum.with_index
-            |> Enum.reduce(acc, fn({value, index}), enum_acc ->
-              parent_key = "#{concat_key(key, parent_key)}[#{index}]"
-              child_payload = flatten_payload(value, parent_key)
-              Map.merge(enum_acc, child_payload)
-            end)
+          |> Enum.with_index()
+          |> Enum.reduce(acc, fn {value, index}, enum_acc ->
+            parent_key = "#{concat_key(key, parent_key)}[#{index}]"
+            child_payload = flatten_payload(value, parent_key)
+            Map.merge(enum_acc, child_payload)
+          end)
 
         value ->
           Map.put(acc, concat_key(key, parent_key), value)
@@ -101,8 +101,11 @@ defmodule Transformers do
 
           if Regex.match?(~r/\[.\]/, parent_key) do
             base_parent_key = Regex.replace(~r/\[.\]/, parent_key, "")
-            index = Regex.scan(~r/\[.\]/, parent_key)
-              |> hd() |> hd()
+
+            index =
+              Regex.scan(~r/\[.\]/, parent_key)
+              |> hd()
+              |> hd()
               |> String.replace("[", "")
               |> String.replace("]", "")
               |> String.to_integer()

--- a/apps/transformers/lib/transformation_conditions.ex
+++ b/apps/transformers/lib/transformation_conditions.ex
@@ -79,8 +79,8 @@ defmodule Transformers.Conditions do
 
         "Target Field" ->
           valid_status
-            |> NotBlank.check(parameters, @target_field)
-            |> NotBlank.check_nested(parameters, @target_field)
+          |> NotBlank.check(parameters, @target_field)
+          |> NotBlank.check_nested(parameters, @target_field)
 
         _ ->
           valid_status

--- a/apps/transformers/lib/transformation_conditions.ex
+++ b/apps/transformers/lib/transformation_conditions.ex
@@ -68,6 +68,7 @@ defmodule Transformers.Conditions do
       |> check_datetime(parameters)
       |> NotBlank.check(parameters, @operation_field)
       |> NotBlank.check(parameters, @source_field)
+      |> NotBlank.check_nested(parameters, @source_field)
 
     comp_val = Map.get(parameters, @condition_compare_to)
 
@@ -77,7 +78,9 @@ defmodule Transformers.Conditions do
           valid_status |> NotBlank.check(parameters, @target_value)
 
         "Target Field" ->
-          valid_status |> NotBlank.check(parameters, @target_field)
+          valid_status
+            |> NotBlank.check(parameters, @target_field)
+            |> NotBlank.check_nested(parameters, @target_field)
 
         _ ->
           valid_status

--- a/apps/transformers/lib/transformations/add.ex
+++ b/apps/transformers/lib/transformations/add.ex
@@ -36,6 +36,8 @@ defmodule Transformers.Add do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @addends)
     |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @addends)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> ValidationStatus.ordered_values_or_errors([@addends, @target_field])
   end
 

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -31,6 +31,8 @@ defmodule Transformers.Concatenation do
     |> NotBlank.check(parameters, @source_fields)
     |> NotBlank.check(parameters, @separator)
     |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @source_fields)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> IsPresent.check(parameters, @separator)
     |> ValidationStatus.ordered_values_or_errors([@source_fields, @separator, @target_field])
   end

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -47,7 +47,6 @@ defmodule Transformers.Concatenation do
 
   def find_values_or_errors(payload, field_names) do
     Enum.reduce(field_names, %{values: [], errors: []}, fn field_name, accumulator ->
-
       if Regex.match?(~r/\[\*\]/, field_name) do
         [base_parent_key, child_key] = String.split(field_name, "[*].")
 

--- a/apps/transformers/lib/transformations/concatenation.ex
+++ b/apps/transformers/lib/transformations/concatenation.ex
@@ -47,9 +47,22 @@ defmodule Transformers.Concatenation do
 
   def find_values_or_errors(payload, field_names) do
     Enum.reduce(field_names, %{values: [], errors: []}, fn field_name, accumulator ->
-      case Map.fetch(payload, field_name) do
-        {:ok, value} -> update_list_in_map(accumulator, :values, value)
-        :error -> update_list_in_map(accumulator, :errors, field_name)
+
+      if Regex.match?(~r/\[\*\]/, field_name) do
+        [base_parent_key, child_key] = String.split(field_name, "[*].")
+
+        Enum.reduce(payload, accumulator, fn {key, value}, acc ->
+          if String.starts_with?(key, base_parent_key) and String.ends_with?(key, child_key) do
+            update_list_in_map(acc, :values, value)
+          else
+            acc
+          end
+        end)
+      else
+        case Map.fetch(payload, field_name) do
+          {:ok, value} -> update_list_in_map(accumulator, :values, value)
+          :error -> update_list_in_map(accumulator, :errors, field_name)
+        end
       end
     end)
     |> reverse_list(:values)

--- a/apps/transformers/lib/transformations/constant.ex
+++ b/apps/transformers/lib/transformations/constant.ex
@@ -20,9 +20,11 @@ defmodule Transformers.Constant do
     end
   end
 
+  @spec validate(any) :: {:error, any} | {:ok, list}
   def validate(parameters) do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> NotBlank.check(parameters, @new_value)
     |> NotBlank.check(parameters, @value_type)
     |> ValidationStatus.ordered_values_or_errors([@target_field, @new_value, @value_type])

--- a/apps/transformers/lib/transformations/date_time.ex
+++ b/apps/transformers/lib/transformations/date_time.ex
@@ -42,6 +42,8 @@ defmodule Transformers.DateTime do
     |> NotBlank.check(parameters, @source_format)
     |> NotBlank.check(parameters, @target_field)
     |> NotBlank.check(parameters, @target_format)
+    |> NotBlank.check_nested(parameters, @source_field)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> DateTimeFormat.check(parameters, @source_format)
     |> DateTimeFormat.check(parameters, @target_format)
     |> ValidationStatus.ordered_values_or_errors([

--- a/apps/transformers/lib/transformations/division.ex
+++ b/apps/transformers/lib/transformations/division.ex
@@ -56,6 +56,9 @@ defmodule Transformers.Division do
     |> NotBlank.check_nil(parameters, @dividend)
     |> NotBlank.check_nil(parameters, @divisor)
     |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @dividend)
+    |> NotBlank.check_nested(parameters, @divisor)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> ValidationStatus.ordered_values_or_errors([@dividend, @divisor, @target_field])
   end
 

--- a/apps/transformers/lib/transformations/division.ex
+++ b/apps/transformers/lib/transformations/division.ex
@@ -18,8 +18,8 @@ defmodule Transformers.Division do
          {:ok, [dividend, divisor, target_field_name]} <- validate(parameters),
          {:ok, numeric_dividend} <- ParseUtils.parseValue(dividend, payload),
          {:ok, numeric_divisor} <- ParseUtils.parseValue(divisor, payload),
-         {:ok, dividend} <- resolve_payload_field(payload, numeric_dividend),
-         {:ok, divisor} <- resolve_divisor(payload, numeric_divisor),
+         {:ok, _dividend} <- resolve_payload_field(payload, numeric_dividend),
+         {:ok, _divisor} <- resolve_divisor(payload, numeric_divisor),
          {:ok, quotient} <- {:ok, D.div(D.cast(numeric_dividend), D.cast(numeric_divisor))} do
       {:ok, payload |> Map.put(target_field_name, D.to_float(quotient))}
     else

--- a/apps/transformers/lib/transformations/multiplication.ex
+++ b/apps/transformers/lib/transformations/multiplication.ex
@@ -67,6 +67,8 @@ defmodule Transformers.Multiplication do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @multiplicands)
     |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @multiplicands)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> ValidationStatus.ordered_values_or_errors([@multiplicands, @target_field])
   end
 

--- a/apps/transformers/lib/transformations/regex_extract.ex
+++ b/apps/transformers/lib/transformations/regex_extract.ex
@@ -38,6 +38,8 @@ defmodule Transformers.RegexExtract do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @source_field)
     |> NotBlank.check(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @source_field)
+    |> NotBlank.check_nested(parameters, @target_field)
     |> NotBlank.check(parameters, @regex)
     |> ValidRegex.check(parameters, @regex)
     |> ValidationStatus.ordered_values_or_errors([@source_field, @target_field, @regex])

--- a/apps/transformers/lib/transformations/regex_replace.ex
+++ b/apps/transformers/lib/transformations/regex_replace.ex
@@ -31,6 +31,8 @@ defmodule Transformers.RegexReplace do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @source_field)
     |> NotBlank.check(parameters, @replacement)
+    |> NotBlank.check_nested(parameters, @source_field)
+    |> NotBlank.check_nested(parameters, @replacement)
     |> NotBlank.check(parameters, @regex)
     |> ValidRegex.check(parameters, @regex)
     |> ValidationStatus.ordered_values_or_errors([@source_field, @replacement, @regex])

--- a/apps/transformers/lib/transformations/remove.ex
+++ b/apps/transformers/lib/transformations/remove.ex
@@ -24,6 +24,7 @@ defmodule Transformers.Remove do
   def validate(parameters) do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @source_field)
+    |> NotBlank.check_nested(parameters, @source_field)
     |> ValidationStatus.ordered_values_or_errors([@source_field])
   end
 

--- a/apps/transformers/lib/transformations/subtract.ex
+++ b/apps/transformers/lib/transformations/subtract.ex
@@ -47,6 +47,9 @@ defmodule Transformers.Subtract do
     |> NotBlank.check_nil(parameters, @minuend)
     |> NotBlank.check(parameters, @target_field)
     |> NotBlank.check(parameters, @subtrahends)
+    |> NotBlank.check_nested(parameters, @minuend)
+    |> NotBlank.check_nested(parameters, @target_field)
+    |> NotBlank.check_nested(parameters, @subtrahends)
     |> ValidationStatus.ordered_values_or_errors([@minuend, @subtrahends, @target_field])
   end
 

--- a/apps/transformers/lib/transformations/type_conversion.ex
+++ b/apps/transformers/lib/transformations/type_conversion.ex
@@ -30,6 +30,7 @@ defmodule Transformers.TypeConversion do
   def validate(parameters) do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @field)
+    |> NotBlank.check_nested(parameters, @field)
     |> NotBlank.check(parameters, @source_type)
     |> NotBlank.check(parameters, @target_type)
     |> ValidTypeConversion.check(parameters, @source_type, @target_type, @conversion_function)

--- a/apps/transformers/lib/validations/not_blank.ex
+++ b/apps/transformers/lib/validations/not_blank.ex
@@ -25,13 +25,14 @@ defmodule Transformers.Validations.NotBlank do
     else
       value = Map.get(parameters, field)
 
-      invalid? = case value do
-        nil -> ValidationStatus.add_error(status, field, "Missing or empty field")
-        value when is_binary(value) -> check_if_nested_binary_invalid(value)
-        value when is_list(value) -> check_if_nested_list_invalid(value)
-        value when is_number(value) -> false
-        _ -> true
-      end
+      invalid? =
+        case value do
+          nil -> ValidationStatus.add_error(status, field, "Missing or empty field")
+          value when is_binary(value) -> check_if_nested_binary_invalid(value)
+          value when is_list(value) -> check_if_nested_list_invalid(value)
+          value when is_number(value) -> false
+          _ -> true
+        end
 
       case invalid? do
         true -> ValidationStatus.add_error(status, field, "Missing or empty child field")
@@ -44,6 +45,7 @@ defmodule Transformers.Validations.NotBlank do
     case String.split(value, ", ") do
       split when length(split) == 1 ->
         String.ends_with?(value, ".")
+
       split ->
         check_if_nested_list_invalid(split)
     end

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.24",
+      version: "1.0.25",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.23",
+      version: "1.0.24",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/transformation_action_test.exs
+++ b/apps/transformers/test/unit/transformation_action_test.exs
@@ -1,0 +1,185 @@
+defmodule TransformationActionTest do
+  use ExUnit.Case
+
+  alias Transformers
+  alias SmartCity.TestDataGenerator, as: TDG
+
+  describe "Construct" do
+    test "should construct transformation" do
+      transformation1 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "add",
+          parameters: %{
+            "condition" => "false",
+            "addends" => "5, 9",
+            "targetField" => "parent.add"
+          },
+          sequence: 0
+        })
+
+      transformation2 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "concatenation",
+          parameters: %{
+            "condition" => "false",
+            "sourceFields" => "one, parent.child.two",
+            "separator" => ", ",
+            "targetField" => "concat"
+          },
+          sequence: 1
+        })
+
+      operations =
+        [transformation1, transformation2]
+        |> Transformers.construct()
+
+      assert length(operations) == 2
+    end
+
+    test "should error" do
+      [error: reason] = Transformers.construct([%{}])
+
+      assert reason == "Map provided is not a valid transformation"
+    end
+  end
+
+  describe "Validate" do
+    test "should validate transformation" do
+      transformation1 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "add",
+          parameters: %{
+            "condition" => "false",
+            "addends" => "5, 9",
+            "targetField" => "parent.add"
+          },
+          sequence: 0
+        })
+
+      transformation2 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "concatenation",
+          parameters: %{
+            "condition" => "false",
+            "sourceFields" => "one, parent.child.two",
+            "separator" => ", ",
+            "targetField" => "concat"
+          },
+          sequence: 1
+        })
+
+      assert [ok: "Transformation valid.", ok: "Transformation valid."] ==
+               [transformation1, transformation2]
+               |> Transformers.validate()
+    end
+
+    test "should error" do
+      [error: reason] = Transformers.validate([%{}])
+
+      assert reason == "Map provided is not a valid transformation"
+    end
+  end
+
+  describe "Perform" do
+    test "should perform operations" do
+      transformation1 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "add",
+          parameters: %{
+            "condition" => "false",
+            "addends" => "5, 9",
+            "targetField" => "parent.add"
+          },
+          sequence: 0
+        })
+
+      transformation2 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "concatenation",
+          parameters: %{
+            "condition" => "false",
+            "sourceFields" => "one, parent.child.two",
+            "separator" => ", ",
+            "targetField" => "concat"
+          },
+          sequence: 1
+        })
+
+      operations =
+        [transformation1, transformation2]
+        |> Transformers.construct()
+
+      initial_payload = %{
+        "one" => "something",
+        "parent" => %{
+          "child" => %{
+            "two" => "else"
+          }
+        }
+      }
+
+      {:ok, resulting_payload} = Transformers.perform(operations, initial_payload)
+
+      assert resulting_payload == %{
+               "one" => "something",
+               "parent" => %{
+                 "add" => 14,
+                 "child" => %{
+                   "two" => "else"
+                 }
+               },
+               "concat" => "something, else"
+             }
+    end
+
+    test "should error out and give reason" do
+      transformation1 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "add",
+          parameters: %{
+            "condition" => "false",
+            "addends" => "5, 9",
+            "targetField" => "parent.add"
+          },
+          sequence: 0
+        })
+
+      transformation2 =
+        TDG.create_transformation(%{
+          name: "sample",
+          type: "concatenation",
+          parameters: %{
+            "condition" => "false",
+            "sourceFields" => "INVALID, parent.child.two",
+            "separator" => ", ",
+            "targetField" => "concat"
+          },
+          sequence: 1
+        })
+
+      operations =
+        [transformation1, transformation2]
+        |> Transformers.construct()
+
+      initial_payload = %{
+        "one" => "something",
+        "parent" => %{
+          "child" => %{
+            "two" => "else"
+          }
+        }
+      }
+
+      {:error, reason} = Transformers.perform(operations, initial_payload)
+
+      assert reason == "Missing field in payload: [INVALID]"
+    end
+  end
+end

--- a/apps/transformers/test/unit/transformation_action_test.exs
+++ b/apps/transformers/test/unit/transformation_action_test.exs
@@ -260,7 +260,6 @@ defmodule TransformationActionTest do
           sequence: 0
         })
 
-
       operations =
         [transformation1]
         |> Transformers.construct()
@@ -276,12 +275,12 @@ defmodule TransformationActionTest do
       {:ok, resulting_payload} = Transformers.perform(operations, initial_payload)
 
       assert resulting_payload == %{
-        "sourceTestField" => %{"inner" => "knownValue"},
-        "targetTestField" => %{"inner" => "knownValue"},
-        "parent" => %{
-          "child" => 14
-        },
-      }
+               "sourceTestField" => %{"inner" => "knownValue"},
+               "targetTestField" => %{"inner" => "knownValue"},
+               "parent" => %{
+                 "child" => 14
+               }
+             }
     end
 
     test "should access listed source values when specified in conditionals" do
@@ -303,7 +302,6 @@ defmodule TransformationActionTest do
           sequence: 0
         })
 
-
       operations =
         [transformation1]
         |> Transformers.construct()
@@ -319,12 +317,12 @@ defmodule TransformationActionTest do
       {:ok, resulting_payload} = Transformers.perform(operations, initial_payload)
 
       assert resulting_payload == %{
-        "sourceTestField" => [%{"inner" => "knownValue"}],
-        "targetTestField" => %{"inner" => "knownValue"},
-        "parent" => %{
-          "child" => 14
-        },
-      }
+               "sourceTestField" => [%{"inner" => "knownValue"}],
+               "targetTestField" => %{"inner" => "knownValue"},
+               "parent" => %{
+                 "child" => 14
+               }
+             }
     end
   end
 end

--- a/apps/transformers/test/unit/transformation_action_test.exs
+++ b/apps/transformers/test/unit/transformation_action_test.exs
@@ -235,7 +235,7 @@ defmodule TransformationActionTest do
                  }
                },
                "parent_list" => [
-                %{"child" => 9}
+                 %{"child" => 9}
                ],
                "concat" => "something, else"
              }

--- a/apps/transformers/test/unit/transformations/add_test.exs
+++ b/apps/transformers/test/unit/transformations/add_test.exs
@@ -191,6 +191,38 @@ defmodule Transformers.AddTest do
                "targetField" => "Missing or empty child field"
              }
     end
+
+    test "should get into list values" do
+      payload = %{
+        "parent_list" => [
+          %{"one" => 4}
+        ],
+        "parent_list2" => [
+          %{"two" => 5},
+          %{"two" => 2},
+          %{"two" => 6}
+        ]
+      }
+
+      parameters = %{
+        "addends" => ["parent_list[0].one", "parent_list[*].two"],
+        "targetField" => "target"
+      }
+
+      {:okay, resulting_payload} = Add.transform(payload, parameters)
+
+      assert resulting_payload == %{
+        "parent_list" => [
+          %{"one" => 4}
+        ],
+        "parent_list2" => [
+          %{"two" => 5},
+          %{"two" => 2},
+          %{"two" => 6}
+        ],
+        "target" => 17
+      }
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/add_test.exs
+++ b/apps/transformers/test/unit/transformations/add_test.exs
@@ -186,7 +186,10 @@ defmodule Transformers.AddTest do
 
       {:error, reason} = Add.transform(payload, parameters)
 
-      assert reason == %{"addends" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+      assert reason == %{
+               "addends" => "Missing or empty child field",
+               "targetField" => "Missing or empty child field"
+             }
     end
   end
 

--- a/apps/transformers/test/unit/transformations/add_test.exs
+++ b/apps/transformers/test/unit/transformations/add_test.exs
@@ -154,6 +154,40 @@ defmodule Transformers.AddTest do
 
       assert result == %{"target" => 0}
     end
+
+    test "if any addends end with a period, return error" do
+      payload = %{
+        "one" => 3,
+        "two" => 4,
+        "target" => 0
+      }
+
+      parameters = %{
+        "addends" => ["one.", "two"],
+        "targetField" => "target"
+      }
+
+      {:error, reason} = Add.transform(payload, parameters)
+
+      assert reason == %{"addends" => "Missing or empty child field"}
+    end
+
+    test "if target end with a period, return error" do
+      payload = %{
+        "one" => 3,
+        "two" => 4,
+        "target" => 0
+      }
+
+      parameters = %{
+        "addends" => ["one", "two."],
+        "targetField" => "target."
+      }
+
+      {:error, reason} = Add.transform(payload, parameters)
+
+      assert reason == %{"addends" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/add_test.exs
+++ b/apps/transformers/test/unit/transformations/add_test.exs
@@ -208,12 +208,12 @@ defmodule Transformers.AddTest do
       {:ok, resulting_payload} = Add.transform(payload, parameters)
 
       assert resulting_payload == %{
-        "parent_list[0].one" => 4,
-        "parent_list2[0].two" => 5,
-        "parent_list2[1].two" => 2,
-        "parent_list2[2].two" => 6,
-        "target" => 17
-      }
+               "parent_list[0].one" => 4,
+               "parent_list2[0].two" => 5,
+               "parent_list2[1].two" => 2,
+               "parent_list2[2].two" => 6,
+               "target" => 17
+             }
     end
   end
 

--- a/apps/transformers/test/unit/transformations/add_test.exs
+++ b/apps/transformers/test/unit/transformations/add_test.exs
@@ -194,14 +194,10 @@ defmodule Transformers.AddTest do
 
     test "should get into list values" do
       payload = %{
-        "parent_list" => [
-          %{"one" => 4}
-        ],
-        "parent_list2" => [
-          %{"two" => 5},
-          %{"two" => 2},
-          %{"two" => 6}
-        ]
+        "parent_list[0].one" => 4,
+        "parent_list2[0].two" => 5,
+        "parent_list2[1].two" => 2,
+        "parent_list2[2].two" => 6
       }
 
       parameters = %{
@@ -209,17 +205,13 @@ defmodule Transformers.AddTest do
         "targetField" => "target"
       }
 
-      {:okay, resulting_payload} = Add.transform(payload, parameters)
+      {:ok, resulting_payload} = Add.transform(payload, parameters)
 
       assert resulting_payload == %{
-        "parent_list" => [
-          %{"one" => 4}
-        ],
-        "parent_list2" => [
-          %{"two" => 5},
-          %{"two" => 2},
-          %{"two" => 6}
-        ],
+        "parent_list[0].one" => 4,
+        "parent_list2[0].two" => 5,
+        "parent_list2[1].two" => 2,
+        "parent_list2[2].two" => 6,
         "target" => 17
       }
     end

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -226,6 +226,41 @@ defmodule Transformers.ConcatenationTest do
       assert "I" == Map.get(result, "middle_initial")
       assert "Am" == Map.get(result, "last_name")
     end
+
+    test "if any addends end with a period, return error" do
+
+      payload = %{
+        "string1" => "one",
+        "string2" => "two"
+      }
+
+      parameters = %{
+        "sourceFields" => "name, last_name.",
+        "separator" => ".",
+        "targetField" => "full_name"
+      }
+
+      {:error, reason} = Concatenation.transform(payload, parameters)
+
+      assert reason == %{"sourceFields" => "Missing or empty child field"}
+    end
+
+    test "if target end with a period, return error" do
+      payload = %{
+        "string1" => "one",
+        "string2" => "two"
+      }
+
+      parameters = %{
+        "sourceFields" => "name, last_name.",
+        "separator" => ".",
+        "targetField" => "full_name."
+      }
+
+      {:error, reason} = Concatenation.transform(payload, parameters)
+
+      assert reason == %{"sourceFields" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+    end
   end
 
   describe "validate/1" do

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -228,7 +228,6 @@ defmodule Transformers.ConcatenationTest do
     end
 
     test "if any addends end with a period, return error" do
-
       payload = %{
         "string1" => "one",
         "string2" => "two"
@@ -259,7 +258,10 @@ defmodule Transformers.ConcatenationTest do
 
       {:error, reason} = Concatenation.transform(payload, parameters)
 
-      assert reason == %{"sourceFields" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+      assert reason == %{
+               "sourceFields" => "Missing or empty child field",
+               "targetField" => "Missing or empty child field"
+             }
     end
   end
 

--- a/apps/transformers/test/unit/transformations/concatenation_test.exs
+++ b/apps/transformers/test/unit/transformations/concatenation_test.exs
@@ -83,6 +83,29 @@ defmodule Transformers.ConcatenationTest do
       assert "Am" == Map.get(result, "last_name")
     end
 
+    test "concatenate string works with lists" do
+      payload = %{
+        "parent_list[0].one" => "Sam",
+        "parent_list2[0].two" => "I",
+        "parent_list2[1].two" => "Am",
+        "parent_list2[2].two" => "Here"
+      }
+
+      parameters = %{
+        "sourceFields" => "parent_list[0].one, parent_list2[*].two",
+        "separator" => ".",
+        "targetField" => "full_name"
+      }
+
+      {:ok, result} = Concatenation.transform(payload, parameters)
+
+      assert "Sam.I.Am.Here" == Map.get(result, "full_name")
+      assert "Sam" == Map.get(result, "parent_list[0].one")
+      assert "I" == Map.get(result, "parent_list2[0].two")
+      assert "Am" == Map.get(result, "parent_list2[1].two")
+      assert "Here" == Map.get(result, "parent_list2[2].two")
+    end
+
     test "concatenate string fields into existing field" do
       payload = %{
         "name" => "Sam",
@@ -227,7 +250,7 @@ defmodule Transformers.ConcatenationTest do
       assert "Am" == Map.get(result, "last_name")
     end
 
-    test "if any addends end with a period, return error" do
+    test "if any parameters end with a period, return error" do
       payload = %{
         "string1" => "one",
         "string2" => "two"

--- a/apps/transformers/test/unit/transformations/constant_test.exs
+++ b/apps/transformers/test/unit/transformations/constant_test.exs
@@ -158,5 +158,21 @@ defmodule Transformers.ConstantTest do
 
       assert result == "Error: could not convert 'flooooaaaat' to type: float"
     end
+
+    test "returns error when target fields ends with ." do
+      parameters = %{
+        "targetField" => "testField.",
+        "newValue" => "new value",
+        "valueType" => "flat"
+      }
+
+      payload = %{
+        "testField" => "old value"
+      }
+
+      {:error, result} = Constant.transform(payload, parameters)
+
+      assert result == %{"targetField" => "Missing or empty child field"}
+    end
   end
 end

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -306,5 +306,19 @@ defmodule Transformers.DateTimeTest do
 
       assert reason == %{"sourceFormat" => "Missing or empty field"}
     end
+
+    test "returns errors when fields ends with ." do
+      parameters = %{
+        "sourceField" => "date1.",
+        "targetField" => "date2.",
+        "sourceFormat" => "{s-epoch}",
+        "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
+      }
+
+      {:error, reason} =
+        DateTime.validate(parameters)
+
+      assert reason == %{"sourceField" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+    end
   end
 end

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -315,10 +315,12 @@ defmodule Transformers.DateTimeTest do
         "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
       }
 
-      {:error, reason} =
-        DateTime.validate(parameters)
+      {:error, reason} = DateTime.validate(parameters)
 
-      assert reason == %{"sourceField" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+      assert reason == %{
+               "sourceField" => "Missing or empty child field",
+               "targetField" => "Missing or empty child field"
+             }
     end
   end
 end

--- a/apps/transformers/test/unit/transformations/date_time_test.exs
+++ b/apps/transformers/test/unit/transformations/date_time_test.exs
@@ -102,6 +102,28 @@ defmodule Transformers.DateTimeTest do
            }
   end
 
+  test "should parse from a list" do
+    params = %{
+      "sourceField" => "parent_list[0].date1",
+      "targetField" => "date1",
+      "sourceFormat" => "{YYYY}-{0M}-{D} {h24}:{m}",
+      "targetFormat" => "{Mfull} {D}, {YYYY} {h12}:{m} {AM}"
+    }
+
+    message_payload = %{
+      "parent_list[0].date1" => "2022-02-28 16:53",
+      "other_field" => "other_data"
+    }
+
+    {:ok, transformed_payload} = Transformers.DateTime.transform(message_payload, params)
+
+    assert transformed_payload == %{
+             "date1" => "February 28, 2022 4:53 PM",
+             "other_field" => "other_data",
+             "parent_list[0].date1" => "2022-02-28 16:53"
+           }
+  end
+
   describe "error handling" do
     data_test "returns error when #{parameter} not there" do
       params =

--- a/apps/transformers/test/unit/transformations/division_test.exs
+++ b/apps/transformers/test/unit/transformations/division_test.exs
@@ -224,6 +224,25 @@ defmodule Transformers.DivisionTest do
 
       assert result == {:ok, %{"target" => "test"}}
     end
+
+    test "should parse from list" do
+      params = %{
+        "dividend" => "parent_list[0].dividend",
+        "divisor" => "parent_list[1].divisor",
+        "targetField" => "output_number"
+      }
+
+      message_payload = %{
+        "parent_list[0].dividend" => 10,
+        "parent_list[0].divisor" => 2,
+        "parent_list[1].divisor" => 2
+      }
+
+      {:ok, transformed_payload} = Division.transform(message_payload, params)
+
+      {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
+      assert actual_target_field == 5
+    end
   end
 
   describe "validate/1" do

--- a/apps/transformers/test/unit/transformations/division_test.exs
+++ b/apps/transformers/test/unit/transformations/division_test.exs
@@ -270,6 +270,23 @@ defmodule Transformers.DivisionTest do
 
       assert reason == %{"targetField" => "Missing or empty field"}
     end
+
+    test "returns error if fields end in ." do
+      params = %{
+        "dividend" => "dividend.",
+        "divisor" => "divisor.",
+        "targetField" => "output_number"
+      }
+
+      message_payload = %{
+        "dividend" => 4,
+        "divisor" => 4
+      }
+
+      {:error, reason} = Division.transform(message_payload, params)
+
+      assert reason == %{"dividend" => "Missing or empty child field", "divisor" => "Missing or empty child field"}
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/division_test.exs
+++ b/apps/transformers/test/unit/transformations/division_test.exs
@@ -285,7 +285,10 @@ defmodule Transformers.DivisionTest do
 
       {:error, reason} = Division.transform(message_payload, params)
 
-      assert reason == %{"dividend" => "Missing or empty child field", "divisor" => "Missing or empty child field"}
+      assert reason == %{
+               "dividend" => "Missing or empty child field",
+               "divisor" => "Missing or empty child field"
+             }
     end
   end
 

--- a/apps/transformers/test/unit/transformations/multiplication_test.exs
+++ b/apps/transformers/test/unit/transformations/multiplication_test.exs
@@ -185,6 +185,34 @@ defmodule Transformers.MultiplicationTest do
 
       assert result == {:ok, %{"input_number" => 8}}
     end
+
+    test "should get all values from a list to multiply" do
+      params = %{
+        "multiplicands" => ["parent_list[*].input_number", "parent2_list[0].input_number"],
+        "targetField" => "output_number"
+      }
+
+      message_payload = %{
+        "parent_list[0].input_number" => 2,
+        "parent_list[1].input_number" => 2,
+        "parent_list[2].input_number" => 2,
+        "parent_list[3].input_number" => 2,
+        "parent_list[4].input_number" => 2,
+        "parent_list[5].input_number" => 2,
+        "parent2_list[0].input_number" => 2,
+        "parent2_list[1].input_number" => 2,
+        "parent2_list[2].input_number" => 2,
+        "parent2_list[3].input_number" => 2,
+        "parent2_list[4].input_number" => 2,
+        "parent2_list[5].input_number" => 2,
+        "parent2_list[6].input_number" => 2
+      }
+
+      {:ok, transformed_payload} = Transformers.Multiplication.transform(message_payload, params)
+
+      {:ok, actual_target_field} = Map.fetch(transformed_payload, "output_number")
+      assert actual_target_field == 128.0
+    end
   end
 
   describe "validate/1" do

--- a/apps/transformers/test/unit/transformations/multiplication_test.exs
+++ b/apps/transformers/test/unit/transformations/multiplication_test.exs
@@ -217,6 +217,19 @@ defmodule Transformers.MultiplicationTest do
 
       where(parameter: ["multiplicands", "targetField"])
     end
+
+    test "returns error when fields end in ." do
+      params = %{
+        "multiplicands" => ["input_number."],
+        "targetField" => "output_number."
+      }
+
+      message_payload = %{"input_number" => 8}
+
+      {:error, reason} = Transformers.Multiplication.transform(message_payload, params)
+
+      assert reason == %{"multiplicands" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/multiplication_test.exs
+++ b/apps/transformers/test/unit/transformations/multiplication_test.exs
@@ -228,7 +228,10 @@ defmodule Transformers.MultiplicationTest do
 
       {:error, reason} = Transformers.Multiplication.transform(message_payload, params)
 
-      assert reason == %{"multiplicands" => "Missing or empty child field", "targetField" => "Missing or empty child field"}
+      assert reason == %{
+               "multiplicands" => "Missing or empty child field",
+               "targetField" => "Missing or empty child field"
+             }
     end
   end
 

--- a/apps/transformers/test/unit/transformations/regex_extract_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_extract_test.exs
@@ -176,5 +176,22 @@ defmodule Transformers.RegexExtractTest do
 
       assert reason == %{"regex" => "Invalid regular expression: missing ) at index 8"}
     end
+
+    data_test "returns error if #{parameter} ends in ." do
+      parameters = %{
+        "sourceField" => "phone_number",
+        "targetField" => "area_code",
+        "regex" => "^\\((\\d{3})\\)"
+      }
+
+      invalid_parameter = Map.get(parameters, parameter)
+      parameters = Map.put(parameters, parameter, "#{invalid_parameter}.")
+
+      {:error, reason} = RegexExtract.validate(parameters)
+
+      assert reason == %{parameter => "Missing or empty child field"}
+
+      where(parameter: ["sourceField", "targetField"])
+    end
   end
 end

--- a/apps/transformers/test/unit/transformations/regex_replace_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_replace_test.exs
@@ -24,6 +24,28 @@ defmodule Transformers.RegexReplaceTest do
     where(parameter: ["sourceField", "regex", "replacement"])
   end
 
+  data_test "returns error when #{parameter} ends in ." do
+    payload = %{
+      "something" => "abc"
+    }
+
+    parameters =
+      %{
+        "sourceField" => "something",
+        "regex" => "a",
+        "replacement" => "123"
+      }
+
+    invalid_parameter = Map.get(parameters, parameter)
+    parameters = Map.put(parameters, parameter, "#{invalid_parameter}.")
+
+    {:error, reason} = RegexReplace.transform(payload, parameters)
+
+    assert reason == %{"#{parameter}" => "Missing or empty child field"}
+
+    where(parameter: ["sourceField", "replacement"])
+  end
+
   test "when source field not on message, return error" do
     payload = %{
       "something_unexpected" => "123"

--- a/apps/transformers/test/unit/transformations/regex_replace_test.exs
+++ b/apps/transformers/test/unit/transformations/regex_replace_test.exs
@@ -29,12 +29,11 @@ defmodule Transformers.RegexReplaceTest do
       "something" => "abc"
     }
 
-    parameters =
-      %{
-        "sourceField" => "something",
-        "regex" => "a",
-        "replacement" => "123"
-      }
+    parameters = %{
+      "sourceField" => "something",
+      "regex" => "a",
+      "replacement" => "123"
+    }
 
     invalid_parameter = Map.get(parameters, parameter)
     parameters = Map.put(parameters, parameter, "#{invalid_parameter}.")

--- a/apps/transformers/test/unit/transformations/remove_test.exs
+++ b/apps/transformers/test/unit/transformations/remove_test.exs
@@ -16,6 +16,20 @@ defmodule Transformers.RemoveTest do
       assert reason == %{"sourceField" => "Missing or empty field"}
     end
 
+    test "if source field ends in ., return error" do
+      payload = %{
+        "dead_field" => "goodbye"
+      }
+
+      parameters = %{
+        "sourceField" => "dead_field."
+      }
+
+      {:error, reason} = Remove.transform(payload, parameters)
+
+      assert reason == %{"sourceField" => "Missing or empty child field"}
+    end
+
     test "if source field not on payload, return error" do
       payload = %{
         "undead_field" => "goodbye"

--- a/apps/transformers/test/unit/transformations/subtract_test.exs
+++ b/apps/transformers/test/unit/transformations/subtract_test.exs
@@ -231,6 +231,39 @@ defmodule Transformers.SubtractTest do
 
       assert reason == %{"subtrahends" => "Missing or empty child field"}
     end
+
+    test "subtracts from all values in list" do
+      parameters = %{
+        "minuend" => "firstTotal",
+        "subtrahends" => ["parent_list[*].subtrahends"],
+        "targetField" => "lastTotal"
+      }
+
+      payload = %{
+        "firstTotal" => 20,
+        "parent_list[0].subtrahends" => 1,
+        "parent_list[2].subtrahends" => 1,
+        "parent_list[3].subtrahends" => 1,
+        "parent_list[4].subtrahends" => 1,
+        "parent_list[5].subtrahends" => 1,
+        "parent_list[6].subtrahends" => 1,
+        "secondField" => 4
+      }
+
+      {:ok, result} = Subtract.transform(payload, parameters)
+
+      assert result == %{
+               "firstTotal" => 20,
+               "parent_list[0].subtrahends" => 1,
+               "parent_list[2].subtrahends" => 1,
+               "parent_list[3].subtrahends" => 1,
+               "parent_list[4].subtrahends" => 1,
+               "parent_list[5].subtrahends" => 1,
+               "parent_list[6].subtrahends" => 1,
+               "secondField" => 4,
+               "lastTotal" => 14
+             }
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/subtract_test.exs
+++ b/apps/transformers/test/unit/transformations/subtract_test.exs
@@ -214,6 +214,23 @@ defmodule Transformers.SubtractTest do
                "secondField" => 4
              }
     end
+
+    test "if parameters ends in ., return error" do
+      payload = %{
+        "some_field" => 0,
+        "target" => "target"
+      }
+
+      parameters = %{
+        "subtrahends" => ["target."],
+        "minuend" => 1,
+        "targetField" => "some_field.some_child.some_field"
+      }
+
+      {:error, reason} = Subtract.transform(payload, parameters)
+
+      assert reason == %{"subtrahends" => "Missing or empty child field"}
+    end
   end
 
   describe "fields/0" do

--- a/apps/transformers/test/unit/transformations/type_conversion_test.exs
+++ b/apps/transformers/test/unit/transformations/type_conversion_test.exs
@@ -85,6 +85,15 @@ defmodule Transformers.TypeConversionTest do
     assert {:error, "Field some_string not of expected type: string"} == result
   end
 
+  test "if field ends with ., return error" do
+    payload = %{"some_string" => 1}
+    parameters = %{"field" => "some_string.", "sourceType" => "string", "targetType" => "float"}
+
+    result = Transformers.TypeConversion.transform(payload, parameters)
+
+    assert {:error, %{"field" => "Missing or empty child field"}} == result
+  end
+
   test "convert from integer to string" do
     payload = %{"thing" => 300}
     parameters = %{"field" => "thing", "sourceType" => "integer", "targetType" => "string"}


### PR DESCRIPTION
## [Ticket Link #1125](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1125)

## Description

- Added a flattening and splitting path for transformations to be able to easily pluck the information needed

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [x] If updating Major or Minor versions , did you update the sauron chart configuration?
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [x] If altering an API endpoint, was the relevant postman collection updated?
  - [x] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
