### PR TITLE
1131 - Transformation Order Bug

### DIFF
--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
@@ -152,8 +152,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStep do
         List.insert_at(remaining_list, new_index, transformation_to_move)
         |> Enum.with_index()
         |> Enum.map(fn {changeset, index} ->
-          changes = Map.get(changeset, :changes) |> Map.put(:sequence, index)
-          Transformation.changeset(changeset, changes)
+          Changeset.put_change(changeset, :sequence, index)
         end)
 
       send(self(), {:update_all_transformations, updated_transformation_changesets})

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
@@ -152,7 +152,8 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStep do
         List.insert_at(remaining_list, new_index, transformation_to_move)
         |> Enum.with_index()
         |> Enum.map(fn {changeset, index} ->
-          Transformation.changeset(changeset, %{sequence: index})
+          params = Map.get(changeset.changes, :parameters)
+          Transformation.changeset(changeset, %{sequence: index, parameters: params})
         end)
 
       send(self(), {:update_all_transformations, updated_transformation_changesets})

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformations_step.ex
@@ -152,8 +152,8 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationsStep do
         List.insert_at(remaining_list, new_index, transformation_to_move)
         |> Enum.with_index()
         |> Enum.map(fn {changeset, index} ->
-          params = Map.get(changeset.changes, :parameters)
-          Transformation.changeset(changeset, %{sequence: index, parameters: params})
+          changes = Map.get(changeset, :changes) |> Map.put(:sequence, index)
+          Transformation.changeset(changeset, changes)
         end)
 
       send(self(), {:update_all_transformations, updated_transformation_changesets})

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.58",
+      version: "2.6.59",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #1131](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1131)

## Description

- Transformation sorting now includes parameters in the changeset update

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
