### PR TITLE
1128 dataset validation bug

### DIFF
--- a/apps/andi/lib/andi_web/live/dataset_live_view/edit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/edit_live_view.ex
@@ -246,7 +246,6 @@ defmodule AndiWeb.EditLiveView do
       |> InputConverter.andi_dataset_to_full_ui_changeset()
       |> Dataset.validate_unique_system_name()
       |> Map.put(:action, :update)
-      |> IO.inspect(label: "mikeyc - form-save")
 
     success_message = save_message(new_changeset.valid?)
 

--- a/apps/andi/lib/andi_web/live/dataset_live_view/edit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/edit_live_view.ex
@@ -134,6 +134,9 @@ defmodule AndiWeb.EditLiveView do
 
     AndiWeb.Endpoint.broadcast_from(self(), "form-save", "save-all", %{dataset_id: dataset_id})
 
+    # Temporary solution to handle concurrent save events. Future rearchitecting suggested.
+    Process.sleep(1_000)
+
     andi_dataset = Datasets.get(dataset_id)
     dataset_changeset = InputConverter.andi_dataset_to_full_ui_changeset(andi_dataset)
 
@@ -243,6 +246,7 @@ defmodule AndiWeb.EditLiveView do
       |> InputConverter.andi_dataset_to_full_ui_changeset()
       |> Dataset.validate_unique_system_name()
       |> Map.put(:action, :update)
+      |> IO.inspect(label: "mikeyc - form-save")
 
     success_message = save_message(new_changeset.valid?)
 

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.61",
+      version: "2.6.62",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #1128](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1128)

## Description

- Add band-aid solution to handle concurrent live view events

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
