### PR TITLE
1101 andi auth error page

### DIFF
--- a/apps/andi/assets/css/app.scss
+++ b/apps/andi/assets/css/app.scss
@@ -152,6 +152,7 @@ body {
 }
 
 @import "./access-groups.scss";
+@import "./autherror.scss";
 @import "./button.scss";
 @import "./data_dictionary_form.scss";
 @import "./datasets.scss";

--- a/apps/andi/assets/css/autherror.scss
+++ b/apps/andi/assets/css/autherror.scss
@@ -1,0 +1,19 @@
+.autherror-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(88, 95, 99);
+  height: 100vh;
+  width: 100vw;
+}
+
+.autherror-inner-content {
+  background: $color-content-background;
+  box-shadow: $box-shadow;
+  height: max-content;
+  width: max-content;
+  margin: 1em;
+  padding: 2em;
+  border-radius: 6px;
+}

--- a/apps/andi/lib/andi_web/controllers/auth_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/auth_controller.ex
@@ -21,7 +21,7 @@ defmodule AndiWeb.AuthController do
     Logger.error("Failed to retrieve auth credentials: #{inspect(fails)} with params #{inspect(params)}")
 
     conn
-    |> redirect(to: "/")
+    |> redirect(to: "/autherror")
   end
 
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do

--- a/apps/andi/lib/andi_web/live/error_live_view/error_live_view.ex
+++ b/apps/andi/lib/andi_web/live/error_live_view/error_live_view.ex
@@ -1,0 +1,23 @@
+defmodule AndiWeb.ErrorLiveView do
+  use AndiWeb, :live_view
+
+  access_levels(render: [:public, :private])
+
+  def render(assigns) do
+    ~L"""
+    <div class="content">
+      <main aria-label="Error Page" class="autherror-view">
+        <div class="autherror-inner-content">
+          <h3>Login Unsuccessful</h3>
+          <p>You do not have permission to access this system.</p>
+          <a href="/">Click here to return to login</a>
+        </div>
+      </main>
+    </div>
+    """
+  end
+
+  def mount(_params, socket) do
+    {:ok, socket}
+  end
+end

--- a/apps/andi/lib/andi_web/router.ex
+++ b/apps/andi/lib/andi_web/router.ex
@@ -106,4 +106,9 @@ defmodule AndiWeb.Router do
   scope "/", AndiWeb do
     get "/healthcheck", HealthCheckController, :index
   end
+
+  scope "/", AndiWeb do
+    pipe_through :browser
+    live "/autherror", ErrorLiveView, layout: {AndiWeb.LayoutView, :app}
+  end
 end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.62",
+      version: "2.6.63",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## [Ticket Link #1101](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1101)

## Description

- Add error page triggered by Auth0 error callback

![Screen Shot 2023-04-18 at 4 52 31 PM](https://user-images.githubusercontent.com/51802118/233112451-097443f0-d73e-4b23-a8aa-e6a3961d6e58.png)


## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
