### PR TITLE
1153 disable remote datasets

### DIFF
--- a/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
+++ b/apps/andi/lib/andi_web/live/organization_live_view/edit_organization_live_view.ex
@@ -76,12 +76,6 @@ defmodule AndiWeb.EditOrganizationLiveView do
         </div>
       </form>
 
-      <div class="harvested-datasets-table">
-        <h2>Remote Datasets Attached To This Organization</h2>
-
-        <%= live_component(@socket, AndiWeb.OrganizationLiveView.HarvestedDatasetsTable, datasets: @harvested_datasets, order: @order) %>
-      </div>
-
       <%= live_component(@socket, AndiWeb.UnsavedChangesModal, id: "edit-org-unsaved-changes-modal", visibility: @unsaved_changes_modal_visibility) %>
 
       <%= live_component(@socket, AndiWeb.EditLiveView.PublishSuccessModal, visibility: @publish_success_modal_visibility) %>

--- a/apps/andi/lib/andi_web/views/options.ex
+++ b/apps/andi/lib/andi_web/views/options.ex
@@ -103,8 +103,7 @@ defmodule AndiWeb.Views.Options do
     %{
       "" => "",
       "ingest" => "Ingest",
-      "stream" => "Stream",
-      "remote" => "Remote"
+      "stream" => "Stream"
     }
   end
 

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.64",
+      version: "2.6.65",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/organizations_live_view/edit_organization_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/organizations_live_view/edit_organization_live_view_test.exs
@@ -302,29 +302,7 @@ defmodule AndiWeb.EditOrganizationLiveViewTest do
       ]
     end
 
-    test "shows all harvested datasets associated with a given organization", %{
-      conn: conn,
-      org: org,
-      dataset1: dataset1,
-      dataset2: dataset2,
-      dataset3: dataset3
-    } do
-      assert {:ok, view, html} = live(conn, @url_path <> org.id)
-
-      get_text(html, ".organizations-table__tr")
-
-      assert get_text(html, ".organizations-table__tr") =~ dataset1.business.dataTitle
-      assert get_text(html, ".organizations-table__tr") =~ dataset2.business.dataTitle
-      refute get_text(html, ".organizations-table__tr") =~ dataset3.business.dataTitle
-    end
-
-    test "include checkbox is present for all datasets", %{conn: conn, org: org} do
-      assert {:ok, view, html} = live(conn, @url_path <> org.id)
-
-      assert length(Floki.attribute(html, ".organizations-table__checkbox--input", "checked")) == 3
-    end
-
-    test "unselecting include for a dataset sends a dataset delete event and updates the include field in the havested table", %{
+    test "unselecting include for a dataset sends a dataset delete event", %{
       conn: conn,
       org: org,
       dataset4: dataset4
@@ -336,8 +314,6 @@ defmodule AndiWeb.EditOrganizationLiveViewTest do
       assert %{include: true} = Organizations.get_harvested_dataset(dataset4.id)
 
       render_change(view, "toggle_include", %{"id" => dataset4.id})
-
-      assert %{include: false} = Organizations.get_harvested_dataset(dataset4.id)
 
       eventually(fn ->
         assert nil == Datasets.get(dataset4.id)


### PR DESCRIPTION
## [Ticket Link #1153](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1153)

## Description

Disabling remote datasets on the UI.

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [x] If updating Major or Minor versions , did you update the sauron chart configuration?
- [x] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [x] If altering an API endpoint, was the relevant postman collection updated?
  - [x] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
