### PR TITLE
1154 - Constant transform has null type option

### DIFF
--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.34",
+      version: "0.2.35",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_field_builder.ex
@@ -116,15 +116,17 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
     options = Map.get(field, :options)
 
     ~L"""
-    <div class="transformation-field">
-      <%= label(form, name, field.field_label, for: id, class: "transformation-field-label label label--required") %>
-      <%= if not is_nil(options) do %>
-        <%= select(form, name, options, [value: value, id: id, class: "select", prompt: "", required: true]) %>
-      <% else %>
-        <%= text_input(form, name, [value: value, id: id, class: "input transformation-form-fields", required: true]) %>
-      <% end %>
-      <%= ErrorHelpers.error_tag_with_label(form.source, name, field.field_label, bind_to_input: false, id: "#{id}_error") %>
-    </div>
+    <%= if show_input?(name, form) do %>
+      <div class="transformation-field">
+        <%= label(form, name, field.field_label, for: id, class: "transformation-field-label label label--required") %>
+        <%= if not is_nil(options) do %>
+          <%= select(form, name, options, [value: value, id: id, class: "select", prompt: "", required: true]) %>
+        <% else %>
+            <%= text_input(form, name, [value: value, id: id, class: "input transformation-form-fields", required: true]) %>
+        <% end %>
+        <%= ErrorHelpers.error_tag_with_label(form.source, name, field.field_label, bind_to_input: false, id: "#{id}_error") %>
+      </div>
+    <% end %>
     """
   end
 
@@ -138,5 +140,9 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFieldBuilder d
 
   defp get_fields(transformation_type) do
     TransformationFields.fields_for(transformation_type)
+  end
+
+  defp show_input?(name, form) do
+    not (name == :newValue and get_in(form.source.changes, [:parameters, :valueType]) == "null / empty")
   end
 end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.67",
+      version: "2.6.68",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -443,7 +443,10 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
     assert options_html =~ "Null or Empty"
   end
 
-  test "in the constant transformation form, when 'null / empty' type is selected, the value field is not shown", %{view: view, ingestion: ingestion} do
+  test "in the constant transformation form, when 'null / empty' type is selected, the value field is not shown", %{
+    view: view,
+    ingestion: ingestion
+  } do
     transformation = Enum.find(ingestion.transformations, fn transformation -> transformation.type == "constant" end)
 
     view

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/transformations/transformations_form_test.exs
@@ -443,6 +443,24 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationFormTest do
     assert options_html =~ "Null or Empty"
   end
 
+  test "in the constant transformation form, when 'null / empty' type is selected, the value field is not shown", %{view: view, ingestion: ingestion} do
+    transformation = Enum.find(ingestion.transformations, fn transformation -> transformation.type == "constant" end)
+
+    view
+    |> element("#transformation_#{transformation.id}__header")
+    |> render_click()
+
+    form_data = %{"valueType" => "null / empty"}
+
+    view
+    |> form("##{transformation.id}", form_data: form_data)
+    |> render_change()
+
+    html = render(view)
+
+    refute has_element?(view, "#transformation_#{transformation.id}__newValue_default")
+  end
+
   data_test "when selecting #{type}, its respective fields will show", %{view: view, ingestion: ingestion} do
     transformation = Enum.find(ingestion.transformations, fn transformation -> transformation.type == "concatenation" end)
 

--- a/apps/transformers/lib/transformations/constant.ex
+++ b/apps/transformers/lib/transformations/constant.ex
@@ -57,7 +57,10 @@ defmodule Transformers.Constant do
 
   defp check_value(status, parameters) do
     data_type = Map.get(parameters, @value_type)
-    if data_type != "null / empty", do: NotBlank.check(status, parameters, @new_value), else: status
+
+    if data_type != "null / empty",
+      do: NotBlank.check(status, parameters, @new_value),
+      else: status
   end
 
   def fields() do

--- a/apps/transformers/lib/transformations/constant.ex
+++ b/apps/transformers/lib/transformations/constant.ex
@@ -25,8 +25,8 @@ defmodule Transformers.Constant do
     %ValidationStatus{}
     |> NotBlank.check(parameters, @target_field)
     |> NotBlank.check_nested(parameters, @target_field)
-    |> NotBlank.check(parameters, @new_value)
     |> NotBlank.check(parameters, @value_type)
+    |> check_value(parameters)
     |> ValidationStatus.ordered_values_or_errors([@target_field, @new_value, @value_type])
   end
 
@@ -50,8 +50,14 @@ defmodule Transformers.Constant do
       "string" -> {value, ""}
       "integer" -> Integer.parse(value, 10)
       "float" -> Float.parse(value)
+      "null / empty" -> {nil, ""}
       _ -> raise "Error: Invalid conversion type: #{value_type}"
     end
+  end
+
+  defp check_value(status, parameters) do
+    data_type = Map.get(parameters, @value_type)
+    if data_type != "null / empty", do: NotBlank.check(status, parameters, @new_value), else: status
   end
 
   def fields() do
@@ -62,15 +68,15 @@ defmodule Transformers.Constant do
         field_label: "Target Field"
       },
       %{
-        field_name: @new_value,
-        field_type: "string",
-        field_label: "Value to replace in source field"
-      },
-      %{
         field_name: @value_type,
         field_type: "string",
         field_label: "Data type",
-        options: ["integer", "string", "float"]
+        options: ["integer", "string", "float", "null / empty"]
+      },
+      %{
+        field_name: @new_value,
+        field_type: "string",
+        field_label: "Value to insert into target field"
       }
     ]
   end

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.28",
+      version: "1.0.29",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/transformations/constant_test.exs
+++ b/apps/transformers/test/unit/transformations/constant_test.exs
@@ -77,6 +77,23 @@ defmodule Transformers.ConstantTest do
              }
     end
 
+    test "converts value to nil" do
+      parameters = %{
+        "targetField" => "testField",
+        "valueType" => "null / empty"
+      }
+
+      payload = %{
+        "testField" => "old value"
+      }
+
+      {:ok, result} = Constant.transform(payload, parameters)
+
+      assert result == %{
+               "testField" => nil
+             }
+    end
+
     test "performs transformation as normal when condition evaluates to true" do
       parameters = %{
         "targetField" => "testField",


### PR DESCRIPTION
## [Ticket Link #1154](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1154)

## Description

- add null option to constant transform and some conditional UI rendering

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
