### PR TITLE
1151 customize dataset ingestion fields

### DIFF
--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -316,6 +316,7 @@ defmodule E2ETest do
         {:ok, _, [message]} = Elsa.fetch(@brokers, topic)
         {:ok, data} = SmartCity.Data.new(message.value)
         IO.inspect(data, label: "data")
+
         assert %{"one" => true, "two" => "foobar", "three" => 10, "parsed" => "oo"} ==
                  data.payload
       end)

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -315,7 +315,6 @@ defmodule E2ETest do
       eventually(fn ->
         {:ok, _, [message]} = Elsa.fetch(@brokers, topic)
         {:ok, data} = SmartCity.Data.new(message.value)
-        IO.inspect(data, label: "data")
 
         assert %{"one" => true, "two" => "foobar", "three" => 10, "parsed" => "oo"} ==
                  data.payload

--- a/apps/e2e/test/e2e_test.exs
+++ b/apps/e2e/test/e2e_test.exs
@@ -20,7 +20,7 @@ defmodule E2ETest do
         %{name: "one", type: "boolean", ingestion_field_selector: "one"},
         %{name: "two", type: "string", ingestion_field_selector: "two"},
         %{name: "three", type: "integer", ingestion_field_selector: "three"},
-        %{name: "parsed", type: "string", ingestion_field_selector: "oparsedne"}
+        %{name: "parsed", type: "string", ingestion_field_selector: "parsed"}
       ],
       sourceType: "ingest",
       sourceUrl: "http://example.com",
@@ -315,7 +315,7 @@ defmodule E2ETest do
       eventually(fn ->
         {:ok, _, [message]} = Elsa.fetch(@brokers, topic)
         {:ok, data} = SmartCity.Data.new(message.value)
-
+        IO.inspect(data, label: "data")
         assert %{"one" => true, "two" => "foobar", "three" => 10, "parsed" => "oo"} ==
                  data.payload
       end)

--- a/apps/valkyrie/lib/valkyrie.ex
+++ b/apps/valkyrie/lib/valkyrie.ex
@@ -22,14 +22,14 @@ defmodule Valkyrie do
 
   defp standardize_schema(schema, payload) do
     schema
-    |> Enum.reduce(%{data: %{}, errors: %{}}, fn %{name: name} = field, acc ->
+    |> Enum.reduce(%{data: %{}, errors: %{}}, fn %{ingestion_field_selector: selector} = field, acc ->
       try do
-        case standardize(field, payload[name]) do
-          {:ok, value} -> %{acc | data: Map.put(acc.data, name, value)}
-          {:error, reason} -> %{acc | errors: Map.put(acc.errors, name, reason)}
+        case standardize(field, payload[selector]) do
+          {:ok, value} -> %{acc | data: Map.put(acc.data, selector, value)}
+          {:error, reason} -> %{acc | errors: Map.put(acc.errors, selector, reason)}
         end
       rescue
-        exception -> %{acc | errors: Map.put(acc.errors, name, %{unhandled_standardization_exception: exception})}
+        exception -> %{acc | errors: Map.put(acc.errors, selector, %{unhandled_standardization_exception: exception})}
       end
     end)
   end

--- a/apps/valkyrie/lib/valkyrie.ex
+++ b/apps/valkyrie/lib/valkyrie.ex
@@ -29,7 +29,7 @@ defmodule Valkyrie do
           {:error, reason} -> %{acc | errors: Map.put(acc.errors, name, reason)}
         end
       rescue
-        exception -> %{acc | errors: Map.put(acc.errors, selector, %{unhandled_standardization_exception: exception})}
+        exception -> %{acc | errors: Map.put(acc.errors, name, %{unhandled_standardization_exception: exception})}
       end
     end)
   end

--- a/apps/valkyrie/lib/valkyrie.ex
+++ b/apps/valkyrie/lib/valkyrie.ex
@@ -22,11 +22,11 @@ defmodule Valkyrie do
 
   defp standardize_schema(schema, payload) do
     schema
-    |> Enum.reduce(%{data: %{}, errors: %{}}, fn %{ingestion_field_selector: selector} = field, acc ->
+    |> Enum.reduce(%{data: %{}, errors: %{}}, fn %{ingestion_field_selector: selector, name: name} = field, acc ->
       try do
         case standardize(field, payload[selector]) do
-          {:ok, value} -> %{acc | data: Map.put(acc.data, selector, value)}
-          {:error, reason} -> %{acc | errors: Map.put(acc.errors, selector, reason)}
+          {:ok, value} -> %{acc | data: Map.put(acc.data, name, value)}
+          {:error, reason} -> %{acc | errors: Map.put(acc.errors, name, reason)}
         end
       rescue
         exception -> %{acc | errors: Map.put(acc.errors, selector, %{unhandled_standardization_exception: exception})}

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.7.25",
+      version: "1.7.26",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.7.26",
+      version: "1.7.27",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/valkyrie/test/integration/dataset_mutation_test.exs
+++ b/apps/valkyrie/test/integration/dataset_mutation_test.exs
@@ -41,7 +41,11 @@ defmodule Valkyrie.DatasetMutationTest do
       40
     )
 
-    updated_dataset = %{dataset | technical: %{dataset.technical | schema: [%{name: "age", type: "integer", ingestion_field_selector: "age"}]}}
+    updated_dataset = %{
+      dataset
+      | technical: %{dataset.technical | schema: [%{name: "age", type: "integer", ingestion_field_selector: "age"}]}
+    }
+
     Brook.Event.send(@instance_name, dataset_update(), :author, updated_dataset)
 
     Process.sleep(2_000)

--- a/apps/valkyrie/test/integration/dataset_mutation_test.exs
+++ b/apps/valkyrie/test/integration/dataset_mutation_test.exs
@@ -16,7 +16,7 @@ defmodule Valkyrie.DatasetMutationTest do
   @tag timeout: 120_000
   test "a dataset with an updated schema properly parses new messages" do
     dataset_id = Faker.UUID.v4()
-    schema = [%{name: "age", type: "string"}]
+    schema = [%{name: "age", type: "string", ingestion_field_selector: "age"}]
     dataset = TDG.create_dataset(id: dataset_id, technical: %{schema: schema})
     ingestion = TDG.create_ingestion(%{targetDataset: dataset_id})
 

--- a/apps/valkyrie/test/integration/dataset_mutation_test.exs
+++ b/apps/valkyrie/test/integration/dataset_mutation_test.exs
@@ -41,7 +41,7 @@ defmodule Valkyrie.DatasetMutationTest do
       40
     )
 
-    updated_dataset = %{dataset | technical: %{dataset.technical | schema: [%{name: "age", type: "integer"}]}}
+    updated_dataset = %{dataset | technical: %{dataset.technical | schema: [%{name: "age", type: "integer", ingestion_field_selector: "age"}]}}
     Brook.Event.send(@instance_name, dataset_update(), :author, updated_dataset)
 
     Process.sleep(2_000)

--- a/apps/valkyrie/test/integration/end_of_data_test.exs
+++ b/apps/valkyrie/test/integration/end_of_data_test.exs
@@ -25,7 +25,7 @@ defmodule Valkyrie.EndOfDataTest do
         id: dataset_id,
         technical: %{
           schema: [
-            %{name: "name", type: "map", subSchema: [%{name: "first", type: "string"}, %{name: "last", type: "string"}]}
+            %{name: "name", type: "map", subSchema: [%{name: "first", type: "string", ingestion_field_selector: "first"}, %{name: "last", type: "string", ingestion_field_selector: "last"}], ingestion_field_selector: "name"}
           ]
         }
       )

--- a/apps/valkyrie/test/integration/end_of_data_test.exs
+++ b/apps/valkyrie/test/integration/end_of_data_test.exs
@@ -25,7 +25,15 @@ defmodule Valkyrie.EndOfDataTest do
         id: dataset_id,
         technical: %{
           schema: [
-            %{name: "name", type: "map", subSchema: [%{name: "first", type: "string", ingestion_field_selector: "first"}, %{name: "last", type: "string", ingestion_field_selector: "last"}], ingestion_field_selector: "name"}
+            %{
+              name: "name",
+              type: "map",
+              subSchema: [
+                %{name: "first", type: "string", ingestion_field_selector: "first"},
+                %{name: "last", type: "string", ingestion_field_selector: "last"}
+              ],
+              ingestion_field_selector: "name"
+            }
           ]
         }
       )

--- a/apps/valkyrie/test/integration/topic_creation_test.exs
+++ b/apps/valkyrie/test/integration/topic_creation_test.exs
@@ -23,7 +23,7 @@ defmodule Valkyrie.TopicCreationTest do
         id: dataset_id,
         technical: %{
           schema: [
-            %{name: "name", type: "map", subSchema: [%{name: "first", type: "string"}, %{name: "last", type: "string"}]}
+            %{name: "name", type: "map", subSchema: [%{name: "first", type: "string", ingestion_field_selector: "first"}, %{name: "last", type: "string", ingestion_field_selector: "last"}], ingestion_field_selector: "name"}
           ]
         }
       )

--- a/apps/valkyrie/test/integration/topic_creation_test.exs
+++ b/apps/valkyrie/test/integration/topic_creation_test.exs
@@ -23,7 +23,15 @@ defmodule Valkyrie.TopicCreationTest do
         id: dataset_id,
         technical: %{
           schema: [
-            %{name: "name", type: "map", subSchema: [%{name: "first", type: "string", ingestion_field_selector: "first"}, %{name: "last", type: "string", ingestion_field_selector: "last"}], ingestion_field_selector: "name"}
+            %{
+              name: "name",
+              type: "map",
+              subSchema: [
+                %{name: "first", type: "string", ingestion_field_selector: "first"},
+                %{name: "last", type: "string", ingestion_field_selector: "last"}
+              ],
+              ingestion_field_selector: "name"
+            }
           ]
         }
       )

--- a/apps/valkyrie/test/unit/valkyrie/broadway_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie/broadway_test.exs
@@ -21,7 +21,8 @@ defmodule Valkyrie.BroadwayTest do
 
     schema = [
       %{name: "name", type: "string", ingestion_field_selector: "name"},
-      %{name: "age", type: "integer", ingestion_field_selector: "age"}
+      %{name: "age", type: "integer", ingestion_field_selector: "age"},
+      %{name: "alias", type: "string", ingestion_field_selector: "name"}
     ]
 
     dataset = TDG.create_dataset(id: @dataset_id, technical: %{schema: schema})
@@ -61,7 +62,7 @@ defmodule Valkyrie.BroadwayTest do
       |> Enum.map(fn {:ok, data} -> data end)
       |> Enum.map(fn data -> data.payload end)
 
-    assert payloads == [%{"name" => "johnny", "age" => 21}]
+    assert payloads == [%{"name" => "johnny", "age" => 21, "alias" => "johnny"}]
   end
 
   test "applies valkyrie message timing", %{broadway: broadway} do
@@ -163,8 +164,8 @@ defmodule Valkyrie.BroadwayTest do
     captured_messages = capture(Elsa.produce(:"#{@dataset_id}_producer", :output_topic, any(), partition: 0), 3)
 
     assert 2 = length(captured_messages)
-    assert Enum.at(captured_messages, 0) |> Jason.decode!() |> Map.get("payload") == data1.payload
-    assert Enum.at(captured_messages, 1) |> Jason.decode!() |> Map.get("payload") == data2.payload
+    assert Enum.at(captured_messages, 0) |> Jason.decode!() |> Map.get("payload") == %{"age" => 21, "name" => "johnny", "alias" => "johnny"}
+    assert Enum.at(captured_messages, 1) |> Jason.decode!() |> Map.get("payload") == %{"age" => 33, "name" => "carl", "alias" => "carl"}
   end
 
   test "should emit a data standarization end event when END_OF_DATA message is recieved", %{broadway: broadway} do

--- a/apps/valkyrie/test/unit/valkyrie/broadway_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie/broadway_test.exs
@@ -164,8 +164,18 @@ defmodule Valkyrie.BroadwayTest do
     captured_messages = capture(Elsa.produce(:"#{@dataset_id}_producer", :output_topic, any(), partition: 0), 3)
 
     assert 2 = length(captured_messages)
-    assert Enum.at(captured_messages, 0) |> Jason.decode!() |> Map.get("payload") == %{"age" => 21, "name" => "johnny", "alias" => "johnny"}
-    assert Enum.at(captured_messages, 1) |> Jason.decode!() |> Map.get("payload") == %{"age" => 33, "name" => "carl", "alias" => "carl"}
+
+    assert Enum.at(captured_messages, 0) |> Jason.decode!() |> Map.get("payload") == %{
+             "age" => 21,
+             "name" => "johnny",
+             "alias" => "johnny"
+           }
+
+    assert Enum.at(captured_messages, 1) |> Jason.decode!() |> Map.get("payload") == %{
+             "age" => 33,
+             "name" => "carl",
+             "alias" => "carl"
+           }
   end
 
   test "should emit a data standarization end event when END_OF_DATA message is recieved", %{broadway: broadway} do

--- a/apps/valkyrie/test/unit/valkyrie/broadway_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie/broadway_test.exs
@@ -20,8 +20,8 @@ defmodule Valkyrie.BroadwayTest do
     allow SmartCity.Data.Timing.current_time(), return: @current_time, meck_options: [:passthrough]
 
     schema = [
-      %{name: "name", type: "string"},
-      %{name: "age", type: "integer"}
+      %{name: "name", type: "string", ingestion_field_selector: "name"},
+      %{name: "age", type: "integer", ingestion_field_selector: "age"}
     ]
 
     dataset = TDG.create_dataset(id: @dataset_id, technical: %{schema: schema})

--- a/apps/valkyrie/test/unit/valkyrie_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie_test.exs
@@ -337,7 +337,13 @@ defmodule ValkyrieTest do
             schema: [
               %{name: "name", type: "string", ingestion_field_selector: "name"},
               %{name: "luckyNumbers", type: "list", itemType: "integer", ingestion_field_selector: "luckyNumbers"},
-              %{name: "spouses", type: "list", itemType: "map", subSchema: sub_schema, ingestion_field_selector: "spouses"}
+              %{
+                name: "spouses",
+                type: "list",
+                itemType: "map",
+                subSchema: sub_schema,
+                ingestion_field_selector: "spouses"
+              }
             ]
           }
         )
@@ -412,7 +418,13 @@ defmodule ValkyrieTest do
           technical: %{
             schema: [
               %{name: "name", type: "string", ingestion_field_selector: "name"},
-              %{name: "spouses", type: "list", itemType: "map", subSchema: sub_schema, ingestion_field_selector: "spouses"}
+              %{
+                name: "spouses",
+                type: "list",
+                itemType: "map",
+                subSchema: sub_schema,
+                ingestion_field_selector: "spouses"
+              }
             ]
           }
         )

--- a/apps/valkyrie/test/unit/valkyrie_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie_test.exs
@@ -17,8 +17,9 @@ defmodule ValkyrieTest do
         )
 
       payload = %{selector => value}
+      expected = %{field_name => value}
 
-      assert {:ok, payload} == Valkyrie.standardize_data(dataset, payload)
+      assert {:ok, expected} == Valkyrie.standardize_data(dataset, payload)
 
       where([
         [:field_name, :selector, :type, :value],
@@ -44,11 +45,12 @@ defmodule ValkyrieTest do
           }
         )
 
-      assert {:ok, %{selector => transformed_value}} === Valkyrie.standardize_data(dataset, %{selector => value})
+      assert {:ok, %{field_name => transformed_value}} === Valkyrie.standardize_data(dataset, %{selector => value})
 
       where([
         [:field_name, :selector, :type, :value, :transformed_value],
         ["age", "age", "string", 123, "123"],
+        ["age", "selector", "string", 123, "123"],
         ["age", "age", "string", 123.5, "123.5"],
         ["age", "age", "string", "  42 ", "42"],
         ["age", "age", "integer", "21", 21],

--- a/apps/valkyrie/test/unit/valkyrie_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie_test.exs
@@ -11,24 +11,25 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: field_name, type: type}
+              %{name: field_name, type: type, ingestion_field_selector: selector}
             ]
           }
         )
 
-      payload = %{field_name => value}
+      payload = %{selector => value}
 
       assert {:ok, payload} == Valkyrie.standardize_data(dataset, payload)
 
       where([
-        [:field_name, :type, :value],
-        ["name", "string", "some string"],
-        ["age", "integer", 1],
-        ["age", "long", 1],
-        ["raining?", "boolean", true],
-        ["raining?", "boolean", false],
-        ["temperature", "float", 87.5],
-        ["temperature", "double", 87.5]
+        [:field_name, :selector, :type, :value],
+        ["name", "name", "string", "some string"],
+        ["name", "selector", "string", "some string"],
+        ["age", "age", "integer", 1],
+        ["age", "age", "long", 1],
+        ["raining?", "raining?", "boolean", true],
+        ["raining?", "raining?", "boolean", false],
+        ["temperature", "temperature", "float", 87.5],
+        ["temperature", "temperature", "double", 87.5]
       ])
     end
 
@@ -38,30 +39,30 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: field_name, type: type}
+              %{name: field_name, type: type, ingestion_field_selector: selector}
             ]
           }
         )
 
-      assert {:ok, %{field_name => transformed_value}} === Valkyrie.standardize_data(dataset, %{field_name => value})
+      assert {:ok, %{selector => transformed_value}} === Valkyrie.standardize_data(dataset, %{selector => value})
 
       where([
-        [:field_name, :type, :value, :transformed_value],
-        ["age", "string", 123, "123"],
-        ["age", "string", 123.5, "123.5"],
-        ["age", "string", "  42 ", "42"],
-        ["age", "integer", "21", 21],
-        ["age", "long", "22", 22],
-        ["age", "integer", "+25", 25],
-        ["age", "integer", "-12", -12],
-        ["raining?", "boolean", "true", true],
-        ["raining?", "boolean", "false", false],
-        ["temperature", "float", 101, 101.0],
-        ["temperature", "float", "101.8", 101.8],
-        ["temperature", "float", "+105.5", 105.5],
-        ["temperature", "float", "-123.7", -123.7],
-        ["temperature", "double", 87, 87.0],
-        ["temperature", "double", "101.8", 101.8]
+        [:field_name, :selector, :type, :value, :transformed_value],
+        ["age", "age", "string", 123, "123"],
+        ["age", "age", "string", 123.5, "123.5"],
+        ["age", "age", "string", "  42 ", "42"],
+        ["age", "age", "integer", "21", 21],
+        ["age", "age", "long", "22", 22],
+        ["age", "age", "integer", "+25", 25],
+        ["age", "age", "integer", "-12", -12],
+        ["raining?", "raining?", "boolean", "true", true],
+        ["raining?", "raining?", "boolean", "false", false],
+        ["temperature", "temperature", "float", 101, 101.0],
+        ["temperature", "temperature", "float", "101.8", 101.8],
+        ["temperature", "temperature", "float", "+105.5", 105.5],
+        ["temperature", "temperature", "float", "-123.7", -123.7],
+        ["temperature", "temperature", "double", 87, 87.0],
+        ["temperature", "temperature", "double", "101.8", 101.8]
       ])
     end
 
@@ -71,7 +72,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "birthdate", format: format, type: type}
+              %{name: "birthdate", format: format, type: type, ingestion_field_selector: "birthdate"}
             ]
           }
         )
@@ -94,7 +95,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "birthdate", format: format, type: type}
+              %{name: "birthdate", format: format, type: type, ingestion_field_selector: "birthdate"}
             ]
           }
         )
@@ -124,24 +125,24 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: field_name, type: type}
+              %{name: field_name, type: type, ingestion_field_selector: selector}
             ]
           }
         )
 
       expected = {:error, %{field_name => reason}}
-      assert expected == Valkyrie.standardize_data(dataset, %{field_name => value})
+      assert expected == Valkyrie.standardize_data(dataset, %{selector => value})
 
       where([
-        [:field_name, :type, :value, :reason],
-        ["age", "integer", "abc", :invalid_integer],
-        ["age", "integer", "34.5", :invalid_integer],
-        ["age", "long", "abc", :invalid_long],
-        ["age", "long", "34.5", :invalid_long],
-        ["raining?", "boolean", "nope", :invalid_boolean],
-        ["temperature", "float", "howdy!", :invalid_float],
-        ["temperature", "double", "howdy!", :invalid_double],
-        ["temperature", "double", "123..7", :invalid_double]
+        [:field_name, :selector, :type, :value, :reason],
+        ["age", "age", "integer", "abc", :invalid_integer],
+        ["age", "age", "integer", "34.5", :invalid_integer],
+        ["age", "age", "long", "abc", :invalid_long],
+        ["age", "age", "long", "34.5", :invalid_long],
+        ["raining?", "raining?", "boolean", "nope", :invalid_boolean],
+        ["temperature", "temperature", "float", "howdy!", :invalid_float],
+        ["temperature", "temperature", "double", "howdy!", :invalid_double],
+        ["temperature", "temperature", "double", "123..7", :invalid_double]
       ])
     end
 
@@ -151,18 +152,18 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: field_name, type: type}
+              %{name: field_name, type: type, ingestion_field_selector: selector}
             ]
           }
         )
 
-      payload = %{field_name => nil}
+      payload = %{selector => nil}
       assert {:ok, payload} == Valkyrie.standardize_data(dataset, payload)
 
       where([
-        [:field_name, :type],
-        ["name", "string"],
-        ["age", "integer"]
+        [:field_name, :selector, :type],
+        ["name", "name", "string"],
+        ["age", "age", "integer"]
       ])
     end
 
@@ -172,21 +173,21 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: field_name, type: type}
+              %{name: field_name, type: type, ingestion_field_selector: selector}
             ]
           }
         )
 
-      assert {:ok, %{field_name => nil}} == Valkyrie.standardize_data(dataset, %{field_name => ""})
+      assert {:ok, %{selector => nil}} == Valkyrie.standardize_data(dataset, %{selector => ""})
 
       where([
-        [:field_name, :type],
-        ["age", "integer"],
-        ["numOfLives", "long"],
-        ["weight", "double"],
-        ["height", "float"],
-        ["isCool", "boolean"],
-        ["dob", "timestamp"]
+        [:field_name, :selector, :type],
+        ["age", "age", "integer"],
+        ["numOfLives", "numOfLives", "long"],
+        ["weight", "weight", "double"],
+        ["height", "height", "float"],
+        ["isCool", "isCool", "boolean"],
+        ["dob", "dob", "timestamp"]
       ])
     end
 
@@ -196,7 +197,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "empty_string", type: "string"}
+              %{name: "empty_string", type: "string", ingestion_field_selector: "empty_string"}
             ]
           }
         )
@@ -206,11 +207,11 @@ defmodule ValkyrieTest do
 
     test "transforms valid values in a map" do
       sub_schema = [
-        %{name: "name", type: "string"},
-        %{name: "age", type: "integer"},
-        %{name: "human", type: "boolean"},
-        %{name: "color", type: "string"},
-        %{name: "luckyNumbers", type: "list", itemType: "integer"}
+        %{name: "name", type: "string", ingestion_field_selector: "name"},
+        %{name: "age", type: "integer", ingestion_field_selector: "age"},
+        %{name: "human", type: "boolean", ingestion_field_selector: "human"},
+        %{name: "color", type: "string", ingestion_field_selector: "color"},
+        %{name: "luckyNumbers", type: "list", itemType: "integer", ingestion_field_selector: "luckyNumbers"}
       ]
 
       dataset =
@@ -218,8 +219,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "spouse", type: "map", subSchema: sub_schema}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "spouse", type: "map", subSchema: sub_schema, ingestion_field_selector: "spouse"}
             ]
           }
         )
@@ -253,7 +254,7 @@ defmodule ValkyrieTest do
 
     test "validates that specified map is a map" do
       sub_schema = [
-        %{name: "name", type: "string"}
+        %{name: "name", type: "string", ingestion_field_selector: "name"}
       ]
 
       dataset =
@@ -261,8 +262,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "spouse", type: "map", subSchema: sub_schema}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "spouse", type: "map", subSchema: sub_schema, ingestion_field_selector: "spouse"}
             ]
           }
         )
@@ -275,8 +276,8 @@ defmodule ValkyrieTest do
 
     test "returns error that identifies nested field that fails" do
       sub_schema = [
-        %{name: "name", type: "string"},
-        %{name: "age", type: "integer"}
+        %{name: "name", type: "string", ingestion_field_selector: "name"},
+        %{name: "age", type: "integer", ingestion_field_selector: "age"}
       ]
 
       dataset =
@@ -284,8 +285,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "spouse", type: "map", subSchema: sub_schema}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "spouse", type: "map", subSchema: sub_schema, ingestion_field_selector: "spouse"}
             ]
           }
         )
@@ -298,12 +299,12 @@ defmodule ValkyrieTest do
 
     test "returns error that identifies deeply nested field that fails" do
       sub_sub_schema = [
-        %{name: "name", type: "string"}
+        %{name: "name", type: "string", ingestion_field_selector: "name"}
       ]
 
       sub_schema = [
-        %{name: "name", type: "string"},
-        %{name: "child", type: "map", subSchema: sub_sub_schema}
+        %{name: "name", type: "string", ingestion_field_selector: "name"},
+        %{name: "child", type: "map", subSchema: sub_sub_schema, ingestion_field_selector: "child"}
       ]
 
       dataset =
@@ -311,8 +312,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "spouse", type: "map", subSchema: sub_schema}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "spouse", type: "map", subSchema: sub_schema, ingestion_field_selector: "spouse"}
             ]
           }
         )
@@ -325,8 +326,8 @@ defmodule ValkyrieTest do
 
     test "transforms valid values in lists" do
       sub_schema = [
-        %{name: "name", type: "string"},
-        %{name: "age", type: "integer"}
+        %{name: "name", type: "string", ingestion_field_selector: "name"},
+        %{name: "age", type: "integer", ingestion_field_selector: "age"}
       ]
 
       dataset =
@@ -334,9 +335,9 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "luckyNumbers", type: "list", itemType: "integer"},
-              %{name: "spouses", type: "list", itemType: "map", subSchema: sub_schema}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "luckyNumbers", type: "list", itemType: "integer", ingestion_field_selector: "luckyNumbers"},
+              %{name: "spouses", type: "list", itemType: "map", subSchema: sub_schema, ingestion_field_selector: "spouses"}
             ]
           }
         )
@@ -370,7 +371,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "luckyNumbers", type: "list", itemType: "integer"}
+              %{name: "luckyNumbers", type: "list", itemType: "integer", ingestion_field_selector: "luckyNumbers"}
             ]
           }
         )
@@ -387,8 +388,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "luckyNumbers", type: "list", itemType: "integer"}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "luckyNumbers", type: "list", itemType: "integer", ingestion_field_selector: "luckyNumbers"}
             ]
           }
         )
@@ -401,8 +402,8 @@ defmodule ValkyrieTest do
 
     test "returns error that identifies invalid map in list" do
       sub_schema = [
-        %{name: "name", type: "string"},
-        %{name: "age", type: "integer"}
+        %{name: "name", type: "string", ingestion_field_selector: "name"},
+        %{name: "age", type: "integer", ingestion_field_selector: "age"}
       ]
 
       dataset =
@@ -410,8 +411,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "spouses", type: "list", itemType: "map", subSchema: sub_schema}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "spouses", type: "list", itemType: "map", subSchema: sub_schema, ingestion_field_selector: "spouses"}
             ]
           }
         )
@@ -434,7 +435,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "geometry", type: "unknown"}
+              %{name: "geometry", type: "unknown", ingestion_field_selector: "geometry"}
             ]
           }
         )
@@ -450,8 +451,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "luckyNumbers", type: "list", itemType: "string"}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "luckyNumbers", type: "list", itemType: "string", ingestion_field_selector: "luckyNumbers"}
             ]
           }
         )
@@ -474,7 +475,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "geometry", type: "json"}
+              %{name: "geometry", type: "json", ingestion_field_selector: "geometry"}
             ]
           }
         )
@@ -491,7 +492,7 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "geometry", type: "json"}
+              %{name: "geometry", type: "json", ingestion_field_selector: "geometry"}
             ]
           }
         )

--- a/apps/valkyrie/test/unit/valkyrie_test.exs
+++ b/apps/valkyrie/test/unit/valkyrie_test.exs
@@ -487,8 +487,8 @@ defmodule ValkyrieTest do
           id: "ds1",
           technical: %{
             schema: [
-              %{name: "name", type: "string"},
-              %{name: "luckyNumbers", type: "list", itemType: "float"}
+              %{name: "name", type: "string", ingestion_field_selector: "name"},
+              %{name: "luckyNumbers", type: "list", itemType: "float", ingestion_field_selector: "luckyNumbers"}
             ]
           }
         )


### PR DESCRIPTION
## [Ticket Link #1151](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1151)

## Description

- Draft

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
