### PR TITLE
1165 ingestion selector bug

### DIFF
--- a/apps/andi/lib/andi/input_schemas/input_converter.ex
+++ b/apps/andi/lib/andi/input_schemas/input_converter.ex
@@ -483,7 +483,6 @@ defmodule Andi.InputSchemas.InputConverter do
     |> Map.delete(:id)
     |> Map.delete(:dataset_id)
     |> Map.delete(:bread_crumb)
-    |> Map.delete(:ingestion_field_sync)
     |> Map.update(:subSchema, nil, fn sub_schema ->
       Enum.map(sub_schema, &drop_fields_from_dictionary_item/1)
     end)

--- a/apps/andi/lib/andi_web/live/dataset_live_view/table.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/table.ex
@@ -11,9 +11,9 @@ defmodule AndiWeb.DatasetLiveView.Table do
     <div id="<%= @id %>" class="datasets-index__table">
       <table class="datasets-table" title="All Datasets">
         <thead>
-          <th class="datasets-table__th datasets-table__cell datasets-table__status-cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@order, "status", "unsorted") %>" phx-click="order-by" phx-value-field="status">Status</th>
-          <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@order, "data_title", "unsorted") %>" phx-click="order-by" phx-value-field="data_title" id="dataset-name">Dataset Name </th>
-          <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@order, "org_title", "unsorted") %>" phx-click="order-by" phx-value-field="org_title">Organization </th>
+          <th class="datasets-table__th datasets-table__cell datasets-table__status-cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@order, 'status', 'unsorted') %>" phx-click="order-by" phx-value-field="status">Status</th>
+          <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@order, 'data_title', 'unsorted') %>" phx-click="order-by" phx-value-field="data_title" id="dataset-name">Dataset Name </th>
+          <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@order, 'org_title', 'unsorted') %>" phx-click="order-by" phx-value-field="org_title">Organization </th>
           <th class="datasets-table__th datasets-table__cell">Actions</th>
         </thead>
 

--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_field_editor.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_field_editor.ex
@@ -26,6 +26,12 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
         <%= hidden_input(@form, :bread_crumb) %>
         <%= hidden_input(@form, :dataset_id) %>
         <%= hidden_input(@form, :ingestion_id) %>
+        <%= hidden_input(@form, :name) %>
+        <%= hidden_input(@form, :type) %>
+        <%= hidden_input(@form, :itemType) %>
+        <%= hidden_input(@form, :format) %>
+        <%= hidden_input(@form, :default_offset) %>
+        <%= hidden_input(@form, :use_default) %>
 
         <div class="data-dictionary-field-editor__name">
           <%= label(@form, :name, "Name", class: "label label--required", for: id <> "_name") %>
@@ -69,7 +75,7 @@ defmodule AndiWeb.DataDictionary.FieldEditor do
             <% sync? = input_value(@form, :ingestion_field_sync) %>
             <div class="ingestion-field-selector-label">
               <%= label(@form, :ingestion_field_sync, "Sync Ingestion Field", for: id <> "__ingestion-field-sync") %>
-              <%= checkbox(@form, :ingestion_field_sync, disabled: read_only?, id: id <> "__ingestion-field-sync", value: sync?) %>
+              <%= checkbox(@form, :ingestion_field_sync, id: id <> "__ingestion-field-sync", value: sync?) %>
             </div>
             <div width="400px">
               <%= label(@form, :ingestion_field_selector, "Ingestion Field", class: "label label--required", for: id <> "_ingestion-field-selector") %>

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.69",
+      version: "2.6.70",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
+++ b/apps/andi/test/unit/andi/input_schemas/input_converter_test.exs
@@ -108,6 +108,15 @@ defmodule Andi.InputSchemas.InputConverterTest do
         |> Ecto.Changeset.apply_changes()
         |> InputConverter.andi_dataset_to_smrt_dataset()
 
+      dataset_schema = Map.get(dataset.technical, :schema, [])
+
+      dataset =
+        Map.put(
+          dataset,
+          :technical,
+          Map.put(dataset.technical, :schema, Enum.map(dataset_schema, fn schema -> Map.put(schema, :ingestion_field_sync, true) end))
+        )
+
       assert new_dataset == dataset
     end
 
@@ -124,6 +133,7 @@ defmodule Andi.InputSchemas.InputConverterTest do
                 type: "timestamp",
                 format: "{YYYY}",
                 ingestion_field_selector: "timstamp_field",
+                ingestion_field_sync: true,
                 default: %{provider: "timestamp", version: "2", opts: %{format: "{YYYY}", offset_in_seconds: -1000}}
               }
             ]
@@ -150,6 +160,15 @@ defmodule Andi.InputSchemas.InputConverterTest do
         |> InputConverter.smrt_dataset_to_full_changeset()
         |> Ecto.Changeset.apply_changes()
         |> InputConverter.andi_dataset_to_smrt_dataset()
+
+      dataset_schema = Map.get(dataset.technical, :schema, [])
+
+      dataset =
+        Map.put(
+          dataset,
+          :technical,
+          Map.put(dataset.technical, :schema, Enum.map(dataset_schema, fn schema -> Map.put(schema, :ingestion_field_sync, true) end))
+        )
 
       assert new_dataset == dataset
     end


### PR DESCRIPTION
## [Ticket Link #1165](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1165)

## Description

- fixed Ingestion Field Sync and Selector to not being disabled upon publish
- fixed Ingestion Field Sync from being dropped from the dataset upon publish/coming back

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
