### PR TITLE
1179 Data dict form checkbox bugfix

### DIFF
--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_tree.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_tree.ex
@@ -65,7 +65,6 @@ defmodule AndiWeb.DataDictionary.Tree do
   end
 
   def handle_event("toggle_selected", %{"field-id" => field_id, "index" => index, "name" => name, "id" => id}, socket) do
-    IO.inspect("_____________________________")
     assign_current_dictionary_field(field_id, index, name, id)
     {:noreply, assign(socket, selected_field_id: field_id, new_field_initial_render: false)}
   end

--- a/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_tree.ex
+++ b/apps/andi/lib/andi_web/live/shared_components/data_dictionary/data_dictionary_tree.ex
@@ -25,13 +25,13 @@ defmodule AndiWeb.DataDictionary.Tree do
           <%= hidden_inputs(field, @selected_field_id) %>
           <%= hidden_input(field, :dataset_id) %>
 
-          <% {icon_modifier, selected_modifier} = get_action(field, assigns) %>
+          <% {icon_modifier, selected_modifier} = get_action(field, assigns)%>
 
           <div class="data-dictionary-tree-field data-dictionary-tree__field data-dictionary-tree__field--<%= icon_modifier %> data-dictionary-tree__field--<%= selected_modifier %>">
           <%= checkbox(field, :selected_modifier,
               [class: "data-dictionary-tree-field__action",
               checked: selected_modifier == "selected",
-              "phx-click": if(is_set?(field, :subSchema), do: "toggle_expanded", else: "toggle_selected"),
+              "phx-click": "toggle_selected",
               "phx-value-field-id": input_value(field, :id),
               "phx-value-index": field.index,
               "phx-value-name": field.name,
@@ -39,7 +39,7 @@ defmodule AndiWeb.DataDictionary.Tree do
               aria_label: "#{input_value(field, :name)} checkbox",
               "phx-target": "##{@root_id}"]) %>
 
-          <div class="data-dictionary-tree-field__text" phx-click="toggle_selected" phx-value-field-id="<%= input_value(field, :id) %>" phx-value-index="<%= field.index %>" phx-value-name="<%= field.name %>" phx-value-id="<%= field.id %>" phx-target="#<%= @root_id %>">
+          <div class="data-dictionary-tree-field__text" phx-click="toggle_expanded" phx-value-field-id="<%= input_value(field, :id) %>" phx-value-index="<%= field.index %>" phx-value-name="<%= field.name %>" phx-value-id="<%= field.id %>" phx-target="#<%= @root_id %>">
               <div class="data-dictionary-tree-field__name data-dictionary-tree-field-attribute"><%= input_value(field, :name) %></div>
               <div class="data-dictionary-tree-field__type data-dictionary-tree-field-attribute"><%= input_value(field, :type) %></div>
             </div>
@@ -65,6 +65,7 @@ defmodule AndiWeb.DataDictionary.Tree do
   end
 
   def handle_event("toggle_selected", %{"field-id" => field_id, "index" => index, "name" => name, "id" => id}, socket) do
+    IO.inspect("_____________________________")
     assign_current_dictionary_field(field_id, index, name, id)
     {:noreply, assign(socket, selected_field_id: field_id, new_field_initial_render: false)}
   end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.76",
+      version: "2.6.77",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary/data_dictionary_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/ingestion_live_view/data_dictionary/data_dictionary_form_test.exs
@@ -451,7 +451,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       assert find_elements(html, ".data-dictionary-remove-field-editor--hidden")
 
       view
-      |> element(".data-dictionary-tree-field__text", "one")
+      |> element("#data_dictionary_form_schema_0_selected_modifier")
       |> render_click()
 
       html =
@@ -484,7 +484,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       assert find_elements(html, ".data-dictionary-remove-field-editor--hidden")
 
       view
-      |> element(".data-dictionary-tree-field__text", "two")
+      |> element("#data_dictionary_form_schema_1_selected_modifier")
       |> render_click()
 
       html =
@@ -573,7 +573,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       {:ok, view, html} = live(conn, "#{@url_path}/#{andi_ingestion.id}")
 
       view
-      |> element(".data-dictionary-tree-field__text", "date_field")
+      |> element("#data_dictionary_form_schema_0_selected_modifier")
       |> render_click()
 
       eventually(fn ->
@@ -619,7 +619,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       {:ok, view, html} = live(conn, "#{@url_path}/#{andi_ingestion.id}")
 
       view
-      |> element(".data-dictionary-tree-field__text", "date_field")
+      |> element("#data_dictionary_form_schema_0_selected_modifier")
       |> render_click()
 
       eventually(fn ->
@@ -665,7 +665,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       {:ok, view, html} = live(conn, "#{@url_path}/#{andi_ingestion_with_timestamp.id}")
 
       view
-      |> element(".data-dictionary-tree-field__text", "timestamp_field")
+      |> element(".data-dictionary-tree-field__action")
       |> render_click()
 
       format = "{YYYY}-{0M}-{0D}"
@@ -708,7 +708,7 @@ defmodule AndiWeb.IngestionLiveView.DataDictionaryFormTest do
       {:ok, view, html} = live(conn, "#{@url_path}/#{andi_ingestion_with_date.id}")
 
       view
-      |> element(".data-dictionary-tree-field__text", "date_field")
+      |> element("#data_dictionary_form_schema_0_selected_modifier")
       |> render_click()
 
       format = "{YYYY}-{0M}-{0D}"

--- a/apps/andi/test/integration/andi_web/live/public_submissions_live_view/data_dictionary_tree_test.exs
+++ b/apps/andi/test/integration/andi_web/live/public_submissions_live_view/data_dictionary_tree_test.exs
@@ -56,17 +56,17 @@ defmodule AndiWeb.DataDictionary.TreeTest do
       assert {:ok, view, html} = live(conn, @url_path <> andi_dataset.id)
       data_dictionary_view = find_live_child(view, "data_dictionary_form_editor")
 
-      [expandable_one_id, expandable_two_id] =
-        get_attributes(html, ".data-dictionary-tree-field__action[phx-click='toggle_expanded']", "phx-value-field-id")
-
-      [expandable_one_target, expandable_two_target] =
-        get_attributes(html, ".data-dictionary-tree-field__action[phx-click='toggle_expanded']", "phx-target")
-
       [checkable_one_id, _, _, checkable_two_id] =
-        get_attributes(html, ".data-dictionary-tree-field__text[phx-click='toggle_selected']", "phx-value-field-id")
+        get_attributes(html, ".data-dictionary-tree-field__action[phx-click='toggle_selected']", "phx-value-field-id")
 
       [checkable_one_target, _, _, checkable_two_target] =
-        get_attributes(html, ".data-dictionary-tree-field__text[phx-click='toggle_selected']", "phx-target")
+        get_attributes(html, ".data-dictionary-tree-field__action[phx-click='toggle_selected']", "phx-target")
+
+      [expandable_one_id, _, expandable_two_id, _] =
+        get_attributes(html, ".data-dictionary-tree-field__text[phx-click='toggle_expanded']", "phx-value-field-id")
+
+      [expandable_one_target, _, expandable_two_target, _] =
+        get_attributes(html, ".data-dictionary-tree-field__text[phx-click='toggle_expanded']", "phx-target")
 
       [
         view: data_dictionary_view,
@@ -92,23 +92,23 @@ defmodule AndiWeb.DataDictionary.TreeTest do
       one_id = expandable_one.id
       two_id = expandable_two.id
 
-      assert [^one_id, ^two_id] = get_action_field_ids(html, "expanded")
+      assert [^one_id, ^two_id] = get_expandable_field_ids(html, "expanded")
     end
 
     test "clicking an expandable field once collapses it", %{view: view, expandable_one: expandable_one} do
       one_id = expandable_one.id
 
-      expandable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{one_id}']")
+      expandable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{one_id}']")
 
       html = render_click(expandable)
 
-      assert [^one_id] = get_action_field_ids(html, "collapsed")
+      assert [^one_id] = get_expandable_field_ids(html, "collapsed")
     end
 
     test "clicking an expandable field twice toggles it", %{view: view, expandable_one: expandable_one} do
       one_id = expandable_one.id
 
-      expandable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{one_id}']")
+      expandable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{one_id}']")
 
       _html = render_click(expandable)
       html = render_click(expandable)
@@ -127,7 +127,7 @@ defmodule AndiWeb.DataDictionary.TreeTest do
 
       assert [^one_id, ^two_id] = get_action_field_ids(html, "expanded")
 
-      expandable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{two_id}']")
+      expandable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{two_id}']")
       html = render_click(expandable)
 
       assert [^one_id] = get_action_field_ids(html, "expanded")
@@ -136,7 +136,7 @@ defmodule AndiWeb.DataDictionary.TreeTest do
 
     test "clicking a selectable and expandable field once selects it but leaves it expanded", %{view: view, checkable_one: checkable_one} do
       one_id = checkable_one.id
-      selectable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{one_id}']")
+      selectable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{one_id}']")
 
       html = render_click(selectable)
 
@@ -147,7 +147,7 @@ defmodule AndiWeb.DataDictionary.TreeTest do
     test "clicking a selectable and checkable field once selects and checks it", %{view: view, checkable_two: checkable_two} do
       two_id = checkable_two.id
 
-      selectable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{two_id}']")
+      selectable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{two_id}']")
       html = render_click(selectable)
 
       assert [^two_id] = get_action_field_ids(html, "selected")
@@ -157,7 +157,7 @@ defmodule AndiWeb.DataDictionary.TreeTest do
     test "clicking a checkable field twice does not unselect it", %{view: view, checkable_one: checkable_one} do
       one_id = checkable_one.id
 
-      selectable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{one_id}']")
+      selectable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{one_id}']")
       _html = render_click(selectable)
       html = render_click(selectable)
 
@@ -176,8 +176,8 @@ defmodule AndiWeb.DataDictionary.TreeTest do
       assert one_id in get_action_field_ids(html, "selected")
       assert two_id in get_action_field_ids(html, "unselected")
 
-      selectable_one = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{one_id}']")
-      selectable_two = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{two_id}']")
+      selectable_one = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{one_id}']")
+      selectable_two = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{two_id}']")
 
       html = render_click(selectable_two)
 
@@ -195,7 +195,7 @@ defmodule AndiWeb.DataDictionary.TreeTest do
       one_name = checkable_one.name
       one_type = checkable_one.type
 
-      selectable = element(view, ".data-dictionary-tree-field__text[phx-value-field-id='#{one_id}']")
+      selectable = element(view, ".data-dictionary-tree-field__action[phx-value-field-id='#{one_id}']")
 
       _html = render_click(selectable)
 
@@ -209,5 +209,9 @@ defmodule AndiWeb.DataDictionary.TreeTest do
 
   def get_action_field_ids(html, action) do
     get_attributes(html, ".data-dictionary-tree__field--#{action} > .data-dictionary-tree-field__action", "phx-value-field-id")
+  end
+
+  def get_expandable_field_ids(html, action) do
+    get_attributes(html, ".data-dictionary-tree__field--#{action} > .data-dictionary-tree-field__text", "phx-value-field-id")
   end
 end


### PR DESCRIPTION
## [Ticket Link #1179](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1179)

## Description

- change UI actions to have singular responsibility

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
