### PR TITLE
Rename auth0_client_id

### DIFF
--- a/apps/andi/config/integration.exs
+++ b/apps/andi/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
-System.put_env("AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
+# System.put_env("AUTH0_DOMAIN", "urbanos-demo.us.auth0.com")
+# System.put_env("AUTH0_CLIENT_ID", "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0")
 System.put_env("SECURE_COOKIE", "false")
 System.put_env("REQUIRE_ADMIN_API_KEY", "false")
 System.put_env("RAPTOR_URL", "http://localhost:4002")
@@ -78,9 +78,9 @@ config :andi, :brook,
     init_arg: [redix_args: redix_args, namespace: "andi:view"]
   ]
 
-config :andi, :auth0,
-  url: "https://urbanos-dev.us.auth0.com/oauth/token",
-  audience: "https://urbanos-dev.us.auth0.com/api/v2/"
+# config :andi, :auth0,
+#   url: "https://urbanos-demo.us.auth0.com/oauth/token",
+#   audience: "https://urbanos-demo.us.auth0.com/api/v2/"
 
 config :andi, AndiWeb.Endpoint,
   pubsub_server: Andi.PubSub,
@@ -130,16 +130,16 @@ config :ueberauth, Ueberauth,
        ]}
   ]
 
-config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
-  domain: "urbanos-dev.us.auth0.com",
-  client_id: "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa",
-  client_secret: System.get_env("AUTH0_CLIENT_SECRET")
+# config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
+#   domain: "urbanos-demo.us.auth0.com",
+#   client_id: "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0",
+#   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
-config :andi, AndiWeb.Auth.TokenHandler,
-  issuer: "https://urbanos-dev.us.auth0.com/",
-  allowed_algos: ["RS256"],
-  verify_issuer: false,
-  allowed_drift: 3_000_000_000_000
+# config :andi, AndiWeb.Auth.TokenHandler,
+#   issuer: "https://urbanos-demo.us.auth0.com/",
+#   allowed_algos: ["RS256"],
+#   verify_issuer: false,
+#   allowed_drift: 3_000_000_000_000
 
 config :andi, Guardian.DB, repo: Andi.Repo
 

--- a/apps/andi/config/integration.exs
+++ b/apps/andi/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
-System.put_env("AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
+System.put_env("ANDI_AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
 System.put_env("SECURE_COOKIE", "false")
 System.put_env("REQUIRE_ADMIN_API_KEY", "false")
 System.put_env("RAPTOR_URL", "http://localhost:4002")

--- a/apps/andi/config/integration.exs
+++ b/apps/andi/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-# System.put_env("AUTH0_DOMAIN", "")
-# System.put_env("AUTH0_CLIENT_ID", "")
+# System.put_env("AUTH0_DOMAIN", "urbanos-demo.us.auth0.com")
+# System.put_env("AUTH0_CLIENT_ID", "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0")
 System.put_env("SECURE_COOKIE", "false")
 System.put_env("REQUIRE_ADMIN_API_KEY", "false")
 System.put_env("RAPTOR_URL", "http://localhost:4002")
@@ -78,9 +78,9 @@ config :andi, :brook,
     init_arg: [redix_args: redix_args, namespace: "andi:view"]
   ]
 
-config :andi, :auth0,
-  url: "oauth/token",
-  audience: "api/v2/"
+# config :andi, :auth0,
+#   url: "https://urbanos-demo.us.auth0.com/oauth/token",
+#   audience: "https://urbanos-demo.us.auth0.com/api/v2/"
 
 config :andi, AndiWeb.Endpoint,
   pubsub_server: Andi.PubSub,
@@ -130,16 +130,16 @@ config :ueberauth, Ueberauth,
        ]}
   ]
 
-config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
-  domain: "",
-  client_id: "",
-  client_secret: System.get_env("AUTH0_CLIENT_SECRET")
+# config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
+#   domain: "urbanos-demo.us.auth0.com",
+#   client_id: "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0",
+#   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
-config :andi, AndiWeb.Auth.TokenHandler,
-  issuer: "",
-  allowed_algos: ["RS256"],
-  verify_issuer: false,
-  allowed_drift: 3_000_000_000_000
+# config :andi, AndiWeb.Auth.TokenHandler,
+#   issuer: "https://urbanos-demo.us.auth0.com/",
+#   allowed_algos: ["RS256"],
+#   verify_issuer: false,
+#   allowed_drift: 3_000_000_000_000
 
 config :andi, Guardian.DB, repo: Andi.Repo
 

--- a/apps/andi/config/integration.exs
+++ b/apps/andi/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-# System.put_env("AUTH0_DOMAIN", "urbanos-demo.us.auth0.com")
-# System.put_env("AUTH0_CLIENT_ID", "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0")
+System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
+System.put_env("AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
 System.put_env("SECURE_COOKIE", "false")
 System.put_env("REQUIRE_ADMIN_API_KEY", "false")
 System.put_env("RAPTOR_URL", "http://localhost:4002")
@@ -78,9 +78,9 @@ config :andi, :brook,
     init_arg: [redix_args: redix_args, namespace: "andi:view"]
   ]
 
-# config :andi, :auth0,
-#   url: "https://urbanos-demo.us.auth0.com/oauth/token",
-#   audience: "https://urbanos-demo.us.auth0.com/api/v2/"
+config :andi, :auth0,
+  url: "https://urbanos-dev.us.auth0.com/oauth/token",
+  audience: "https://urbanos-dev.us.auth0.com/api/v2/"
 
 config :andi, AndiWeb.Endpoint,
   pubsub_server: Andi.PubSub,
@@ -130,16 +130,16 @@ config :ueberauth, Ueberauth,
        ]}
   ]
 
-# config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
-#   domain: "urbanos-demo.us.auth0.com",
-#   client_id: "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0",
-#   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
+config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
+  domain: "urbanos-dev.us.auth0.com",
+  client_id: "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa",
+  client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
-# config :andi, AndiWeb.Auth.TokenHandler,
-#   issuer: "https://urbanos-demo.us.auth0.com/",
-#   allowed_algos: ["RS256"],
-#   verify_issuer: false,
-#   allowed_drift: 3_000_000_000_000
+config :andi, AndiWeb.Auth.TokenHandler,
+  issuer: "https://urbanos-dev.us.auth0.com/",
+  allowed_algos: ["RS256"],
+  verify_issuer: false,
+  allowed_drift: 3_000_000_000_000
 
 config :andi, Guardian.DB, repo: Andi.Repo
 

--- a/apps/andi/config/integration.exs
+++ b/apps/andi/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
-# System.put_env("AUTH0_DOMAIN", "urbanos-demo.us.auth0.com")
-# System.put_env("AUTH0_CLIENT_ID", "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0")
+# System.put_env("AUTH0_DOMAIN", "")
+# System.put_env("AUTH0_CLIENT_ID", "")
 System.put_env("SECURE_COOKIE", "false")
 System.put_env("REQUIRE_ADMIN_API_KEY", "false")
 System.put_env("RAPTOR_URL", "http://localhost:4002")
@@ -78,9 +78,9 @@ config :andi, :brook,
     init_arg: [redix_args: redix_args, namespace: "andi:view"]
   ]
 
-# config :andi, :auth0,
-#   url: "https://urbanos-demo.us.auth0.com/oauth/token",
-#   audience: "https://urbanos-demo.us.auth0.com/api/v2/"
+config :andi, :auth0,
+  url: "oauth/token",
+  audience: "api/v2/"
 
 config :andi, AndiWeb.Endpoint,
   pubsub_server: Andi.PubSub,
@@ -130,16 +130,16 @@ config :ueberauth, Ueberauth,
        ]}
   ]
 
-# config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
-#   domain: "urbanos-demo.us.auth0.com",
-#   client_id: "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0",
-#   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
+config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
+  domain: "",
+  client_id: "",
+  client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
-# config :andi, AndiWeb.Auth.TokenHandler,
-#   issuer: "https://urbanos-demo.us.auth0.com/",
-#   allowed_algos: ["RS256"],
-#   verify_issuer: false,
-#   allowed_drift: 3_000_000_000_000
+config :andi, AndiWeb.Auth.TokenHandler,
+  issuer: "",
+  allowed_algos: ["RS256"],
+  verify_issuer: false,
+  allowed_drift: 3_000_000_000_000
 
 config :andi, Guardian.DB, repo: Andi.Repo
 

--- a/apps/andi/lib/andi/application.ex
+++ b/apps/andi/lib/andi/application.ex
@@ -112,7 +112,7 @@ defmodule Andi.Application do
   def set_auth0_credentials() do
     Application.put_env(:ueberauth, Ueberauth.Strategy.Auth0.OAuth,
       domain: get_env_variable("AUTH0_DOMAIN", false),
-      client_id: get_env_variable("AUTH0_CLIENT_ID", false),
+      client_id: get_env_variable("ANDI_AUTH0_CLIENT_ID", false),
       client_secret: get_env_variable("AUTH0_CLIENT_SECRET", false)
     )
   end

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.78",
+      version: "2.7.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/raptor/config/integration.exs
+++ b/apps/raptor/config/integration.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
-System.put_env("AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
+System.put_env("RAPTOR_AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
 
 host = "localhost"
 endpoints = [{to_charlist(host), 9092}]
@@ -9,7 +9,7 @@ redix_args = [host: host]
 
 config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
   domain: System.get_env("AUTH0_DOMAIN"),
-  client_id: System.get_env("AUTH0_CLIENT_ID"),
+  client_id: System.get_env("RAPTOR_AUTH0_CLIENT_ID"),
   client_secret: System.get_env("AUTH0_CLIENT_SECRET")
 
 config :raptor, :auth0,

--- a/apps/raptor/lib/raptor/application.ex
+++ b/apps/raptor/lib/raptor/application.ex
@@ -72,7 +72,7 @@ defmodule Raptor.Application do
   def set_auth0_credentials() do
     Application.put_env(:ueberauth, Ueberauth.Strategy.Auth0.OAuth,
       domain: get_env_variable("AUTH0_DOMAIN", false),
-      client_id: get_env_variable("AUTH0_CLIENT_ID", false),
+      client_id: get_env_variable("RAPTOR_AUTH0_CLIENT_ID", false),
       client_secret: get_env_variable("AUTH0_CLIENT_SECRET", false)
     )
   end

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.2.18",
+      version: "1.3.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
## Description

So auth0_client_id isn't the same everywhere

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [x] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
