### PR TITLE
add keywords and access level to report generation

### DIFF
--- a/apps/andi/lib/andi_web/controllers/reports_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/reports_controller.ex
@@ -20,6 +20,7 @@ defmodule AndiWeb.ReportsController do
       get_datasets()
       |> Enum.map(fn dataset ->
         IO.inspect(dataset, label: "report dataset")
+
         [
           dataset.id,
           dataset.dataTitle,

--- a/apps/andi/lib/andi_web/controllers/reports_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/reports_controller.ex
@@ -19,8 +19,6 @@ defmodule AndiWeb.ReportsController do
     values =
       get_datasets()
       |> Enum.map(fn dataset ->
-        IO.inspect(dataset, label: "report dataset")
-
         [
           dataset.id,
           dataset.dataTitle,
@@ -52,6 +50,14 @@ defmodule AndiWeb.ReportsController do
       "Public"
     else
       "Private"
+    end
+  end
+
+  defp get_keyword_list(keywords) do
+    if length(keywords) > 0 do
+      Enum.join(keywords, ", ")
+    else
+      []
     end
   end
 

--- a/apps/andi/lib/andi_web/controllers/reports_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/reports_controller.ex
@@ -19,16 +19,19 @@ defmodule AndiWeb.ReportsController do
     values =
       get_datasets()
       |> Enum.map(fn dataset ->
+        IO.inspect(dataset, label: "report dataset")
         [
           dataset.id,
           dataset.dataTitle,
           dataset.orgTitle,
           dataset.systemName,
-          get_users_for_dataset(dataset.is_public, dataset.access_groups, dataset.org_id)
+          get_users_for_dataset(dataset.is_public, dataset.access_groups, dataset.org_id),
+          dataset.keywords |> Enum.join(", "),
+          get_access_level(dataset.is_public)
         ]
       end)
 
-    [["Dataset ID", "Dataset Title", "Organization", "System Name", "Users"] | values]
+    [["Dataset ID", "Dataset Title", "Organization", "System Name", "Users", "Tags", "Access Level"] | values]
   end
 
   defp get_users_for_dataset(is_public, access_groups, org_id) do
@@ -40,6 +43,14 @@ defmodule AndiWeb.ReportsController do
       |> Enum.dedup()
       |> Enum.sort()
       |> Enum.join(", ")
+    end
+  end
+
+  defp get_access_level(is_public) do
+    if is_public do
+      "Public"
+    else
+      "Private"
     end
   end
 
@@ -59,7 +70,8 @@ defmodule AndiWeb.ReportsController do
         systemName: dataset.technical.systemName,
         is_public: not dataset.technical.private,
         access_groups: dataset.access_groups,
-        org_id: dataset.technical.orgId
+        org_id: dataset.technical.orgId,
+        keywords: dataset.business.keywords
       }
     end)
   end

--- a/apps/andi/lib/andi_web/controllers/reports_controller.ex
+++ b/apps/andi/lib/andi_web/controllers/reports_controller.ex
@@ -25,7 +25,7 @@ defmodule AndiWeb.ReportsController do
           dataset.orgTitle,
           dataset.systemName,
           get_users_for_dataset(dataset.is_public, dataset.access_groups, dataset.org_id),
-          dataset.keywords |> Enum.join(", "),
+          get_keyword_list(dataset.keywords),
           get_access_level(dataset.is_public)
         ]
       end)

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.6.78",
+      version: "2.6.79",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -23,7 +23,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),Public,\"keyword1,keyword2\"\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),\"keyword1,keyword2\",Public\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org", %{curator_conn: conn} do

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -59,7 +59,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com\", user2@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com\", user2@fakemail.com,\"keyword1,keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2,keyword3\",Public\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org and access groups", %{curator_conn: conn} do
@@ -104,7 +104,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1,keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),,Public\r\n"
     end
 
     test "filters duplicates", %{curator_conn: conn} do
@@ -137,7 +137,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1,keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2,keyword3\",Public\r\n"
     end
   end
 end

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -137,7 +137,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword1, keyword2\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
     end
   end
 end

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -23,7 +23,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),Public,keyword1,keyword2\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),Public,\"keyword1,keyword2\"\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org", %{curator_conn: conn} do
@@ -59,7 +59,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com,Public,keyword1, keyword2\"\r\n6789,Example2,Test2,Test2__Example2,All (public),Public,keyword2, keyword3\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com\", user2@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org and access groups", %{curator_conn: conn} do
@@ -104,7 +104,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com,Private,keyword1, keyword2\"\r\n6789,Example2,Test2,Test2__Example2,All (public),Public,keyword1, keyword2\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword1, keyword2\",Public\r\n"
     end
 
     test "filters duplicates", %{curator_conn: conn} do
@@ -137,7 +137,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,Private,keyword1, keyword2\r\n6789,Example2,Test2,Test2__Example2,All (public),Public,keyword1, keyword2\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword1, keyword2\",Public\r\n"
     end
   end
 end

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -93,7 +93,7 @@ defmodule Andi.ReportsControllerTest do
 
       dataset2 = %Dataset{
         id: "6789",
-        business: %Business{dataTitle: "Example2", orgTitle: "Test2"},
+        business: %Business{dataTitle: "Example2", orgTitle: "Test2", keywords: []},
         technical: %Technical{private: false, systemName: "Test2__Example2"}
       }
 
@@ -104,7 +104,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword1, keyword2\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"\",Public\r\n"
     end
 
     test "filters duplicates", %{curator_conn: conn} do

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -23,7 +23,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),\"keyword1,keyword2\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),\"keyword1, keyword2\",Public\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org", %{curator_conn: conn} do
@@ -59,7 +59,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com\", user2@fakemail.com,\"keyword1,keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2,keyword3\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com\", user2@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org and access groups", %{curator_conn: conn} do
@@ -104,7 +104,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1,keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),,Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\",\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),,Public\r\n"
     end
 
     test "filters duplicates", %{curator_conn: conn} do
@@ -137,7 +137,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1,keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2,keyword3\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
     end
   end
 end

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -59,7 +59,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com\", user2@fakemail.com,\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com\",\"keyword1, keyword2\",Private\r\n6789,Example2,Test2,Test2__Example2,All (public),\"keyword2, keyword3\",Public\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org and access groups", %{curator_conn: conn} do

--- a/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
+++ b/apps/andi/test/integration/andi_web/controllers/reports_controller_test.exs
@@ -14,7 +14,7 @@ defmodule Andi.ReportsControllerTest do
     test "sets dataset users to public when dataset is not private", %{curator_conn: conn} do
       dataset1 = %Dataset{
         id: "12345",
-        business: %Business{dataTitle: "Example", orgTitle: "Test"},
+        business: %Business{dataTitle: "Example", orgTitle: "Test", keywords: ["keyword1", "keyword2"]},
         technical: %Technical{private: false, systemName: "Test__Example"}
       }
 
@@ -23,20 +23,20 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users\r\n12345,Example,Test,Test__Example,All (public)\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,All (public),Public,keyword1,keyword2\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org", %{curator_conn: conn} do
       dataset1 = %Dataset{
         id: "12345",
-        business: %Business{dataTitle: "Example", orgTitle: "Test"},
+        business: %Business{dataTitle: "Example", orgTitle: "Test", keywords: ["keyword1", "keyword2"]},
         technical: %Technical{private: true, orgId: "1122", systemName: "Test__Example"},
         access_groups: []
       }
 
       dataset2 = %Dataset{
         id: "6789",
-        business: %Business{dataTitle: "Example2", orgTitle: "Test2"},
+        business: %Business{dataTitle: "Example2", orgTitle: "Test2", keywords: ["keyword2", "keyword3"]},
         technical: %Technical{private: false, systemName: "Test2__Example2"}
       }
 
@@ -59,7 +59,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com\"\r\n6789,Example2,Test2,Test2__Example2,All (public)\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com,Public,keyword1, keyword2\"\r\n6789,Example2,Test2,Test2__Example2,All (public),Public,keyword2, keyword3\r\n"
     end
 
     test "adds users to private dataset based on the dataset's org and access groups", %{curator_conn: conn} do
@@ -86,7 +86,7 @@ defmodule Andi.ReportsControllerTest do
 
       dataset1 = %Dataset{
         id: "12345",
-        business: %Business{dataTitle: "Example", orgTitle: "Test"},
+        business: %Business{dataTitle: "Example", orgTitle: "Test", keywords: ["keyword1", "keyword2"]},
         technical: %Technical{private: true, orgId: "1122", systemName: "Test__Example"},
         access_groups: [access_group1, access_group2]
       }
@@ -104,7 +104,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com\"\r\n6789,Example2,Test2,Test2__Example2,All (public)\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,\"user1@fakemail.com, user2@fakemail.com, user3@fakemail.com,Private,keyword1, keyword2\"\r\n6789,Example2,Test2,Test2__Example2,All (public),Public,keyword1, keyword2\r\n"
     end
 
     test "filters duplicates", %{curator_conn: conn} do
@@ -119,14 +119,14 @@ defmodule Andi.ReportsControllerTest do
 
       dataset1 = %Dataset{
         id: "12345",
-        business: %Business{dataTitle: "Example", orgTitle: "Test"},
+        business: %Business{dataTitle: "Example", orgTitle: "Test", keywords: ["keyword1", "keyword2"]},
         technical: %Technical{private: true, orgId: "1122", systemName: "Test__Example"},
         access_groups: [access_group1, access_group2]
       }
 
       dataset2 = %Dataset{
         id: "6789",
-        business: %Business{dataTitle: "Example2", orgTitle: "Test2"},
+        business: %Business{dataTitle: "Example2", orgTitle: "Test2", keywords: ["keyword2", "keyword3"]},
         technical: %Technical{private: false, systemName: "Test2__Example2"}
       }
 
@@ -137,7 +137,7 @@ defmodule Andi.ReportsControllerTest do
       assert result.status == 200
 
       assert result.resp_body ==
-               "Dataset ID,Dataset Title,Organization,System Name,Users\r\n12345,Example,Test,Test__Example,user1@fakemail.com\r\n6789,Example2,Test2,Test2__Example2,All (public)\r\n"
+               "Dataset ID,Dataset Title,Organization,System Name,Users,Tags,Access Level\r\n12345,Example,Test,Test__Example,user1@fakemail.com,Private,keyword1, keyword2\r\n6789,Example2,Test2,Test2__Example2,All (public),Public,keyword1, keyword2\r\n"
     end
   end
 end


### PR DESCRIPTION
## [Ticket Link #1209](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1209)

## Description

Add keywords and access level to andi report generation

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
