### PR TITLE
delete event logs after 7 days

### DIFF
--- a/apps/andi/588d14e9-ad5f-4ca6-87a5-30a09049d08f
+++ b/apps/andi/588d14e9-ad5f-4ca6-87a5-30a09049d08f
@@ -1,0 +1,1 @@
+true,foobar,10

--- a/apps/andi/608fb311-b99c-4b95-a527-35ae257ae5ec
+++ b/apps/andi/608fb311-b99c-4b95-a527-35ae257ae5ec
@@ -1,0 +1,1 @@
+true,foobar,10

--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -37,6 +37,7 @@ defmodule Andi.Event.EventHandler do
   alias Andi.Services.IngestionStore
 
   @instance_name Andi.instance_name()
+  @event_log_retention 7
 
   def handle_event(%Brook.Event{type: dataset_update(), data: %Dataset{} = data, author: author}) do
     Logger.info("Dataset: #{data.id} - Received dataset_update event from #{author}")
@@ -65,7 +66,7 @@ defmodule Andi.Event.EventHandler do
     event_log_published()
     |> add_event_count(author, event_log.dataset_id)
 
-    EventLogs.delete_all_before_date(7, "day")
+    EventLogs.delete_all_before_date(@event_log_retention, "day")
     EventLogs.update(event_log)
 
     :ok

--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -65,6 +65,7 @@ defmodule Andi.Event.EventHandler do
     event_log_published()
     |> add_event_count(author, event_log.dataset_id)
 
+    EventLogs.delete_all_before_date(7, "day")
     EventLogs.update(event_log)
 
     :ok

--- a/apps/andi/lib/andi/input_schemas/event_logs.ex
+++ b/apps/andi/lib/andi/input_schemas/event_logs.ex
@@ -28,6 +28,17 @@ defmodule Andi.InputSchemas.EventLogs do
     Repo.all(query)
   end
 
+  def get_all_with_limit_for_dataset_id(dataset_id, limit) do
+    query = from(
+      eventlog in EventLog,
+      where: eventlog.dataset_id == ^dataset_id,
+      limit: ^limit,
+      order_by: [desc: eventlog.timestamp]
+    )
+
+    Repo.all(query)
+  end
+
   def update(%SmartCity.EventLog{} = event_log) do
     EventLog.changeset(event_log)
     |> Repo.insert_or_update()
@@ -39,4 +50,14 @@ defmodule Andi.InputSchemas.EventLogs do
     _e in Ecto.StaleEntryError ->
       {:error, "attempted to remove an eventlog: #{inspect(event_log)} that does not exist."}
   end
+
+  def delete_all_before_date(value, unit) do
+    query = from(
+      eventlog in EventLog,
+      where: eventlog.timestamp < ago(^value, ^unit)
+    )
+    Repo.all(query) |> IO.inspect(label: "query")
+    Repo.delete_all(query)
+  end
 end
+

--- a/apps/andi/lib/andi/input_schemas/event_logs.ex
+++ b/apps/andi/lib/andi/input_schemas/event_logs.ex
@@ -29,12 +29,13 @@ defmodule Andi.InputSchemas.EventLogs do
   end
 
   def get_all_with_limit_for_dataset_id(dataset_id, limit) do
-    query = from(
-      eventlog in EventLog,
-      where: eventlog.dataset_id == ^dataset_id,
-      limit: ^limit,
-      order_by: [desc: eventlog.timestamp]
-    )
+    query =
+      from(
+        eventlog in EventLog,
+        where: eventlog.dataset_id == ^dataset_id,
+        limit: ^limit,
+        order_by: [desc: eventlog.timestamp]
+      )
 
     Repo.all(query)
   end
@@ -52,12 +53,13 @@ defmodule Andi.InputSchemas.EventLogs do
   end
 
   def delete_all_before_date(value, unit) do
-    query = from(
-      eventlog in EventLog,
-      where: eventlog.timestamp < ago(^value, ^unit)
-    )
+    query =
+      from(
+        eventlog in EventLog,
+        where: eventlog.timestamp < ago(^value, ^unit)
+      )
+
     Repo.all(query) |> IO.inspect(label: "query")
     Repo.delete_all(query)
   end
 end
-

--- a/apps/andi/lib/andi/input_schemas/event_logs.ex
+++ b/apps/andi/lib/andi/input_schemas/event_logs.ex
@@ -59,7 +59,6 @@ defmodule Andi.InputSchemas.EventLogs do
         where: eventlog.timestamp < ago(^value, ^unit)
       )
 
-    Repo.all(query) |> IO.inspect(label: "query")
     Repo.delete_all(query)
   end
 end

--- a/apps/andi/lib/andi_web/live/dataset_live_view/event_log_form.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/event_log_form.ex
@@ -16,11 +16,13 @@ defmodule AndiWeb.EditLiveView.EventLogForm do
   alias Andi.InputSchemas.InputConverter
   alias Ecto.Changeset
 
+  @limit 50
+
   def mount(_, %{"dataset" => dataset, "order" => order}, socket) do
     AndiWeb.Endpoint.subscribe("toggle-visibility")
 
     event_log =
-      Andi.InputSchemas.EventLogs.get_all_for_dataset_id(dataset.id)
+      Andi.InputSchemas.EventLogs.get_all_with_limit_for_dataset_id(dataset.id, @limit)
       |> convert_to_string_keys
       |> sort_list_by_field(:timestamp, "asc")
 

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.7.3",
+      version: "2.7.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/priv/repo/migrations/20230811191751_create_index_dataset_id.exs
+++ b/apps/andi/priv/repo/migrations/20230811191751_create_index_dataset_id.exs
@@ -1,0 +1,7 @@
+defmodule Andi.Repo.Migrations.CreateIndexDatasetId do
+  use Ecto.Migration
+
+  def change do
+    create index(:event_log, [:dataset_id])
+  end
+end

--- a/apps/andi/test/integration/andi/event/event_handler_test.exs
+++ b/apps/andi/test/integration/andi/event/event_handler_test.exs
@@ -633,8 +633,15 @@ defmodule Andi.Event.EventHandlerTest do
     end
 
     test "Event Log Published event handler deletes records older than 7 days" do
-      old_time = DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), -9
-      * 3600 * 24, :second))
+      old_time =
+        DateTime.to_iso8601(
+          DateTime.add(
+            DateTime.utc_now(),
+            -9 *
+              3600 * 24,
+            :second
+          )
+        )
 
       old_event_log = %SmartCity.EventLog{
         title: "someTitle",
@@ -657,6 +664,7 @@ defmodule Andi.Event.EventHandlerTest do
       expected_timestamp = DateTime.truncate(event_log_datetime, :second)
 
       Brook.Event.send(@instance_name, event_log_published(), __MODULE__, new_event_log)
+
       eventually(fn ->
         all_datasets = Andi.InputSchemas.EventLogs.get_all()
         assert length(all_datasets) == 1
@@ -667,8 +675,15 @@ defmodule Andi.Event.EventHandlerTest do
     end
 
     test "Event Log Published event handler does not delete records from 7 days or newer" do
-      old_time = DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), -7
-      * 3600 * 24, :second))
+      old_time =
+        DateTime.to_iso8601(
+          DateTime.add(
+            DateTime.utc_now(),
+            -7 *
+              3600 * 24,
+            :second
+          )
+        )
 
       old_event_log = %SmartCity.EventLog{
         title: "someTitle",
@@ -691,6 +706,7 @@ defmodule Andi.Event.EventHandlerTest do
       expected_timestamp = DateTime.truncate(event_log_datetime, :second)
 
       Brook.Event.send(@instance_name, event_log_published(), __MODULE__, new_event_log)
+
       eventually(fn ->
         all_datasets = Andi.InputSchemas.EventLogs.get_all()
         assert length(all_datasets) == 1
@@ -698,7 +714,6 @@ defmodule Andi.Event.EventHandlerTest do
         assert persisted_event_log.dataset_id == new_event_log.dataset_id
         assert persisted_event_log.description == new_event_log.description
       end)
-
     end
   end
 end

--- a/apps/andi/test/integration/andi/event/event_handler_test.exs
+++ b/apps/andi/test/integration/andi/event/event_handler_test.exs
@@ -631,5 +631,74 @@ defmodule Andi.Event.EventHandlerTest do
         assert persisted_event_log.description == event_log.description
       end)
     end
+
+    test "Event Log Published event handler deletes records older than 7 days" do
+      old_time = DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), -9
+      * 3600 * 24, :second))
+
+      old_event_log = %SmartCity.EventLog{
+        title: "someTitle",
+        timestamp: old_time,
+        description: "someStuff",
+        source: "fromATest",
+        dataset_id: UUID.uuid4(),
+        ingestion_id: UUID.uuid4()
+      }
+
+      Brook.Event.send(@instance_name, event_log_published(), __MODULE__, old_event_log)
+
+      eventually(fn ->
+        assert 1 == length(Andi.InputSchemas.EventLogs.get_all())
+      end)
+
+      new_event_log = %{old_event_log | timestamp: DateTime.to_iso8601(DateTime.utc_now()), description: "someOtherStuff"}
+
+      {:ok, event_log_datetime, _} = DateTime.from_iso8601(new_event_log.timestamp)
+      expected_timestamp = DateTime.truncate(event_log_datetime, :second)
+
+      Brook.Event.send(@instance_name, event_log_published(), __MODULE__, new_event_log)
+      eventually(fn ->
+        all_datasets = Andi.InputSchemas.EventLogs.get_all()
+        assert length(all_datasets) == 1
+        [persisted_event_log | tail] = all_datasets
+        assert persisted_event_log.dataset_id == new_event_log.dataset_id
+        assert persisted_event_log.description == new_event_log.description
+      end)
+    end
+
+    test "Event Log Published event handler does not delete records from 7 days or newer" do
+      old_time = DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), -7
+      * 3600 * 24, :second))
+
+      old_event_log = %SmartCity.EventLog{
+        title: "someTitle",
+        timestamp: old_time,
+        description: "someStuff",
+        source: "fromATest",
+        dataset_id: UUID.uuid4(),
+        ingestion_id: UUID.uuid4()
+      }
+
+      Brook.Event.send(@instance_name, event_log_published(), __MODULE__, old_event_log)
+
+      eventually(fn ->
+        assert 1 == length(Andi.InputSchemas.EventLogs.get_all())
+      end)
+
+      new_event_log = %{old_event_log | timestamp: DateTime.to_iso8601(DateTime.utc_now()), description: "someOtherStuff"}
+
+      {:ok, event_log_datetime, _} = DateTime.from_iso8601(new_event_log.timestamp)
+      expected_timestamp = DateTime.truncate(event_log_datetime, :second)
+
+      Brook.Event.send(@instance_name, event_log_published(), __MODULE__, new_event_log)
+      eventually(fn ->
+        all_datasets = Andi.InputSchemas.EventLogs.get_all()
+        assert length(all_datasets) == 1
+        [persisted_event_log | tail] = all_datasets
+        assert persisted_event_log.dataset_id == new_event_log.dataset_id
+        assert persisted_event_log.description == new_event_log.description
+      end)
+
+    end
   end
 end

--- a/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
@@ -97,7 +97,7 @@ defmodule AndiWeb.EventLogFormTest do
         }
       ]
 
-      allow(Andi.InputSchemas.EventLogs.get_all_for_dataset_id(dataset.id), return: event_logs)
+      allow(Andi.InputSchemas.EventLogs.get_all_with_limit_for_dataset_id(dataset.id, 50), return: event_logs)
       assert {:ok, view, html} = live(conn, @url_path <> dataset.id)
 
       event_log_view = find_live_child(view, "event_log_form")


### PR DESCRIPTION
## [Ticket Link #1227](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1227)

## Description

Delete event logs after 7 days and limit event log view to 50

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
