### PR TITLE
info log levels in almost all environments

### DIFF
--- a/apps/alchemist/config/config.exs
+++ b/apps/alchemist/config/config.exs
@@ -2,6 +2,9 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :logger,
+  level: :info
+
 config :alchemist,
   retry_count: 10,
   retry_initial_delay: 100,

--- a/apps/alchemist/config/config.exs
+++ b/apps/alchemist/config/config.exs
@@ -6,6 +6,7 @@ config :logger,
   level: :info
 
 config :alchemist,
+  env: Mix.env(),
   retry_count: 10,
   retry_initial_delay: 100,
   max_outgoing_bytes: 900_000,

--- a/apps/alchemist/config/dev.exs
+++ b/apps/alchemist/config/dev.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+
 config :libcluster,
   topologies: [
     alchemist_cluster: [

--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.48",
+      version: "0.2.49",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/config/config.exs
+++ b/apps/forklift/config/config.exs
@@ -3,6 +3,7 @@ use Mix.Config
 input_topic_prefix = "transformed"
 
 config :forklift,
+  env: Mix.env(),
   data_reader: Pipeline.Reader.DatasetTopicReader,
   topic_writer: Pipeline.Writer.TopicWriter,
   table_writer: Pipeline.Writer.S3Writer,

--- a/apps/forklift/config/dev.exs
+++ b/apps/forklift/config/dev.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+  
 config :forklift,
   topic_writer: MockTopic,
   table_writer: MockTable,

--- a/apps/forklift/config/dev.exs
+++ b/apps/forklift/config/dev.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger,
   level: :info
-  
+
 config :forklift,
   topic_writer: MockTopic,
   table_writer: MockTable,

--- a/apps/forklift/config/integration.exs
+++ b/apps/forklift/config/integration.exs
@@ -1,5 +1,6 @@
 use Mix.Config
 
+
 host =
   case System.get_env("HOST_IP") do
     nil -> "127.0.0.1"
@@ -11,6 +12,9 @@ endpoints = [{to_charlist(host), 9092}]
 
 output_topic = "streaming-persisted"
 bucket_name = "trino-hive-storage"
+
+config :logger,
+  level: :info
 
 config :forklift,
   data_reader: Pipeline.Reader.DatasetTopicReader,

--- a/apps/forklift/config/integration.exs
+++ b/apps/forklift/config/integration.exs
@@ -1,6 +1,5 @@
 use Mix.Config
 
-
 host =
   case System.get_env("HOST_IP") do
     nil -> "127.0.0.1"

--- a/apps/forklift/config/prod.exs
+++ b/apps/forklift/config/prod.exs
@@ -11,4 +11,3 @@ config :tzdata, :data_dir, "./tzdata"
 
 config :logger,
   level: :info
-  

--- a/apps/forklift/config/prod.exs
+++ b/apps/forklift/config/prod.exs
@@ -8,3 +8,7 @@ config :ex_aws,
   debug_requests: false
 
 config :tzdata, :data_dir, "./tzdata"
+
+config :logger,
+  level: :info
+  

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.19.22",
+      version: "0.19.23",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/unit/forklift/ingestion_timer_test.exs
+++ b/apps/forklift/test/unit/forklift/ingestion_timer_test.exs
@@ -5,7 +5,7 @@ defmodule Forklift.IngestionTimerTest do
   import Mock
 
   setup do
-    [ingestion_id: Faker.UUID.v4(), extract_time: Timex.now() |> Timex.to_unix(), dataset: %{}]
+    [ingestion_id: Faker.UUID.v4(), extract_time: Timex.now() |> Timex.to_unix(), dataset: %{id: Faker.UUID.v4()}]
   end
 
   describe "IngestionTimerTest" do

--- a/apps/raptor/config/config.exs
+++ b/apps/raptor/config/config.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+  
 config :raptor, RaptorWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "EkTifp9BP1V1Mr1QPj9WU05X709LxaHj+2LbqDp6pHjz4XlKPVe/bh9aFq0dxtnx",

--- a/apps/raptor/config/config.exs
+++ b/apps/raptor/config/config.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger,
   level: :info
-  
+
 config :raptor, RaptorWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "EkTifp9BP1V1Mr1QPj9WU05X709LxaHj+2LbqDp6pHjz4XlKPVe/bh9aFq0dxtnx",

--- a/apps/raptor/config/integration.exs
+++ b/apps/raptor/config/integration.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+
 System.put_env("AUTH0_DOMAIN", "urbanos-dev.us.auth0.com")
 System.put_env("RAPTOR_AUTH0_CLIENT_ID", "oRb8LbGixCD7a6T7u3sTx1Ve65nL2hWa")
 

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.3.1",
+      version: "1.3.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/reaper/config/config.exs
+++ b/apps/reaper/config/config.exs
@@ -4,6 +4,7 @@ config :logger,
   level: :info
 
 config :reaper,
+  env: Mix.env(),
   produce_retries: 10,
   produce_timeout: 100
 

--- a/apps/reaper/config/config.exs
+++ b/apps/reaper/config/config.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger,
   level: :info
-  
+
 config :reaper,
   produce_retries: 10,
   produce_timeout: 100

--- a/apps/reaper/config/config.exs
+++ b/apps/reaper/config/config.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+  
 config :reaper,
   produce_retries: 10,
   produce_timeout: 100

--- a/apps/reaper/config/dev.exs
+++ b/apps/reaper/config/dev.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+
 host =
   case System.get_env("HOST_IP") do
     nil -> "127.0.0.1"

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.39",
+      version: "2.0.40",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/valkyrie/config/config.exs
+++ b/apps/valkyrie/config/config.exs
@@ -2,7 +2,11 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :logger,
+  level: :info
+  
 config :valkyrie,
+  env: Mix.env(),
   retry_count: 10,
   retry_initial_delay: 100,
   max_outgoing_bytes: 900_000,

--- a/apps/valkyrie/config/config.exs
+++ b/apps/valkyrie/config/config.exs
@@ -4,7 +4,7 @@ use Mix.Config
 
 config :logger,
   level: :info
-  
+
 config :valkyrie,
   env: Mix.env(),
   retry_count: 10,

--- a/apps/valkyrie/config/dev.exs
+++ b/apps/valkyrie/config/dev.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+
 config :libcluster,
   topologies: [
     valkyrie_cluster: [

--- a/apps/valkyrie/config/integration.exs
+++ b/apps/valkyrie/config/integration.exs
@@ -11,7 +11,7 @@ redix_args = [host: host]
 endpoints = [{String.to_atom(host), 9092}]
 
 config :logger,
-  level: :warn
+  level: :info
 
 config :valkyrie,
   elsa_brokers: endpoints,

--- a/apps/valkyrie/config/test.exs
+++ b/apps/valkyrie/config/test.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+config :logger,
+  level: :info
+  
 config :valkyrie,
   elsa_brokers: [localhost: 9092],
   retry_count: 5,

--- a/apps/valkyrie/config/test.exs
+++ b/apps/valkyrie/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger,
   level: :info
-  
+
 config :valkyrie,
   elsa_brokers: [localhost: 9092],
   retry_count: 5,

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.7.33",
+      version: "1.7.34",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Changed log levels for almost all environments to info

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
