### PR TITLE
Removed runtime config of log levels

### DIFF
--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.49",
+      version: "0.2.50",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/alchemist/runtime.exs
+++ b/apps/alchemist/runtime.exs
@@ -20,11 +20,8 @@ redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.ge
 input_topic_prefix = System.get_env("INPUT_TOPIC_PREFIX")
 output_topic_prefix = System.get_env("OUTPUT_TOPIC_PREFIX")
 processor_stages = System.get_env("PROCESSOR_STAGES") || "1"
-log_level = (System.get_env("LOG_LEVEL") || "warn") |> String.to_atom()
 profiling_enabled = System.get_env("PROFILING_ENABLED") == "true"
 
-config :logger,
-  level: log_level
 
 if System.get_env("RUN_IN_KUBERNETES") do
   config :libcluster,

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.7.34",
+      version: "1.7.35",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/valkyrie/runtime.exs
+++ b/apps/valkyrie/runtime.exs
@@ -18,11 +18,7 @@ redix_args = get_redix_args.(System.get_env("REDIS_HOST"), redis_port, System.ge
 input_topic_prefix = System.get_env("INPUT_TOPIC_PREFIX")
 output_topic_prefix = System.get_env("OUTPUT_TOPIC_PREFIX")
 processor_stages = System.get_env("PROCESSOR_STAGES") || "1"
-log_level = (System.get_env("LOG_LEVEL") || "warn") |> String.to_atom()
 profiling_enabled = System.get_env("PROFILING_ENABLED") == "true"
-
-config :logger,
-  level: log_level
 
 if System.get_env("RUN_IN_KUBERNETES") do
   config :libcluster,


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Removed runtime config of log levels in Alchemist and Valk. This should be configured per environment in config folder

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
