### PR TITLE
Validated datetime format fields only when static field or target value

### DIFF
--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.53",
+      version: "0.2.54",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/andi/lib/andi/event/event_handler.ex
+++ b/apps/andi/lib/andi/event/event_handler.ex
@@ -202,7 +202,7 @@ defmodule Andi.Event.EventHandler do
   end
 
   def handle_event(%Brook.Event{type: dataset_harvest_end(), data: data}) do
-    Logger.info("Dataset: #{data.id} - Received dataset_harvest_end event")
+    Logger.info("Dataset: #{data["datasetId"]} - Received dataset_harvest_end event")
 
     Organizations.update_harvested_dataset(data)
     :discard

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -84,7 +84,6 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
       check_form_data(form_data, "conditionOperation", "Is Equal To") ||
         check_form_data(form_data, "conditionOperation", "Is Not Equal To")
 
-
     transformation = Transformation.changeset(socket.assigns.transformation_changeset, form_data)
 
     AndiWeb.IngestionLiveView.Transformations.TransformationsStep.update_transformation(transformation, socket.assigns.id)

--- a/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
+++ b/apps/andi/lib/andi_web/live/ingestion_live_view/transformations/transformation_form.ex
@@ -84,6 +84,7 @@ defmodule AndiWeb.IngestionLiveView.Transformations.TransformationForm do
       check_form_data(form_data, "conditionOperation", "Is Equal To") ||
         check_form_data(form_data, "conditionOperation", "Is Not Equal To")
 
+
     transformation = Transformation.changeset(socket.assigns.transformation_changeset, form_data)
 
     AndiWeb.IngestionLiveView.Transformations.TransformationsStep.update_transformation(transformation, socket.assigns.id)

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.7.4",
+      version: "2.7.5",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/lib/transformation_conditions.ex
+++ b/apps/transformers/lib/transformation_conditions.ex
@@ -66,7 +66,6 @@ defmodule Transformers.Conditions do
       %ValidationStatus{}
       |> NotBlank.check(parameters, @condition_compare_to)
       |> NotBlank.check(parameters, @data_type)
-      |> check_datetime(parameters)
       |> NotBlank.check(parameters, @operation_field)
       |> NotBlank.check(parameters, @source_field)
       |> NotBlank.check_nested(parameters, @source_field)
@@ -76,12 +75,15 @@ defmodule Transformers.Conditions do
     valid_status =
       case comp_val do
         "Static Value" ->
-          valid_status |> NotBlank.check(parameters, @target_value)
+          valid_status
+          |> NotBlank.check(parameters, @target_value)
+          |> check_datetime(parameters)
 
         "Target Field" ->
           valid_status
           |> NotBlank.check(parameters, @target_field)
           |> NotBlank.check_nested(parameters, @target_field)
+          |> check_datetime(parameters)
 
         _ ->
           valid_status

--- a/apps/transformers/mix.exs
+++ b/apps/transformers/mix.exs
@@ -4,7 +4,7 @@ defmodule Transformers.MixProject do
   def project do
     [
       app: :transformers,
-      version: "1.0.37",
+      version: "1.0.38",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/transformers/test/unit/transformation_conditions_test.exs
+++ b/apps/transformers/test/unit/transformation_conditions_test.exs
@@ -149,7 +149,7 @@ defmodule Transformers.ConditionsTest do
         "newValue" => "new value",
         "condition" => "true",
         "conditionCompareTo" => "Null or Empty",
-        "conditionDataType" => value_type,
+        "conditionDataType" => condition_data_type,
         "sourceConditionField" => "testField",
         "conditionOperation" => operation,
         "targetConditionField" => nil,
@@ -164,7 +164,7 @@ defmodule Transformers.ConditionsTest do
       assert result == {:ok, expected_result}
 
       where([
-        [:value_type, :operation, :expected_result, :test_field],
+        [:condition_data_type, :operation, :expected_result, :test_field],
         ["String", "=", true, nil],
         ["String", "=", false, "asdf"],
         ["String", "!=", false, nil],

--- a/apps/transformers/test/unit/transformation_conditions_test.exs
+++ b/apps/transformers/test/unit/transformation_conditions_test.exs
@@ -9,7 +9,7 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string"
+        "conditionDataType" => "string"
       }
 
       payload = %{
@@ -25,7 +25,7 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
+        "conditionDataType" => "string",
         "condition" => "false"
       }
 
@@ -42,7 +42,7 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
+        "conditionDataType" => "string",
         "condition" => nil
       }
 
@@ -61,7 +61,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "string",
@@ -83,7 +82,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "string",
@@ -105,7 +103,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -128,7 +125,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -151,10 +147,9 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => value_type,
         "condition" => "true",
         "conditionCompareTo" => "Null or Empty",
-        "conditionDataType" => "string",
+        "conditionDataType" => value_type,
         "sourceConditionField" => "testField",
         "conditionOperation" => operation,
         "targetConditionField" => nil,
@@ -189,7 +184,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -212,7 +206,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "String",
@@ -235,7 +228,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "string",
@@ -257,7 +249,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -280,7 +271,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -305,7 +295,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "string",
@@ -327,7 +316,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "string",
@@ -349,7 +337,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -372,7 +359,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "string",
@@ -395,7 +381,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "string",
@@ -419,7 +404,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "number",
@@ -441,7 +425,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "number",
@@ -463,7 +446,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "number",
@@ -486,7 +468,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "number",
@@ -509,7 +490,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "number",
@@ -533,7 +513,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "number",
@@ -555,7 +534,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "number",
@@ -577,7 +555,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "number",
@@ -600,7 +577,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "number",
@@ -623,7 +599,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Static Value",
         "conditionDataType" => "number",
@@ -647,7 +622,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "datetime",
@@ -780,7 +754,6 @@ defmodule Transformers.ConditionsTest do
       parameters = %{
         "targetField" => "testField",
         "newValue" => "new value",
-        "valueType" => "string",
         "condition" => "true",
         "conditionCompareTo" => "Target Field",
         "conditionDataType" => "datetime",
@@ -804,7 +777,6 @@ defmodule Transformers.ConditionsTest do
     parameters = %{
       "targetField" => "testField",
       "newValue" => "new value",
-      "valueType" => "string",
       "condition" => "true",
       "conditionCompareTo" => "Target Field",
       "conditionDataType" => "datetime",
@@ -827,7 +799,6 @@ defmodule Transformers.ConditionsTest do
     parameters = %{
       "targetField" => "testField",
       "newValue" => "new value",
-      "valueType" => "string",
       "condition" => "true",
       "conditionCompareTo" => "Target Field",
       "conditionDataType" => "datetime",


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Validated datetime format fields only when static field or target value

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
