### PR TITLE
Event log polish

### DIFF
--- a/apps/andi/lib/andi/input_schemas/event_log.ex
+++ b/apps/andi/lib/andi/input_schemas/event_log.ex
@@ -11,7 +11,7 @@ defmodule Andi.InputSchemas.EventLog do
   @primary_key {:id, Ecto.UUID, autogenerate: true}
   schema "event_log" do
     field(:title, :string)
-    field(:timestamp, :utc_datetime)
+    field(:timestamp, :utc_datetime_usec)
     field(:source, :string)
     field(:description, :string)
     field(:ingestion_id, Ecto.UUID)

--- a/apps/andi/lib/andi_web/live/dataset_live_view/event_log_form.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/event_log_form.ex
@@ -69,7 +69,7 @@ defmodule AndiWeb.EditLiveView.EventLogForm do
             <table class="datasets-table" title="Event Log">
               <thead>
                 <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@event_log_order, "timestamp", "unsorted") %>" phx-click="order-by" phx-value-field="timestamp">Timestamp</th>
-                <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@event_log_order, "source", "unsorted") %>" phx-click="order-by" phx-value-field="source">Source</th>
+                <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@event_log_order, "source", "unsorted") %>" style="width:13%" phx-click="order-by" phx-value-field="source">Source</th>
                 <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@event_log_order, "title", "unsorted") %>" phx-click="order-by" phx-value-field="title">Title</th>
                 <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@event_log_order, "dataset_id", "unsorted") %>" phx-click="order-by" phx-value-field="dataset_id">Dataset ID</th>
                 <th class="datasets-table__th datasets-table__cell datasets-table__th--sortable datasets-table__th--<%= Map.get(@event_log_order, "ingestion_id", "unsorted") %>" phx-click="order-by" phx-value-field="ingestion_id">Ingestion ID</th>

--- a/apps/andi/lib/andi_web/live/dataset_live_view/event_log_form.ex
+++ b/apps/andi/lib/andi_web/live/dataset_live_view/event_log_form.ex
@@ -23,6 +23,7 @@ defmodule AndiWeb.EditLiveView.EventLogForm do
 
     event_log =
       Andi.InputSchemas.EventLogs.get_all_with_limit_for_dataset_id(dataset.id, @limit)
+      |> truncate_datetime_to_milliseconds
       |> convert_to_string_keys
       |> sort_list_by_field(:timestamp, "asc")
 
@@ -147,6 +148,10 @@ defmodule AndiWeb.EditLiveView.EventLogForm do
       "collapsed" -> "EDIT"
       "expanded" -> "MINIMIZE"
     end
+  end
+
+  defp truncate_datetime_to_milliseconds(event_logs) do
+    Enum.map(event_logs, fn event_log -> %{event_log | timestamp: DateTime.truncate(event_log.timestamp, :millisecond)} end)
   end
 
   defp convert_to_string_keys(event_logs) do

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.7.5",
+      version: "2.7.6",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "2.7.4",
+      version: "2.7.5",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/priv/repo/migrations/20230907190131_modify_event_log_timestamp_type.exs
+++ b/apps/andi/priv/repo/migrations/20230907190131_modify_event_log_timestamp_type.exs
@@ -1,0 +1,10 @@
+defmodule Andi.Repo.Migrations.ModifyEventLogTimestampType do
+  use Ecto.Migration
+
+  def change do
+    IO.inspect("running migration")
+    alter table(:event_log) do
+      modify :timestamp, :utc_datetime_usec, from: :utc_datetime
+    end
+  end
+end

--- a/apps/andi/priv/repo/migrations/20230907190131_modify_event_log_timestamp_type.exs
+++ b/apps/andi/priv/repo/migrations/20230907190131_modify_event_log_timestamp_type.exs
@@ -2,7 +2,6 @@ defmodule Andi.Repo.Migrations.ModifyEventLogTimestampType do
   use Ecto.Migration
 
   def change do
-    IO.inspect("running migration")
     alter table(:event_log) do
       modify :timestamp, :utc_datetime_usec, from: :utc_datetime
     end

--- a/apps/andi/test/integration/andi/event/event_handler_test.exs
+++ b/apps/andi/test/integration/andi/event/event_handler_test.exs
@@ -619,7 +619,7 @@ defmodule Andi.Event.EventHandlerTest do
       Brook.Event.send(@instance_name, event_log_published(), __MODULE__, event_log)
 
       {:ok, event_log_datetime, _} = DateTime.from_iso8601(event_log.timestamp)
-      expected_timestamp = DateTime.truncate(event_log_datetime, :second)
+      expected_timestamp = DateTime.truncate(event_log_datetime, :microsecond)
 
       eventually(fn ->
         [persisted_event_log | tail] = Andi.InputSchemas.EventLogs.get_all_for_dataset_id(event_log.dataset_id)
@@ -661,7 +661,7 @@ defmodule Andi.Event.EventHandlerTest do
       new_event_log = %{old_event_log | timestamp: DateTime.to_iso8601(DateTime.utc_now()), description: "someOtherStuff"}
 
       {:ok, event_log_datetime, _} = DateTime.from_iso8601(new_event_log.timestamp)
-      expected_timestamp = DateTime.truncate(event_log_datetime, :second)
+      expected_timestamp = DateTime.truncate(event_log_datetime, :microsecond)
 
       Brook.Event.send(@instance_name, event_log_published(), __MODULE__, new_event_log)
 
@@ -703,7 +703,7 @@ defmodule Andi.Event.EventHandlerTest do
       new_event_log = %{old_event_log | timestamp: DateTime.to_iso8601(DateTime.utc_now()), description: "someOtherStuff"}
 
       {:ok, event_log_datetime, _} = DateTime.from_iso8601(new_event_log.timestamp)
-      expected_timestamp = DateTime.truncate(event_log_datetime, :second)
+      expected_timestamp = DateTime.truncate(event_log_datetime, :microsecond)
 
       Brook.Event.send(@instance_name, event_log_published(), __MODULE__, new_event_log)
 

--- a/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
@@ -77,6 +77,7 @@ defmodule AndiWeb.EventLogFormTest do
 
     test "Event Log Form shows populated row for each event log", %{curator_conn: conn, curator: curator} do
       dataset = Datasets.create(curator)
+      timestamp = ~U[2023-01-01 00:00:00Z]
 
       event_logs = [
         %{
@@ -84,7 +85,7 @@ defmodule AndiWeb.EventLogFormTest do
           description: "testDescription",
           ingestion_id: "testIngestionId",
           source: "testSource",
-          timestamp: ~U[2023-01-01 00:00:00Z],
+          timestamp: timestamp,
           title: "testTitle"
         },
         %{
@@ -92,7 +93,7 @@ defmodule AndiWeb.EventLogFormTest do
           description: "testDescription2",
           ingestion_id: "testIngestionId2",
           source: "testSource2",
-          timestamp: ~U[2023-01-01 00:00:00Z],
+          timestamp: timestamp,
           title: "testTitle2"
         }
       ]
@@ -115,14 +116,14 @@ defmodule AndiWeb.EventLogFormTest do
       assert Enum.member?(row_values, "testSource")
       assert Enum.member?(row_values, "testDatasetId")
       assert Enum.member?(row_values, "testIngestionId")
-      assert Enum.member?(row_values, "testTimestamp")
+      assert Enum.member?(row_values, timestamp)
       assert Enum.member?(row_values, "testTitle")
 
       assert Enum.member?(row_values, "testTitle2")
       assert Enum.member?(row_values, "testSource2")
       assert Enum.member?(row_values, "testDatasetId2")
       assert Enum.member?(row_values, "testIngestionId2")
-      assert Enum.member?(row_values, "testTimestamp2")
+      assert Enum.member?(row_values, timestamp)
       assert Enum.member?(row_values, "testTitle2")
     end
   end

--- a/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
@@ -78,6 +78,7 @@ defmodule AndiWeb.EventLogFormTest do
     test "Event Log Form shows populated row for each event log", %{curator_conn: conn, curator: curator} do
       dataset = Datasets.create(curator)
       timestamp = ~U[2023-01-01 00:00:00Z]
+      timestamp2 = ~U[2023-01-01 00:00:01Z]
 
       event_logs = [
         %{
@@ -93,7 +94,7 @@ defmodule AndiWeb.EventLogFormTest do
           description: "testDescription2",
           ingestion_id: "testIngestionId2",
           source: "testSource2",
-          timestamp: timestamp,
+          timestamp: timestamp2,
           title: "testTitle2"
         }
       ]
@@ -116,14 +117,14 @@ defmodule AndiWeb.EventLogFormTest do
       assert Enum.member?(row_values, "testSource")
       assert Enum.member?(row_values, "testDatasetId")
       assert Enum.member?(row_values, "testIngestionId")
-      assert Enum.member?(row_values, timestamp)
+      assert Enum.member?(row_values, DateTime.to_string(timestamp))
       assert Enum.member?(row_values, "testTitle")
 
       assert Enum.member?(row_values, "testTitle2")
       assert Enum.member?(row_values, "testSource2")
       assert Enum.member?(row_values, "testDatasetId2")
       assert Enum.member?(row_values, "testIngestionId2")
-      assert Enum.member?(row_values, timestamp)
+      assert Enum.member?(row_values, DateTime.to_string(timestamp2))
       assert Enum.member?(row_values, "testTitle2")
     end
   end

--- a/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
+++ b/apps/andi/test/integration/andi_web/live/dataset_live_view/event_log_form_test.exs
@@ -84,7 +84,7 @@ defmodule AndiWeb.EventLogFormTest do
           description: "testDescription",
           ingestion_id: "testIngestionId",
           source: "testSource",
-          timestamp: "testTimestamp",
+          timestamp: ~U[2023-01-01 00:00:00Z],
           title: "testTitle"
         },
         %{
@@ -92,7 +92,7 @@ defmodule AndiWeb.EventLogFormTest do
           description: "testDescription2",
           ingestion_id: "testIngestionId2",
           source: "testSource2",
-          timestamp: "testTimestamp2",
+          timestamp: ~U[2023-01-01 00:00:00Z],
           title: "testTitle2"
         }
       ]


### PR DESCRIPTION
## [Ticket Link #1236](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1236)

## Description

- Move timestamps to millisecond precision in the event log table
- Add fixed percentage width to source column

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
