### PR TITLE
Initializing the data reader on every data_extract_start within forklift

### DIFF
--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -59,7 +59,7 @@ defmodule Forklift.Event.EventHandler do
     Logger.info("Ingestion: #{data.id} - Received data_extract_start event from #{author}")
 
     Enum.each(target_dataset_ids, fn target_dataset_id ->
-      add_event_count(data_ingest_start(), author, target_dataset_id)
+      add_event_count(data_extract_start(), author, target_dataset_id)
       dataset = Brook.get!(@instance_name, :datasets, target_dataset_id)
 
       if dataset != nil do

--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -9,6 +9,7 @@ defmodule Forklift.Event.EventHandler do
   import SmartCity.Event,
     only: [
       data_ingest_start: 0,
+      data_extract_start: 0,
       dataset_update: 0,
       data_ingest_end: 0,
       data_write_complete: 0,
@@ -46,6 +47,32 @@ defmodule Forklift.Event.EventHandler do
   rescue
     error ->
       Logger.error("data_ingest_start failed to process. #{inspect(error)}")
+      DeadLetter.process(data.targetDatasets, data.id, data, Atom.to_string(@instance_name), reason: inspect(error))
+      :discard
+  end
+
+  def handle_event(%Brook.Event{
+    type: data_extract_start(),
+    data: %Ingestion{targetDatasets: target_dataset_ids} = data,
+    author: author
+  }) do
+    Logger.info("Ingestion: #{data.id} - Received data_extract_start event from #{author}")
+
+    Enum.each(target_dataset_ids, fn target_dataset_id ->
+      add_event_count(data_ingest_start(), author, target_dataset_id)
+      dataset = Brook.get!(@instance_name, :datasets, target_dataset_id)
+
+      if dataset != nil do
+        :ok = Forklift.DataReaderHelper.init(dataset)
+      else
+        Logger.error("Could not find dataset_id: #{target_dataset_id} in ingestion: #{data.id}")
+      end
+    end)
+
+    :ok
+  rescue
+    error ->
+      Logger.error("data_extract_start failed to process: #{inspect(error)}")
       DeadLetter.process(data.targetDatasets, data.id, data, Atom.to_string(@instance_name), reason: inspect(error))
       :discard
   end

--- a/apps/forklift/lib/forklift/event/event_handler.ex
+++ b/apps/forklift/lib/forklift/event/event_handler.ex
@@ -52,10 +52,10 @@ defmodule Forklift.Event.EventHandler do
   end
 
   def handle_event(%Brook.Event{
-    type: data_extract_start(),
-    data: %Ingestion{targetDatasets: target_dataset_ids} = data,
-    author: author
-  }) do
+        type: data_extract_start(),
+        data: %Ingestion{targetDatasets: target_dataset_ids} = data,
+        author: author
+      }) do
     Logger.info("Ingestion: #{data.id} - Received data_extract_start event from #{author}")
 
     Enum.each(target_dataset_ids, fn target_dataset_id ->

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.19.25",
+      version: "0.19.26",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/forklift/test/integration/forklift/event/event_handler_test.exs
+++ b/apps/forklift/test/integration/forklift/event/event_handler_test.exs
@@ -204,4 +204,46 @@ defmodule Forklift.Event.EventHandlerTest do
       end)
     end
   end
+
+  describe "Data Extract Start" do
+    test "A failing message gets placed on dead letter queue and discarded" do
+      id_for_invalid_ingestion = UUID.uuid4()
+      id_for_target_dataset = UUID.uuid4()
+      invalid_ingestion = TDG.create_ingestion(%{id: id_for_invalid_ingestion, targetDatasets: [id_for_target_dataset]})
+
+      id_for_valid_dataset = UUID.uuid4()
+      valid_dataset = TDG.create_dataset(%{id: id_for_valid_dataset})
+      allow(Brook.get!(@instance_name, :datasets, id_for_target_dataset), exec: fn _, _, _ -> raise "nope" end)
+
+      Brook.Event.send(@instance_name, data_extract_start(), __MODULE__, invalid_ingestion)
+      Brook.Event.send(@instance_name, dataset_update(), __MODULE__, valid_dataset)
+
+      eventually(fn ->
+        cached_dataset_id =
+          case Brook.ViewState.get(@instance_name, :datasets, id_for_valid_dataset) do
+            {:ok, %{id: id}} -> id
+            _ -> nil
+          end
+
+        failed_messages =
+          Elsa.Fetch.fetch(elsa_brokers(), "dead-letters")
+          |> elem(2)
+          |> Enum.filter(fn message ->
+            actual = Jason.decode!(message.value)
+
+            case actual["original_message"] do
+              %{"id" => message_dataset_id} ->
+                message_dataset_id == id_for_invalid_ingestion
+
+              _ ->
+                false
+            end
+          end)
+
+        assert cached_dataset_id != nil
+        assert cached_dataset_id == id_for_valid_dataset
+        assert 1 == length(failed_messages)
+      end)
+    end
+  end
 end


### PR DESCRIPTION
## [Ticket Link #111](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/111)

## Description

- Initializing the data reader on every data_extract_start within forklift

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
