### PR TITLE
bump remaining application versions to trigger new image builds

### DIFF
--- a/apps/alchemist/mix.exs
+++ b/apps/alchemist/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemist.MixProject do
   def project do
     [
       app: :alchemist,
-      version: "0.2.56",
+      version: "0.2.57",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/andi/docker-compose.yml
+++ b/apps/andi/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - "5456:5432"
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     ports:
     - "2181:2181"

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "1.3.18",
+      version: "1.3.19",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/test/integration/docker-compose.yaml
+++ b/apps/discovery_api/test/integration/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
 
   zookeeper:
     platform: linux/amd64
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     ports:
     - "2181:2181"
   kafka:

--- a/apps/discovery_streams/mix.exs
+++ b/apps/discovery_streams/mix.exs
@@ -4,7 +4,7 @@ defmodule DiscoveryStreams.Mixfile do
   def project do
     [
       app: :discovery_streams,
-      version: "3.0.24",
+      version: "3.0.25",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/e2e/test/docker-compose.yml
+++ b/apps/e2e/test/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     volumes:
       - ${PWD}/test/hive.properties:/etc/trino/catalog/hive.properties
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     ports:
     - "2181:2181"

--- a/apps/forklift/docker-compose.yml
+++ b/apps/forklift/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - ${PWD}/test/integration/hive.properties:/etc/trino/catalog/hive.properties
 
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     ports:
     - "2181:2181"

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.19.27",
+      version: "0.19.28",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/pipeline/docker-compose.yml
+++ b/apps/pipeline/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - ${PWD}/test/integration/hive.properties:/etc/trino/catalog/hive.properties
 
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     ports:
     - "2181:2181"

--- a/apps/raptor/mix.exs
+++ b/apps/raptor/mix.exs
@@ -5,7 +5,7 @@ defmodule Raptor.MixProject do
     [
       app: :raptor,
       compilers: [:phoenix] ++ Mix.compilers(),
-      version: "1.3.3",
+      version: "1.3.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/raptor/test/integration/docker-compose.yaml
+++ b/apps/raptor/test/integration/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       timeout: 20s
       retries: 3
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     container_name: zookeeper
     ports:

--- a/apps/reaper/docker-compose.yml
+++ b/apps/reaper/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - init
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     ports:
     - "2181:2181"

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "2.0.43",
+      version: "2.0.44",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/template/test/integration/docker-compose.yaml
+++ b/apps/template/test/integration/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       timeout: 20s
       retries: 3
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:3.4.13
     platform: linux/amd64
     container_name: zookeeper
     ports:

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -4,7 +4,7 @@ defmodule Valkyrie.MixProject do
   def project do
     [
       app: :valkyrie,
-      version: "1.7.40",
+      version: "1.7.41",
       elixir: "~> 1.10",
       build_path: "../../_build",
       config_path: "../../config/config.exs",


### PR DESCRIPTION
## Description

Bump versions to trigger new image builds to get the latest security updates

## Reminders:

- Be mindful of impacts of changing Major/Minor/Patch versions of each elixir app:
  - [ ] If updating patch version, are you sure there are no chart changes required to maintain functionality? If so, you should bump minor version instead.
  - [ ] If updating Major or Minor versions , did you update the sauron chart configuration?
- [ ] If changing elixir code in an "app", did you update the relevant version
      in `mix.exs`?
- [ ] If altering an API endpoint, was the relevant postman collection updated?
  - [ ] If a new version of `smart_city` is being used (new fields on a struct), were the relevant postman collections updated?
